### PR TITLE
refactor: tune clarifying questions to reduce over-questioning

### DIFF
--- a/src/shotgun/prompts/agents/partials/common_agent_system_prompt.j2
+++ b/src/shotgun/prompts/agents/partials/common_agent_system_prompt.j2
@@ -7,11 +7,11 @@ Your extensive expertise spans, among other things:
 ## KEY RULES
 
 {% if interactive_mode %}
-0. Always ask CLARIFYING QUESTIONS using structured output before doing work.
+0. Ask CLARIFYING QUESTIONS using structured output for complex or multi-step tasks when the request lacks sufficient detail.
    - Return your response with the clarifying_questions field populated
-   - Do not make assumptions about what the user wants, get a clear understanding first.
+   - For simple, straightforward requests, make reasonable assumptions and proceed.
+   - Only ask the most critical questions to avoid overwhelming the user.
    - Questions should be clear, specific, and answerable
-   - Do not ask too many questions that might overwhelm the user; prioritize the most important ones.
 {% endif %}
 1. Above all, prefer using tools to do the work and NEVER respond with text.
 2. IMPORTANT: Always ask for review and go ahead to move forward after using write_file().

--- a/src/shotgun/prompts/agents/partials/interactive_mode.j2
+++ b/src/shotgun/prompts/agents/partials/interactive_mode.j2
@@ -19,10 +19,10 @@ You must return responses using this structured format:
 
 ## When to Use Clarifying Questions
 
-- BEFORE GETTING TO WORK: If the user's request is ambiguous, use clarifying_questions to ask what they want
+- BEFORE GETTING TO WORK: For complex or multi-step tasks where the request is ambiguous or lacks sufficient detail, use clarifying_questions to ask what they want
 - DURING WORK: After using write_file(), you can suggest that the user review it and ask any clarifying questions with clarifying_questions
-- Don't assume - ask for confirmation of your understanding
-- When in doubt about any aspect of the goal, include clarifying_questions
+- For simple, straightforward requests, make reasonable assumptions and proceed
+- Only ask critical questions that significantly impact the outcome
 
 ## Important Notes
 

--- a/src/shotgun/prompts/agents/research.j2
+++ b/src/shotgun/prompts/agents/research.j2
@@ -38,9 +38,6 @@ For research tasks:
 
 ## RESEARCH PRINCIPLES
 
-{% if interactive_mode -%}
-- CRITICAL: BEFORE RUNNING ANY SEARCH TOOL, ASK THE USER FOR APPROVAL using clarifying questions. Include what you plan to search for and ask if they want you to proceed.
-{% endif -%}
 - Build upon existing research rather than starting from scratch
 - Focus on practical, actionable information over theoretical concepts
 - Include specific examples, tools, and implementation details


### PR DESCRIPTION
## Summary

Adjusts the clarifying questions behavior to strike a better balance between thoroughness and user experience. The current implementation (introduced in commit `eb12712`) asks questions too aggressively, prompting for every task regardless of complexity.

This PR implements a "middle ground" approach that:
- Asks clarifying questions only for complex or multi-step tasks when details are lacking
- Allows agents to make reasonable assumptions for simple, straightforward requests
- Removes the research agent's requirement to ask permission before running searches

## Changes

### Modified Files

1. **`src/shotgun/prompts/agents/partials/common_agent_system_prompt.j2`**
   - Changed Rule #0 from "Always ask before doing work" to "Ask for complex or multi-step tasks when the request lacks sufficient detail"
   - Added guidance to make reasonable assumptions for simple requests
   - Emphasized asking only critical questions

2. **`src/shotgun/prompts/agents/partials/interactive_mode.j2`**
   - Updated "When to Use Clarifying Questions" section to be more selective
   - Replaced "when in doubt, ask" with "only ask critical questions that significantly impact the outcome"
   - Explicitly allows proceeding without questions for simple requests

3. **`src/shotgun/prompts/agents/research.j2`**
   - Removed the requirement to ask user approval before running any search tool
   - Research agent can now search freely, reducing friction in research workflows

## Impact

**Before**: Agents would ask clarifying questions for nearly every request, including simple tasks like "create a branch" or "run tests"

**After**: Agents ask questions only when:
- The task is complex or involves multiple steps
- The request is genuinely ambiguous or lacks critical details
- The questions would significantly impact the outcome

## Test Plan

- Test with simple requests (e.g., "create a new file", "run the tests") - should proceed without questions
- Test with complex requests (e.g., "implement authentication system") - should ask targeted clarifying questions
- Test research agent - should search without asking permission first

🤖 Generated with [Claude Code](https://claude.com/claude-code)