### PR TITLE
Remove misleading parallel agents claim from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,9 +265,9 @@ Start at specification. Build first, discover problems later.
 </tr>
 
 <tr>
-<td><strong>Multi-Agent Coordination</strong></td>
+<td><strong>Dedicated Agents Per Mode</strong></td>
 <td>
-15+ specialized agents work in parallel (research, security, architecture) with coordinated outputs.
+Each mode (research, spec, plan, tasks, export) uses a <strong>separate specialized agent</strong> with prompts tailored specifically for that phase. 100% user-controllable via mode switching.
 </td>
 <td>
 Single-agent or one-size-fits-all prompts.


### PR DESCRIPTION
Replace inaccurate claim about "15+ specialized agents working in parallel" with correct description: each mode (research, spec, plan, tasks, export) uses a separate dedicated agent with specialized prompts for that phase.

This accurately represents the mode-based agent architecture while highlighting it as a user-controllable feature.