### PR TITLE
fix: configure Docker builds with telemetry for deploy and skip for tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -333,6 +333,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            SHOTGUN_SENTRY_DSN=${{ secrets.SENTRY_DSN }}
+            SHOTGUN_POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}
+            SHOTGUN_POSTHOG_PROJECT_ID=${{ secrets.POSTHOG_PROJECT_ID }}
+            SHOTGUN_LOGFIRE_ENABLED=${{ needs.build-and-package.outputs.is_dev == 'true' && 'true' || '' }}
+            SHOTGUN_LOGFIRE_TOKEN=${{ needs.build-and-package.outputs.is_dev == 'true' && secrets.LOGFIRE_TOKEN || '' }}
 
   notify-slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -272,6 +272,8 @@ jobs:
           tags: shotgun:pr-${{ github.event.pull_request.number }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            SHOTGUN_BUILD_SKIP_VALIDATION=true
 
   notify-slack-on-secret-found:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
 # Use Python 3.13 slim as base image
 FROM python:3.13-slim
 
+# Build arguments for telemetry configuration
+# These are used during the build process to embed analytics keys
+ARG SHOTGUN_SENTRY_DSN=""
+ARG SHOTGUN_POSTHOG_API_KEY=""
+ARG SHOTGUN_POSTHOG_PROJECT_ID=""
+ARG SHOTGUN_LOGFIRE_ENABLED=""
+ARG SHOTGUN_LOGFIRE_TOKEN=""
+ARG SHOTGUN_BUILD_SKIP_VALIDATION=""
+
 # OCI annotations for package metadata
 LABEL org.opencontainers.image.title="Shotgun" \
       org.opencontainers.image.description="AI-powered CLI tool for research, planning, and task management. Always use :latest for production - see README for details." \
@@ -12,8 +21,7 @@ LABEL org.opencontainers.image.title="Shotgun" \
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    UV_SYSTEM_PYTHON=1 \
-    SHOTGUN_BUILD_SKIP_VALIDATION=true
+    UV_SYSTEM_PYTHON=1
 
 # Install uv for dependency management
 RUN pip install --no-cache-dir uv
@@ -31,7 +39,14 @@ COPY --chown=shotgun:shotgun README.md LICENSE ./
 COPY --chown=shotgun:shotgun docs/README_DOCKER.md ./docs/
 
 # Install dependencies
-RUN uv sync --frozen --no-dev
+# Pass build args as environment variables for the build hook
+RUN SHOTGUN_SENTRY_DSN="${SHOTGUN_SENTRY_DSN}" \
+    SHOTGUN_POSTHOG_API_KEY="${SHOTGUN_POSTHOG_API_KEY}" \
+    SHOTGUN_POSTHOG_PROJECT_ID="${SHOTGUN_POSTHOG_PROJECT_ID}" \
+    SHOTGUN_LOGFIRE_ENABLED="${SHOTGUN_LOGFIRE_ENABLED}" \
+    SHOTGUN_LOGFIRE_TOKEN="${SHOTGUN_LOGFIRE_TOKEN}" \
+    SHOTGUN_BUILD_SKIP_VALIDATION="${SHOTGUN_BUILD_SKIP_VALIDATION}" \
+    uv sync --frozen --no-dev
 
 # Create directories for workspace and config
 RUN mkdir -p /workspace /home/shotgun/.shotgun-sh && \


### PR DESCRIPTION
## Summary

This PR fixes Docker build configuration to properly handle telemetry keys in different contexts:

- **Deploy workflow**: Passes real Sentry/PostHog secrets as build-args so production Docker images have telemetry embedded
- **PR workflow**: Skips validation for docker-build-test jobs (no secrets available in PRs)
- **Dockerfile**: Accepts telemetry keys as ARGs and passes them to the build hook during `uv sync`

## Problem

After adding telemetry key validation in the build hook (PR #85), Docker builds were affected:

1. PR docker-build-test job was failing because it doesn't have access to secrets
2. Deploy docker builds would need to embed real telemetry values for production use

The solution needs to work differently in each context:
- Test builds: Skip validation (no secrets)
- Production builds: Use real secrets

## Changes

### Dockerfile
- Added `ARG` declarations for all telemetry environment variables
- Modified `RUN uv sync` to pass ARGs as environment variables to the build hook
- Removed hardcoded `SHOTGUN_BUILD_SKIP_VALIDATION=true` (was temporary fix)

### .github/workflows/deploy.yml
- Added `build-args` to pass GitHub secrets to Docker build during deployment
- Logfire is conditionally enabled only for dev builds

### .github/workflows/pr.yml
- Added `build-args` to docker-build-test job with `SHOTGUN_BUILD_SKIP_VALIDATION=true`
- This allows PR builds to succeed without requiring secrets

## Testing

- PR workflow's docker-build-test will validate the skip validation path
- Deploy workflow (when this is merged and tagged) will validate the real secrets path

🤖 Generated with [Claude Code](https://claude.com/claude-code)