### PR TITLE
feat: add automatic issue assignment and Slack notifications

### DIFF
--- a/.github/workflows/issue-notifications.yml
+++ b/.github/workflows/issue-notifications.yml
@@ -12,21 +12,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Auto-assign issue to scottfrasso
+      - name: Auto-assign issue
         uses: actions/github-script@v8
+        env:
+          ASSIGNEE: ${{ secrets.AUTO_ASSIGN_TO_USER }}
         with:
           script: |
-            await github.rest.issues.addAssignees({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              assignees: ['scottfrasso']
-            });
-            console.log('✅ Issue assigned to scottfrasso');
+            const assignee = process.env.ASSIGNEE;
+            if (assignee) {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                assignees: [assignee]
+              });
+              console.log(`✅ Issue assigned to ${assignee}`);
+            } else {
+              console.log('⚠️ AUTO_ASSIGN_TO_USER secret not set, skipping assignment');
+            }
 
       - name: Send Slack notification
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SHOTGUN_ALPHA_WEBHOOK }}
+          ASSIGNEE: ${{ secrets.AUTO_ASSIGN_TO_USER }}
         run: |
           # Get issue information
           ISSUE_NUMBER="${{ github.event.issue.number }}"
@@ -44,6 +52,20 @@ jobs:
           # Escape for JSON using jq
           ISSUE_TITLE_ESCAPED=$(printf '%s' "$ISSUE_TITLE" | jq -Rs . | sed 's/^"//;s/"$//')
           ISSUE_BODY_ESCAPED=$(printf '%s' "$ISSUE_BODY_TRUNCATED" | jq -Rs . | sed 's/^"//;s/"$//')
+          ASSIGNEE_ESCAPED=$(printf '%s' "$ASSIGNEE" | jq -Rs . | sed 's/^"//;s/"$//')
+
+          # Build assigned field only if ASSIGNEE is set
+          if [[ -n "$ASSIGNEE" ]]; then
+            ASSIGNED_FIELD="{
+                    \"type\": \"mrkdwn\",
+                    \"text\": \"*Assigned to:*\n@${ASSIGNEE_ESCAPED}\"
+                  }"
+          else
+            ASSIGNED_FIELD="{
+                    \"type\": \"mrkdwn\",
+                    \"text\": \"*Assigned to:*\nNone\"
+                  }"
+          fi
 
           # Create Slack payload
           cat <<EOF > /tmp/slack_payload.json
@@ -71,10 +93,7 @@ jobs:
                     "type": "mrkdwn",
                     "text": "*Reported by:*\n@${ISSUE_AUTHOR}"
                   },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Assigned to:*\n@scottfrasso"
-                  }
+                  ${ASSIGNED_FIELD}
                 ]
               },
               {

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -97,7 +97,7 @@ Runs daily to verify installation methods work:
 ### `.github/workflows/issue-notifications.yml`
 
 Runs when new issues are created:
-- Auto-assigns issues to scottfrasso
+- Auto-assigns issues to configured user (via `AUTO_ASSIGN_TO_USER` secret)
 - Sends Slack notification with issue details
 
 ## Local CI Testing
@@ -223,6 +223,7 @@ The following secrets must be configured in GitHub repository settings:
 - `SHOTGUN_POSTHOG_API_KEY` - PostHog analytics (embedded at build time)
 - `SHOTGUN_POSTHOG_PROJECT_ID` - PostHog project ID (embedded at build time)
 - `SHOTGUN_ALPHA_WEBHOOK` - Slack webhook URL for notifications (deployments, issues, test failures)
+- `AUTO_ASSIGN_TO_USER` - GitHub username to auto-assign new issues to (optional)
 
 ### Build-Time Secrets
 


### PR DESCRIPTION
## Summary

- Automatically assigns all new GitHub issues to @scottfrasso
- Sends formatted Slack notifications to the existing webhook
- Updated CI/CD documentation to reflect the new workflow

## Changes

### New Workflow: `.github/workflows/issue-notifications.yml`

Triggers on `issues.opened` event and:
- Uses `actions/github-script` to auto-assign issues to scottfrasso
- Sends rich Slack notification with:
  - Issue number and title
  - Reporter username  
  - Assigned person
  - Issue description (truncated to 500 chars)
  - Direct link to view issue on GitHub

### Documentation: `docs/CI_CD.md`

- Added section documenting the new `issue-notifications.yml` workflow
- Documented the existing `SHOTGUN_ALPHA_WEBHOOK` secret usage

## Benefits

- Faster response times to new issues
- Better visibility into user-reported problems
- Automatic assignment prevents issues from being missed
- Leverages existing Slack integration (no new setup required)

## Test Plan

- [x] Workflow file syntax is valid
- [x] Uses existing `SHOTGUN_ALPHA_WEBHOOK` secret (already configured)
- [x] Follows same pattern as other notification workflows in the repo
- [ ] Will verify on first real issue created after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)