### PR TITLE
Configure logger file output destinations

### DIFF
--- a/src/shotgun/logging_config.py
+++ b/src/shotgun/logging_config.py
@@ -70,10 +70,7 @@ def setup_logger(
     logger = logging.getLogger(name)
 
     # Check if we already have a file handler
-    has_file_handler = any(
-        isinstance(h, logging.FileHandler)
-        for h in logger.handlers
-    )
+    has_file_handler = any(isinstance(h, logging.FileHandler) for h in logger.handlers)
 
     # If we already have a file handler, just return the logger
     if has_file_handler:
@@ -188,10 +185,7 @@ def get_logger(name: str) -> logging.Logger:
     logger = logging.getLogger(name)
 
     # Check if we have a file handler already
-    has_file_handler = any(
-        isinstance(h, logging.FileHandler)
-        for h in logger.handlers
-    )
+    has_file_handler = any(isinstance(h, logging.FileHandler) for h in logger.handlers)
 
     # If no file handler, set up the logger (will add file handler)
     if not has_file_handler:


### PR DESCRIPTION
Each shotgun run now writes to a unique log file named with an ISO8601 timestamp (e.g., shotgun-20251104T172129Z.log). This isolates logs per run making debugging easier and removing the need for log rotation.

Changes:
- Generate single ISO8601 timestamp per run at module load
- Replace TimedRotatingFileHandler with regular FileHandler
- Update filename format from "shotgun.log" to "shotgun-{timestamp}.log"
- Remove rotation configuration (daily rotation, 7-day backup)