### PR TITLE
fix: filter orphaned tool responses after compaction

### DIFF
--- a/src/shotgun/agents/conversation_history.py
+++ b/src/shotgun/agents/conversation_history.py
@@ -9,8 +9,11 @@ from pydantic import BaseModel, ConfigDict, Field
 from pydantic_ai.messages import (
     ModelMessage,
     ModelMessagesTypeAdapter,
+    ModelRequest,
+    ModelRequestPart,
     ModelResponse,
     ToolCallPart,
+    ToolReturnPart,
 )
 from pydantic_core import to_jsonable_python
 
@@ -111,6 +114,67 @@ def filter_incomplete_messages(messages: list[ModelMessage]) -> list[ModelMessag
     return filtered
 
 
+def filter_orphaned_tool_responses(messages: list[ModelMessage]) -> list[ModelMessage]:
+    """Filter out tool responses without corresponding tool calls.
+
+    This ensures message history is valid for OpenAI API which requires
+    tool responses to follow their corresponding tool calls.
+
+    Args:
+        messages: List of messages to filter
+
+    Returns:
+        List of messages with orphaned tool responses removed
+    """
+    # Collect all tool_call_ids from ToolCallPart in ModelResponse
+    valid_tool_call_ids: set[str] = set()
+    for msg in messages:
+        if isinstance(msg, ModelResponse):
+            for part in msg.parts:
+                if isinstance(part, ToolCallPart) and part.tool_call_id:
+                    valid_tool_call_ids.add(part.tool_call_id)
+
+    # Filter out orphaned ToolReturnPart from ModelRequest
+    filtered: list[ModelMessage] = []
+    orphaned_count = 0
+    orphaned_tool_names: list[str] = []
+
+    for msg in messages:
+        if isinstance(msg, ModelRequest):
+            # Filter parts, removing orphaned ToolReturnPart
+            filtered_parts: list[ModelRequestPart] = []
+            request_part: ModelRequestPart
+            for request_part in msg.parts:
+                if isinstance(request_part, ToolReturnPart):
+                    if request_part.tool_call_id in valid_tool_call_ids:
+                        filtered_parts.append(request_part)
+                    else:
+                        # Skip orphaned tool response
+                        orphaned_count += 1
+                        orphaned_tool_names.append(request_part.tool_name or "unknown")
+                else:
+                    filtered_parts.append(request_part)
+
+            # Only add if there are remaining parts
+            if filtered_parts:
+                filtered.append(ModelRequest(parts=filtered_parts))
+        else:
+            filtered.append(msg)
+
+    # Log if any tool responses were filtered
+    if orphaned_count > 0:
+        logger.info(
+            "Filtered orphaned tool responses",
+            extra={
+                "orphaned_count": orphaned_count,
+                "total_messages": len(messages),
+                "orphaned_tool_names": orphaned_tool_names,
+            },
+        )
+
+    return filtered
+
+
 class ConversationState(BaseModel):
     """Represents the complete state of a conversation in memory."""
 
@@ -144,6 +208,8 @@ class ConversationHistory(BaseModel):
         """
         # Filter out messages with incomplete tool calls to prevent corruption
         filtered_messages = filter_incomplete_messages(messages)
+        # Filter out orphaned tool responses (tool responses without tool calls)
+        filtered_messages = filter_orphaned_tool_responses(filtered_messages)
 
         # Serialize ModelMessage list to JSON-serializable format
         self.agent_history = to_jsonable_python(

--- a/src/shotgun/agents/history/history_processors.py
+++ b/src/shotgun/agents/history/history_processors.py
@@ -13,6 +13,7 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 
+from shotgun.agents.conversation_history import filter_orphaned_tool_responses
 from shotgun.agents.llm import shotgun_model_request
 from shotgun.agents.messages import AgentSystemPrompt, SystemStatusPrompt
 from shotgun.agents.models import AgentDeps
@@ -416,6 +417,9 @@ async def token_limit_compactor(
             compacted_messages, messages
         )
 
+        # Filter out orphaned tool responses (tool responses without tool calls)
+        compacted_messages = filter_orphaned_tool_responses(compacted_messages)
+
         logger.debug(
             f"Incremental compaction complete: {len(messages)} -> {len(compacted_messages)} messages"
         )
@@ -564,6 +568,9 @@ async def _full_compaction(
 
     # Ensure history ends with ModelRequest for PydanticAI compatibility
     compacted_messages = ensure_ends_with_model_request(compacted_messages, messages)
+
+    # Filter out orphaned tool responses (tool responses without tool calls)
+    compacted_messages = filter_orphaned_tool_responses(compacted_messages)
 
     # Track full compaction event
     messages_before = len(messages)

--- a/test/unit/test_conversation_history.py
+++ b/test/unit/test_conversation_history.py
@@ -8,12 +8,15 @@ from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
     TextPart,
+    ToolCallPart,
+    ToolReturnPart,
     UserPromptPart,
 )
 
 from shotgun.agents.conversation_history import (
     ConversationHistory,
     ConversationState,
+    filter_orphaned_tool_responses,
 )
 from shotgun.agents.conversation_manager import ConversationManager
 from shotgun.tui.screens.chat_screen.hint_message import HintMessage
@@ -253,3 +256,155 @@ def test_conversation_history_ui_messages_with_hints():
     assert isinstance(retrieved[0], ModelRequest)
     assert isinstance(retrieved[1], ModelResponse)
     assert isinstance(retrieved[2], HintMessage)
+
+
+def test_filter_orphaned_tool_responses_removes_orphans():
+    """Test that orphaned tool responses are filtered out."""
+    # Create messages with orphaned tool response (no matching tool call)
+    messages = [
+        ModelRequest(parts=[UserPromptPart(content="Read a file")]),
+        # Note: No ModelResponse with ToolCallPart for "orphan-id"
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="file_read",
+                    content="file contents",
+                    tool_call_id="orphan-id",
+                )
+            ]
+        ),
+    ]
+
+    filtered = filter_orphaned_tool_responses(messages)
+
+    # The orphaned tool response should be removed entirely
+    # since ModelRequest only had the ToolReturnPart
+    assert len(filtered) == 1
+    assert isinstance(filtered[0], ModelRequest)
+    assert isinstance(filtered[0].parts[0], UserPromptPart)
+
+
+def test_filter_orphaned_tool_responses_preserves_valid_pairs():
+    """Test that valid tool call/response pairs are preserved."""
+    tool_call_id = "valid-id-123"
+
+    messages = [
+        ModelRequest(parts=[UserPromptPart(content="Read a file")]),
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="file_read",
+                    args={"path": "/test.txt"},
+                    tool_call_id=tool_call_id,
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="file_read",
+                    content="file contents",
+                    tool_call_id=tool_call_id,
+                )
+            ]
+        ),
+    ]
+
+    filtered = filter_orphaned_tool_responses(messages)
+
+    # All messages should be preserved
+    assert len(filtered) == 3
+    assert isinstance(filtered[2], ModelRequest)
+    assert isinstance(filtered[2].parts[0], ToolReturnPart)
+
+
+def test_filter_orphaned_tool_responses_mixed_scenario():
+    """Test filtering with mix of valid and orphaned tool responses."""
+    valid_id = "valid-id"
+    orphan_id = "orphan-id"
+
+    messages = [
+        ModelRequest(parts=[UserPromptPart(content="Do things")]),
+        # Valid tool call
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="valid_tool",
+                    args={},
+                    tool_call_id=valid_id,
+                )
+            ]
+        ),
+        # Request with both valid and orphaned tool responses
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="valid_tool",
+                    content="valid result",
+                    tool_call_id=valid_id,
+                ),
+                ToolReturnPart(
+                    tool_name="orphan_tool",
+                    content="orphan result",
+                    tool_call_id=orphan_id,
+                ),
+            ]
+        ),
+    ]
+
+    filtered = filter_orphaned_tool_responses(messages)
+
+    # All 3 messages should exist, but last one should only have valid tool return
+    assert len(filtered) == 3
+    last_request = filtered[2]
+    assert isinstance(last_request, ModelRequest)
+    assert len(last_request.parts) == 1
+    tool_return = last_request.parts[0]
+    assert isinstance(tool_return, ToolReturnPart)
+    assert tool_return.tool_call_id == valid_id
+
+
+def test_filter_orphaned_tool_responses_preserves_other_parts():
+    """Test that non-tool parts in ModelRequest are preserved."""
+    orphan_id = "orphan-id"
+
+    messages = [
+        ModelRequest(
+            parts=[
+                UserPromptPart(content="User message"),
+                ToolReturnPart(
+                    tool_name="orphan_tool",
+                    content="orphan result",
+                    tool_call_id=orphan_id,
+                ),
+            ]
+        ),
+    ]
+
+    filtered = filter_orphaned_tool_responses(messages)
+
+    # Message should still exist with just the UserPromptPart
+    assert len(filtered) == 1
+    assert isinstance(filtered[0], ModelRequest)
+    assert len(filtered[0].parts) == 1
+    assert isinstance(filtered[0].parts[0], UserPromptPart)
+
+
+def test_filter_orphaned_tool_responses_empty_list():
+    """Test filtering with empty message list."""
+    filtered = filter_orphaned_tool_responses([])
+    assert filtered == []
+
+
+def test_filter_orphaned_tool_responses_no_tool_messages():
+    """Test filtering when there are no tool-related messages."""
+    messages = [
+        ModelRequest(parts=[UserPromptPart(content="Hello")]),
+        ModelResponse(parts=[TextPart(content="Hi there!")]),
+    ]
+
+    filtered = filter_orphaned_tool_responses(messages)
+
+    # All messages should be unchanged
+    assert len(filtered) == 2
+    assert filtered == messages


### PR DESCRIPTION
## Summary

- Fixes a bug where conversation compaction could leave the history in an invalid state
- After compaction, `ToolReturnPart` messages could exist without their corresponding `ToolCallPart` messages
- This caused OpenAI API to reject requests with: `"messages with role 'tool' must be a response to a preceeding message with 'tool_calls'"`

## Root Cause

In `history_building.py`, `ensure_ends_with_model_request()` appends the `last_user_request` from original messages. If this request contains `ToolReturnPart` but the corresponding `ModelResponse` with `ToolCallPart` was summarized away during compaction, we get orphaned tool responses.

## Solution

Added `filter_orphaned_tool_responses()` function that:
1. Collects all `tool_call_id` values from `ToolCallPart` in `ModelResponse` messages
2. Filters out `ToolReturnPart` from `ModelRequest` messages if their `tool_call_id` is not in the collected set

Applied in two places:
- After compaction (both incremental and full paths) - primary fix
- Before serialization in `set_agent_messages()` - defense-in-depth

## Test plan

- [x] Added 6 new unit tests for `filter_orphaned_tool_responses()`
- [x] All existing tests pass
- [x] Type checking passes
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)