### PR TITLE
Reduce excessive logging output

### DIFF
--- a/src/shotgun/agents/context_analyzer/analyzer.py
+++ b/src/shotgun/agents/context_analyzer/analyzer.py
@@ -76,17 +76,23 @@ class ContextAnalyzer:
                 break
 
         if last_input_tokens == 0:
-            logger.warning(
-                f"[ANALYZER] No usage data found in message history! "
-                f"message_count={len(message_history)}, "
-                f"response_count={sum(1 for m in message_history if isinstance(m, ModelResponse))}"
-            )
+            # Only warn if there are actual messages that should have usage data
+            if len(message_history) > 0:
+                logger.warning(
+                    f"[ANALYZER] No usage data found in message history! "
+                    f"message_count={len(message_history)}, "
+                    f"response_count={sum(1 for m in message_history if isinstance(m, ModelResponse))}"
+                )
+                logger.info("[ANALYZER] Falling back to token estimation")
+
             # Fallback to token estimation
-            logger.info("[ANALYZER] Falling back to token estimation")
             last_input_tokens = await estimate_tokens_from_messages(
                 message_history, self.model_config
             )
-            logger.debug(f"[ANALYZER] Estimated tokens: {last_input_tokens}")
+
+            # Only log if we actually estimated non-zero tokens
+            if last_input_tokens > 0:
+                logger.debug(f"[ANALYZER] Estimated tokens: {last_input_tokens}")
 
         # Step 2: Calculate total output tokens (sum across all responses)
         for msg in message_history:
@@ -247,16 +253,18 @@ class ContextAnalyzer:
             # If no content, put all in agent responses
             agent_response_tokens = total_output_tokens
 
-        logger.debug(
-            f"Token allocation complete: user={user_tokens}, agent_responses={agent_response_tokens}, "
-            f"system_prompts={system_prompt_tokens}, system_status={system_status_tokens}, "
-            f"codebase_understanding={codebase_understanding_tokens}, "
-            f"artifact_management={artifact_management_tokens}, web_research={web_research_tokens}, "
-            f"unknown={unknown_tokens}"
-        )
-        logger.debug(
-            f"Input tokens (from last response): {last_input_tokens}, Output tokens (sum): {total_output_tokens}"
-        )
+        # Only log token allocation if there are meaningful non-zero values
+        if last_input_tokens > 0 or total_output_tokens > 0:
+            logger.debug(
+                f"Token allocation complete: user={user_tokens}, agent_responses={agent_response_tokens}, "
+                f"system_prompts={system_prompt_tokens}, system_status={system_status_tokens}, "
+                f"codebase_understanding={codebase_understanding_tokens}, "
+                f"artifact_management={artifact_management_tokens}, web_research={web_research_tokens}, "
+                f"unknown={unknown_tokens}"
+            )
+            logger.debug(
+                f"Input tokens (from last response): {last_input_tokens}, Output tokens (sum): {total_output_tokens}"
+            )
 
         # Create TokenAllocation model
         return TokenAllocation(


### PR DESCRIPTION
- Only log token estimation when non-zero values are present
- Make token allocation debug logs conditional on meaningful data
- Only warn about missing usage data for non-empty conversations

This prevents log spam when analyzer runs on empty or zero-token conversations, which was cluttering logs with unhelpful messages.