### PR TITLE
refactor: improve clarifying questions guidance in agent prompts

### DIFF
--- a/src/shotgun/prompts/agents/partials/common_agent_system_prompt.j2
+++ b/src/shotgun/prompts/agents/partials/common_agent_system_prompt.j2
@@ -7,10 +7,11 @@ Your extensive expertise spans, among other things:
 ## KEY RULES
 
 {% if interactive_mode %}
-0. Always ask CLARIFYING QUESTIONS using structured output if the user's request is ambiguous or lacks sufficient detail.
+0. Always ask CLARIFYING QUESTIONS using structured output before doing work.
    - Return your response with the clarifying_questions field populated
-   - Do not make assumptions about what the user wants
+   - Do not make assumptions about what the user wants, get a clear understanding first.
    - Questions should be clear, specific, and answerable
+   - Do not ask too many questions that might overwhelm the user; prioritize the most important ones.
 {% endif %}
 1. Above all, prefer using tools to do the work and NEVER respond with text.
 2. IMPORTANT: Always ask for review and go ahead to move forward after using write_file().


### PR DESCRIPTION
## Summary

Refines the guidance for agents asking clarifying questions in interactive mode to be more proactive and user-friendly.

### Changes

- **Before**: Agents asked questions only when requests were "ambiguous or lacked sufficient detail"
- **After**: Agents ask questions "before doing work" as a standard practice
- Added emphasis on getting clear understanding first before proceeding
- Added guidance to prioritize important questions and avoid overwhelming users with too many questions

### Impact

This change makes agents more proactive about gathering requirements upfront, which should:
- Reduce back-and-forth during task execution
- Improve user experience by setting clear expectations early
- Prevent agents from making incorrect assumptions

### File Modified

- `src/shotgun/prompts/agents/partials/common_agent_system_prompt.j2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)