### PR TITLE
ci: switch dependabot from pip to uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@
 
 version: 2
 updates:
-  # Python dependencies
-  - package-ecosystem: "pip"
+  # Python dependencies (using uv)
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
## Summary

- Changes Dependabot configuration from `pip` to `uv` package ecosystem
- Enables Dependabot to properly update Python dependencies in `uv.lock`

## Problem

Dependabot was only creating PRs for GitHub Actions updates, not Python dependencies. The root cause was that the configuration used `package-ecosystem: "pip"` which doesn't support `uv.lock` files.

## Solution

GitHub officially added `uv` ecosystem support in March 2025. This PR updates the dependabot config to use the native `uv` package ecosystem, which can properly read and update `uv.lock` files.

## Expected Impact

After this change merges, Dependabot should start creating PRs for Python dependency updates (e.g., anthropic 0.39.0 → 0.68.0, aiofiles 24.0.0 → 25.1.0, etc.)

## References

- [Dependabot uv support announcement](https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/)
- [uv dependency bot integration guide](https://docs.astral.sh/uv/guides/integration/dependency-bots/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)