### PR TITLE
fix: correct biometric verification URL and add key re-add instructions

### DIFF
--- a/src/shotgun/agents/agent_manager.py
+++ b/src/shotgun/agents/agent_manager.py
@@ -633,7 +633,10 @@ class AgentManager(Widget):
                             "Your OpenAI organization doesn't have streaming enabled for this model.\n\n"
                             "**Options:**\n"
                             "- Get a [Shotgun Account](https://shotgun.sh) - streaming works out of the box\n"
-                            "- Complete [Biometric Verification](https://platform.openai.com/settings/organization/billing/payment-methods) with OpenAI\n\n"
+                            "- Complete [Biometric Verification](https://platform.openai.com/settings/organization/general) with OpenAI, then:\n"
+                            "  1. Press `Ctrl+P` → Open Provider Setup\n"
+                            "  2. Select OpenAI → Clear key\n"
+                            "  3. Re-add your OpenAI API key\n\n"
                             "Continuing without streaming (responses will appear all at once)."
                         )
                     )


### PR DESCRIPTION
## Summary

- Fixed incorrect URL in streaming warning for GPT-5 BYOK users
- Added step-by-step instructions for clearing and re-adding API key after biometric verification

## Changes

**Updated warning message** in `src/shotgun/agents/agent_manager.py:636-639`:

### Before:
- URL pointed to `organization/billing/payment-methods` (incorrect)
- Generic instruction to "clear and re-add your API key"

### After:
- URL points to `organization/general` (correct)
- Clear step-by-step instructions:
  1. Press `Ctrl+P` → Open Provider Setup
  2. Select OpenAI → Clear key
  3. Re-add your OpenAI API key

## Why?

Users reported confusion about:
1. Wrong URL - biometric verification is in Organization Settings → General, not Billing
2. Unclear instructions - users didn't know how to clear and re-add their key in the TUI

## Test Plan

- [x] Ruff linting passed
- [x] Ruff formatting passed  
- [x] Mypy type checking passed
- [ ] Manually verify warning message displays correctly in TUI when streaming is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)