### PR TITLE
fix: resolve reactive attribute crash in partial response widget

### DIFF
--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -104,7 +104,6 @@ class ChatScreen(Screen[None]):
     history: PromptHistory = PromptHistory()
     messages = reactive(list[ModelMessage | HintMessage]())
     indexing_job: reactive[CodebaseIndexSelection | None] = reactive(None)
-    partial_message: reactive[ModelMessage | None] = reactive(None)
 
     # Q&A mode state (for structured output clarifying questions)
     qa_mode = reactive(False)
@@ -579,8 +578,6 @@ class ChatScreen(Screen[None]):
 
     @on(PartialResponseMessage)
     def handle_partial_response(self, event: PartialResponseMessage) -> None:
-        self.partial_message = event.message
-
         # Filter event.messages to exclude ModelRequest with only ToolReturnPart
         # These are intermediate tool results that would render as empty (UserQuestionWidget
         # filters out ToolReturnPart in format_prompt_parts), causing user messages to disappear
@@ -604,9 +601,7 @@ class ChatScreen(Screen[None]):
         )
 
         # Use widget coordinator to set partial response
-        self.widget_coordinator.set_partial_response(
-            self.partial_message, new_message_list
-        )
+        self.widget_coordinator.set_partial_response(event.message, new_message_list)
 
         # Skip context updates for file write operations (they don't add to input context)
         has_file_write = any(

--- a/src/shotgun/tui/screens/chat_screen/history/chat_history.py
+++ b/src/shotgun/tui/screens/chat_screen/history/chat_history.py
@@ -47,7 +47,6 @@ class ChatHistory(Widget):
         super().__init__()
         self.items: Sequence[ModelMessage | HintMessage] = []
         self.vertical_tail: VerticalTail | None = None
-        self.partial_response = None
         self._rendered_count = 0  # Track how many messages have been mounted
 
     def compose(self) -> ComposeResult:
@@ -63,7 +62,7 @@ class ChatHistory(Widget):
                     yield HintMessageWidget(item)
                 elif isinstance(item, ModelResponse):
                     yield AgentResponseWidget(item)
-            yield PartialResponseWidget(self.partial_response).data_bind(
+            yield PartialResponseWidget(None).data_bind(
                 item=ChatHistory.partial_response
             )
 

--- a/src/shotgun/tui/widgets/widget_coordinator.py
+++ b/src/shotgun/tui/widgets/widget_coordinator.py
@@ -166,8 +166,9 @@ class WidgetCoordinator:
 
         try:
             chat_history = self.screen.query_one(ChatHistory)
-            if message:
-                chat_history.partial_response = message
+            # Set the reactive attribute to trigger the PartialResponseWidget update
+            chat_history.partial_response = message
+            # Also update the full message list
             chat_history.update_messages(messages)
         except Exception as e:
             logger.exception(f"Failed to set partial response: {e}")


### PR DESCRIPTION
## Summary
- Fixed crash that occurred when removing `self.partial_response = None` TODO comment
- Resolved reactive attribute binding issues preventing proper streaming display
- Cleaned up duplicate message handling code from previous fix

## Problem
The `ChatHistory` component had a TODO comment to remove `self.partial_response = None`, but removing it caused crashes. This was because:
1. The instance attribute assignment was overwriting Textual's reactive descriptor
2. The widget coordinator wasn't actually setting the reactive attribute
3. The data binding was incorrectly passing an initial value to the widget constructor

## Solution
1. **Removed the problematic instance attribute assignment** that was breaking the reactive system
2. **Fixed the data binding** to pass `None` to the widget constructor and let the reactive binding handle values
3. **Updated widget coordinator** to actually set `chat_history.partial_response` to trigger UI updates
4. **Fixed event handling** to pass `event.message` for proper streaming display

## Test plan
- [x] Verify TUI launches without crashes
- [x] Test streaming messages display correctly during agent responses
- [x] Confirm partial response widget hides when streaming completes
- [x] Check that duplicate messages issue remains fixed
- [x] Run mypy type checking - passes
- [x] Verify reactive binding works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)