### PR TITLE
feat: add validation for required telemetry keys during build

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -23,9 +23,29 @@ class CustomBuildHook(BuildHookInterface):  # type: ignore[type-arg]
         # Get Sentry configuration from environment (SHOTGUN_ prefix for production builds)
         sentry_dsn = os.environ.get("SHOTGUN_SENTRY_DSN", "")
 
+        # Validate that Sentry DSN is present for all builds
+        if not sentry_dsn:
+            raise ValueError(
+                "❌ SHOTGUN_SENTRY_DSN is required for builds but not found in environment. "
+                "Ensure the GitHub secret SENTRY_DSN is set and passed to the build."
+            )
+
         # Get PostHog configuration from environment (SHOTGUN_ prefix)
         posthog_api_key = os.environ.get("SHOTGUN_POSTHOG_API_KEY", "")
         posthog_project_id = os.environ.get("SHOTGUN_POSTHOG_PROJECT_ID", "")
+
+        # Validate that PostHog keys are present for all builds
+        # This ensures we never deploy without analytics configured
+        if not posthog_api_key:
+            raise ValueError(
+                "❌ SHOTGUN_POSTHOG_API_KEY is required for builds but not found in environment. "
+                "Ensure the GitHub secret POSTHOG_API_KEY is set and passed to the build."
+            )
+        if not posthog_project_id:
+            raise ValueError(
+                "❌ SHOTGUN_POSTHOG_PROJECT_ID is required for builds but not found in environment. "
+                "Ensure the GitHub secret POSTHOG_PROJECT_ID is set and passed to the build."
+            )
 
         # Get Logfire configuration (SHOTGUN_ prefix, only for dev builds)
         logfire_enabled = ""


### PR DESCRIPTION
## Summary

Add build-time validation to ensure telemetry credentials (Sentry DSN and PostHog API keys) are present before creating packages. This prevents accidentally deploying packages without proper error tracking and analytics.

## Problem

Currently, if GitHub secrets for telemetry are missing or misconfigured, the build succeeds but produces packages without analytics. Users appear in Logfire but not in PostHog, making it difficult to track adoption and usage patterns.

## Solution

Add validation in `hatch_build.py` to check for required environment variables:
- `SHOTGUN_SENTRY_DSN`
- `SHOTGUN_POSTHOG_API_KEY` 
- `SHOTGUN_POSTHOG_PROJECT_ID`

If any key is missing, the build fails immediately with a clear error message indicating which secret needs to be configured.

## Changes

- ✅ Validate Sentry DSN before build
- ✅ Validate PostHog API key before build
- ✅ Validate PostHog project ID before build
- ✅ Raise `ValueError` with actionable error messages
- ✅ Ensures CI/CD fails fast if secrets are misconfigured

## Test Plan

- [ ] Verify build fails locally without env vars set
- [ ] Verify build succeeds in CI with secrets configured
- [ ] Verify error messages are clear and actionable
- [ ] Confirm deployed package has telemetry properly embedded

## Related Issues

Addresses PostHog initialization failures where `tui_started` events weren't being tracked because credentials weren't embedded in deployed packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)