### PR TITLE
Prevent unit tests from writing logs

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,6 +5,13 @@ across both unit and integration tests, particularly for Kuzu database
 resource management.
 """
 
+# IMPORTANT: Set environment variables BEFORE any imports to ensure
+# they're available when settings are loaded during module import
+import os
+
+os.environ["SHOTGUN_LOGGING_TO_FILE"] = "false"
+
+# Now safe to import modules that depend on settings
 import asyncio
 import gc
 import shutil


### PR DESCRIPTION
Set SHOTGUN_LOGGING_TO_FILE=false environment variable at the top of test/conftest.py before any imports to prevent unit tests from creating log files in ~/.shotgun-sh/logs/.

This ensures:
- Tests don't write to the filesystem unnecessarily
- Faster test execution (no file I/O overhead)
- Cleaner test environment
- No leftover log files after test runs

The environment variable is set before importing any modules that depend on settings, ensuring it takes effect when the settings singleton is initialized.