### PR TITLE
feat: add PostHog analytics for spec operations and auth

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -207,6 +207,23 @@ PostHog tracks:
 - Update checks
 - Errors and exceptions
 
+### Spec Operations Events
+
+- `spec_pull_started` - Spec download initiated (properties: source)
+- `spec_pull_completed` - Spec download successful (properties: source, file_count, total_bytes, duration_seconds, had_backup)
+- `spec_pull_failed` - Spec download failed (properties: source, error_type, phase)
+- `spec_pull_cancelled` - Spec download cancelled by user (properties: source, phase)
+- `spec_upload_started` - Spec upload initiated
+- `spec_upload_completed` - Spec upload successful (properties: file_count, total_bytes, duration_seconds)
+- `spec_upload_failed` - Spec upload failed (properties: error_type, phase, files_uploaded, bytes_uploaded)
+
+### Authentication Events
+
+- `auth_started` - Authentication flow initiated
+- `auth_completed` - Authentication successful (properties: duration_seconds)
+- `auth_failed` - Authentication failed (properties: phase, error_type)
+- `auth_cancelled` - Authentication cancelled by user
+
 ### Viewing Analytics
 
 1. Log into PostHog dashboard

--- a/src/shotgun/cli/spec/commands.py
+++ b/src/shotgun/cli/spec/commands.py
@@ -16,6 +16,7 @@ from shotgun.shotgun_web.exceptions import (
 from shotgun.tui import app as tui_app
 from shotgun.utils.file_system_utils import get_shotgun_base_path
 
+from .models import PullSource
 from .pull_service import CancelledError, PullProgress, SpecPullService
 
 app = typer.Typer(
@@ -94,6 +95,7 @@ async def _async_pull(version_id: str) -> bool:
                 version_id=version_id,
                 shotgun_dir=shotgun_dir,
                 on_progress=on_progress,
+                source=PullSource.CLI,
             )
 
         if result.success:

--- a/src/shotgun/cli/spec/models.py
+++ b/src/shotgun/cli/spec/models.py
@@ -1,8 +1,26 @@
 """Pydantic models for spec CLI commands."""
 
 from datetime import datetime
+from enum import StrEnum
 
 from pydantic import BaseModel, Field
+
+
+class PullSource(StrEnum):
+    """Source of spec pull operation for analytics."""
+
+    CLI = "cli"
+    TUI = "tui"
+
+
+class PullPhase(StrEnum):
+    """Phases during spec pull operation for analytics."""
+
+    STARTING = "starting"
+    FETCHING = "fetching"
+    BACKUP = "backup"
+    DOWNLOADING = "downloading"
+    FINALIZING = "finalizing"
 
 
 class SpecMeta(BaseModel):

--- a/src/shotgun/cli/spec/pull_service.py
+++ b/src/shotgun/cli/spec/pull_service.py
@@ -1,16 +1,18 @@
 """Shared spec pull service for CLI and TUI."""
 
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
 from shotgun.logging_config import get_logger
+from shotgun.posthog_telemetry import track_event
 from shotgun.shotgun_web.specs_client import SpecsClient
 from shotgun.shotgun_web.supabase_client import download_file_from_url
 
 from .backup import clear_shotgun_dir, create_backup
-from .models import SpecMeta
+from .models import PullPhase, PullSource, SpecMeta
 
 logger = get_logger(__name__)
 
@@ -53,6 +55,7 @@ class SpecPullService:
         shotgun_dir: Path,
         on_progress: Callable[[PullProgress], None] | None = None,
         is_cancelled: Callable[[], bool] | None = None,
+        source: PullSource = PullSource.CLI,
     ) -> PullResult:
         """Pull a spec version to the local directory.
 
@@ -61,10 +64,14 @@ class SpecPullService:
             shotgun_dir: Target directory (typically .shotgun/)
             on_progress: Optional callback for progress updates
             is_cancelled: Optional callback to check if cancelled
+            source: Source of the pull request (CLI or TUI)
 
         Returns:
             PullResult with success status and details
         """
+        start_time = time.time()
+        current_phase: PullPhase = PullPhase.STARTING
+        track_event("spec_pull_started", {"source": source.value})
 
         def report(
             phase: str,
@@ -83,83 +90,130 @@ class SpecPullService:
                 )
 
         def check_cancelled() -> None:
+            nonlocal current_phase
             if is_cancelled and is_cancelled():
+                track_event(
+                    "spec_pull_cancelled",
+                    {"source": source.value, "phase": current_phase.value},
+                )
                 raise CancelledError()
 
-        # Phase 1: Fetch version metadata
-        report("Fetching version info...")
-        check_cancelled()
-
-        response = await self._client.get_version_with_files(version_id)
-        spec_name = response.spec_name
-        files = response.files
-
-        if not files:
-            return PullResult(
-                success=False,
-                spec_name=spec_name,
-                error="No files in this version.",
-            )
-
-        # Phase 2: Backup existing content
-        backup_path: str | None = None
-        if shotgun_dir.exists():
-            report("Backing up existing files...")
+        try:
+            # Phase 1: Fetch version metadata
+            current_phase = PullPhase.FETCHING
+            report("Fetching version info...")
             check_cancelled()
 
-            backup_path = await create_backup(shotgun_dir)
-            if backup_path:
-                clear_shotgun_dir(shotgun_dir)
+            response = await self._client.get_version_with_files(version_id)
+            spec_name = response.spec_name
+            files = response.files
 
-        # Ensure directory exists
-        shotgun_dir.mkdir(parents=True, exist_ok=True)
-
-        # Phase 3: Download files
-        total_files = len(files)
-        for idx, file_info in enumerate(files):
-            check_cancelled()
-
-            report(
-                f"Downloading files ({idx + 1}/{total_files})...",
-                file_index=idx,
-                total_files=total_files,
-                current_file=file_info.relative_path,
-            )
-
-            if not file_info.download_url:
-                logger.warning(
-                    "Skipping file without download URL: %s",
-                    file_info.relative_path,
+            if not files:
+                track_event(
+                    "spec_pull_failed",
+                    {
+                        "source": source.value,
+                        "error_type": "EmptyVersion",
+                        "phase": current_phase.value,
+                    },
                 )
-                continue
+                return PullResult(
+                    success=False,
+                    spec_name=spec_name,
+                    error="No files in this version.",
+                )
 
-            content = await download_file_from_url(file_info.download_url)
+            # Phase 2: Backup existing content
+            current_phase = PullPhase.BACKUP
+            backup_path: str | None = None
+            if shotgun_dir.exists():
+                report("Backing up existing files...")
+                check_cancelled()
 
-            local_path = shotgun_dir / file_info.relative_path
-            local_path.parent.mkdir(parents=True, exist_ok=True)
-            local_path.write_bytes(content)
+                backup_path = await create_backup(shotgun_dir)
+                if backup_path:
+                    clear_shotgun_dir(shotgun_dir)
 
-        # Phase 4: Write meta.json
-        report("Finalizing...")
-        check_cancelled()
+            # Ensure directory exists
+            shotgun_dir.mkdir(parents=True, exist_ok=True)
 
-        meta = SpecMeta(
-            version_id=response.version.id,
-            spec_id=response.spec_id,
-            spec_name=response.spec_name,
-            workspace_id=response.workspace_id,
-            is_latest=response.version.is_latest,
-            pulled_at=datetime.now(timezone.utc),
-            backup_path=backup_path,
-            web_url=response.web_url,
-        )
-        meta_path = shotgun_dir / "meta.json"
-        meta_path.write_text(meta.model_dump_json(indent=2))
+            # Phase 3: Download files
+            current_phase = PullPhase.DOWNLOADING
+            total_files = len(files)
+            total_bytes = 0
+            for idx, file_info in enumerate(files):
+                check_cancelled()
 
-        return PullResult(
-            success=True,
-            spec_name=spec_name,
-            file_count=total_files,
-            backup_path=backup_path,
-            web_url=response.web_url,
-        )
+                report(
+                    f"Downloading files ({idx + 1}/{total_files})...",
+                    file_index=idx,
+                    total_files=total_files,
+                    current_file=file_info.relative_path,
+                )
+
+                if not file_info.download_url:
+                    logger.warning(
+                        "Skipping file without download URL: %s",
+                        file_info.relative_path,
+                    )
+                    continue
+
+                content = await download_file_from_url(file_info.download_url)
+                total_bytes += file_info.size_bytes
+
+                local_path = shotgun_dir / file_info.relative_path
+                local_path.parent.mkdir(parents=True, exist_ok=True)
+                local_path.write_bytes(content)
+
+            # Phase 4: Write meta.json
+            current_phase = PullPhase.FINALIZING
+            report("Finalizing...")
+            check_cancelled()
+
+            meta = SpecMeta(
+                version_id=response.version.id,
+                spec_id=response.spec_id,
+                spec_name=response.spec_name,
+                workspace_id=response.workspace_id,
+                is_latest=response.version.is_latest,
+                pulled_at=datetime.now(timezone.utc),
+                backup_path=backup_path,
+                web_url=response.web_url,
+            )
+            meta_path = shotgun_dir / "meta.json"
+            meta_path.write_text(meta.model_dump_json(indent=2))
+
+            # Track successful completion
+            duration = time.time() - start_time
+            track_event(
+                "spec_pull_completed",
+                {
+                    "source": source.value,
+                    "file_count": total_files,
+                    "total_bytes": total_bytes,
+                    "duration_seconds": round(duration, 2),
+                    "had_backup": backup_path is not None,
+                },
+            )
+
+            return PullResult(
+                success=True,
+                spec_name=spec_name,
+                file_count=total_files,
+                backup_path=backup_path,
+                web_url=response.web_url,
+            )
+
+        except CancelledError:
+            # Already tracked in check_cancelled()
+            raise
+        except Exception as e:
+            track_event(
+                "spec_pull_failed",
+                {
+                    "source": source.value,
+                    "error_type": type(e).__name__,
+                    "phase": current_phase.value,
+                },
+            )
+            raise

--- a/src/shotgun/shotgun_web/shared_specs/upload_pipeline.py
+++ b/src/shotgun/shotgun_web/shared_specs/upload_pipeline.py
@@ -1,10 +1,12 @@
 """Upload pipeline for .shotgun/ directory to Specs API."""
 
 import asyncio
+import time
 from collections.abc import Callable
 from pathlib import Path
 
 from shotgun.logging_config import get_logger
+from shotgun.posthog_telemetry import track_event
 from shotgun.shotgun_web.models import FileMetadata
 from shotgun.shotgun_web.shared_specs.file_scanner import (
     scan_shotgun_directory_with_counts,
@@ -54,6 +56,9 @@ async def run_upload_pipeline(
         project_root = Path.cwd()
 
     state = UploadState()
+    start_time = time.time()
+    current_phase: UploadPhase = UploadPhase.CREATING
+    track_event("spec_upload_started")
 
     def report_progress(progress: UploadProgress) -> None:
         """Report progress to callback if provided."""
@@ -62,6 +67,7 @@ async def run_upload_pipeline(
 
     try:
         # Phase 1: Scan files
+        current_phase = UploadPhase.SCANNING
         report_progress(
             UploadProgress(
                 phase=UploadPhase.SCANNING,
@@ -84,6 +90,15 @@ async def run_upload_pipeline(
                     "No files to share. Add specifications to .shotgun/ first."
                 )
 
+            track_event(
+                "spec_upload_failed",
+                {
+                    "error_type": "EmptyDirectory",
+                    "phase": current_phase.value,
+                    "files_uploaded": 0,
+                    "bytes_uploaded": 0,
+                },
+            )
             report_progress(
                 UploadProgress(
                     phase=UploadPhase.ERROR,
@@ -110,6 +125,7 @@ async def run_upload_pipeline(
         )
 
         # Phase 2: Calculate hashes
+        current_phase = UploadPhase.HASHING
         report_progress(
             UploadProgress(
                 phase=UploadPhase.HASHING,
@@ -122,6 +138,7 @@ async def run_upload_pipeline(
         files_with_hashes = await _calculate_hashes(files, state, report_progress)
 
         # Phase 3: Upload files
+        current_phase = UploadPhase.UPLOADING
         report_progress(
             UploadProgress(
                 phase=UploadPhase.UPLOADING,
@@ -144,6 +161,7 @@ async def run_upload_pipeline(
         )
 
         # Phase 4: Close version
+        current_phase = UploadPhase.CLOSING
         report_progress(
             UploadProgress(
                 phase=UploadPhase.CLOSING,
@@ -169,6 +187,17 @@ async def run_upload_pipeline(
             )
         )
 
+        # Track successful completion
+        duration = time.time() - start_time
+        track_event(
+            "spec_upload_completed",
+            {
+                "file_count": state.files_uploaded,
+                "total_bytes": state.bytes_uploaded,
+                "duration_seconds": round(duration, 2),
+            },
+        )
+
         return UploadResult(
             success=True,
             web_url=close_response.web_url,
@@ -178,6 +207,15 @@ async def run_upload_pipeline(
 
     except Exception as e:
         logger.error(f"Upload pipeline failed: {e}", exc_info=True)
+        track_event(
+            "spec_upload_failed",
+            {
+                "error_type": type(e).__name__,
+                "phase": current_phase.value,
+                "files_uploaded": state.files_uploaded,
+                "bytes_uploaded": state.bytes_uploaded,
+            },
+        )
         report_progress(
             UploadProgress(
                 phase=UploadPhase.ERROR,

--- a/src/shotgun/tui/screens/shotgun_auth.py
+++ b/src/shotgun/tui/screens/shotgun_auth.py
@@ -1,6 +1,7 @@
 """Shotgun Account authentication screen."""
 
 import asyncio
+import time
 import webbrowser
 from typing import TYPE_CHECKING, cast
 
@@ -15,6 +16,7 @@ from textual.worker import Worker, WorkerState
 
 from shotgun.agents.config import ConfigManager
 from shotgun.logging_config import get_logger
+from shotgun.posthog_telemetry import track_event
 from shotgun.shotgun_web import (
     ShotgunWebClient,
     TokenStatus,
@@ -118,6 +120,7 @@ class ShotgunAuthScreen(Screen[bool]):
         self.token: str | None = None
         self.auth_url: str | None = None
         self.poll_worker: Worker[None] | None = None
+        self._auth_start_time: float | None = None
 
     def compose(self) -> ComposeResult:
         with Vertical(id="titlebox"):
@@ -158,6 +161,7 @@ class ShotgunAuthScreen(Screen[bool]):
 
     def action_cancel(self) -> None:
         """Cancel authentication and close screen."""
+        track_event("auth_cancelled")
         if self.poll_worker and self.poll_worker.state == WorkerState.RUNNING:
             self.poll_worker.cancel()
         self.dismiss(False)
@@ -174,6 +178,9 @@ class ShotgunAuthScreen(Screen[bool]):
 
     async def _start_auth_flow(self) -> None:
         """Start the authentication flow."""
+        self._auth_start_time = time.time()
+        track_event("auth_started")
+
         try:
             # Get shotgun instance ID from config
             shotgun_instance_id = await self.config_manager.get_shotgun_instance_id()
@@ -220,12 +227,20 @@ class ShotgunAuthScreen(Screen[bool]):
 
         except httpx.HTTPError as e:
             logger.error("Failed to create auth token: %s", e)
+            track_event(
+                "auth_failed",
+                {"phase": "token_creation", "error_type": type(e).__name__},
+            )
             self.query_one("#status", Label).update(
                 f"❌ Error: Failed to create authentication token\n{e}"
             )
 
         except Exception as e:
             logger.error("Unexpected error during auth flow: %s", e)
+            track_event(
+                "auth_failed",
+                {"phase": "token_creation", "error_type": type(e).__name__},
+            )
             self.query_one("#status", Label).update(f"❌ Unexpected error: {e}")
 
     async def _poll_token_status(self) -> None:
@@ -272,6 +287,17 @@ class ShotgunAuthScreen(Screen[bool]):
                             workspace_id=workspace_id,
                         )
 
+                        # Track successful auth
+                        duration = (
+                            time.time() - self._auth_start_time
+                            if self._auth_start_time
+                            else 0
+                        )
+                        track_event(
+                            "auth_completed",
+                            {"duration_seconds": round(duration, 2)},
+                        )
+
                         self.query_one("#status", Label).update(
                             "✅ Authentication successful! Saving credentials..."
                         )
@@ -279,6 +305,10 @@ class ShotgunAuthScreen(Screen[bool]):
                         self.dismiss(True)
                     else:
                         logger.error("Completed but missing keys")
+                        track_event(
+                            "auth_failed",
+                            {"phase": "polling", "error_type": "MissingKeys"},
+                        )
                         self.query_one("#status", Label).update(
                             "❌ Error: Authentication completed but keys are missing"
                         )
@@ -293,6 +323,10 @@ class ShotgunAuthScreen(Screen[bool]):
 
                 elif status_response.status == TokenStatus.EXPIRED:
                     logger.error("Token expired")
+                    track_event(
+                        "auth_failed",
+                        {"phase": "token_expired", "error_type": "TokenExpired"},
+                    )
                     self.query_one("#status", Label).update(
                         "❌ Authentication token expired (30 minutes)\n"
                         "Please try again."
@@ -312,6 +346,10 @@ class ShotgunAuthScreen(Screen[bool]):
                 if e.response.status_code == 410:
                     # Token expired
                     logger.error("Token expired (410)")
+                    track_event(
+                        "auth_failed",
+                        {"phase": "token_expired", "error_type": "TokenExpired"},
+                    )
                     self.query_one("#status", Label).update(
                         "❌ Authentication token expired"
                     )
@@ -320,6 +358,10 @@ class ShotgunAuthScreen(Screen[bool]):
                     return
                 else:
                     logger.error("HTTP error polling status: %s", e)
+                    track_event(
+                        "auth_failed",
+                        {"phase": "polling_error", "error_type": type(e).__name__},
+                    )
                     self.query_one("#status", Label).update(
                         f"❌ Error checking status: {e}"
                     )
@@ -327,11 +369,19 @@ class ShotgunAuthScreen(Screen[bool]):
 
             except Exception as e:
                 logger.error("Error polling token status: %s", e)
+                track_event(
+                    "auth_failed",
+                    {"phase": "polling_error", "error_type": type(e).__name__},
+                )
                 self.query_one("#status", Label).update(f"⚠️ Error checking status: {e}")
                 await asyncio.sleep(5)  # Wait a bit longer on error
 
         # Timeout reached
         logger.error("Polling timeout reached")
+        track_event(
+            "auth_failed",
+            {"phase": "timeout", "error_type": "Timeout"},
+        )
         self.query_one("#status", Label).update(
             "❌ Authentication timeout (30 minutes)\nPlease try again."
         )

--- a/src/shotgun/tui/screens/spec_pull.py
+++ b/src/shotgun/tui/screens/spec_pull.py
@@ -8,6 +8,7 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Label, ProgressBar, Static
 from textual.worker import Worker, get_current_worker
 
+from shotgun.cli.spec.models import PullSource
 from shotgun.cli.spec.pull_service import (
     CancelledError,
     PullProgress,
@@ -187,6 +188,7 @@ class SpecPullScreen(ModalScreen[bool]):
                 shotgun_dir=shotgun_dir,
                 on_progress=on_progress,
                 is_cancelled=lambda: worker.is_cancelled,
+                source=PullSource.TUI,
             )
 
             if result.success:

--- a/test/unit/cli/spec/test_pull_service.py
+++ b/test/unit/cli/spec/test_pull_service.py
@@ -6,10 +6,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from shotgun.cli.spec.models import PullSource
 from shotgun.cli.spec.pull_service import (
     CancelledError,
     PullProgress,
-    PullResult,
     SpecPullService,
 )
 from shotgun.shotgun_web.models import SpecFileResponse, SpecVersionResponse
@@ -74,9 +74,7 @@ async def test_pull_version_success(tmp_path: Path, mock_version_response):
     mock_client.get_version_with_files.return_value = mock_version_response
 
     with (
-        patch(
-            "shotgun.cli.spec.pull_service.SpecsClient", return_value=mock_client
-        ),
+        patch("shotgun.cli.spec.pull_service.SpecsClient", return_value=mock_client),
         patch(
             "shotgun.cli.spec.pull_service.download_file_from_url",
             return_value=b"# Test Content",
@@ -112,9 +110,7 @@ async def test_pull_version_with_progress_callback(
     mock_client.get_version_with_files.return_value = mock_version_response
 
     with (
-        patch(
-            "shotgun.cli.spec.pull_service.SpecsClient", return_value=mock_client
-        ),
+        patch("shotgun.cli.spec.pull_service.SpecsClient", return_value=mock_client),
         patch(
             "shotgun.cli.spec.pull_service.download_file_from_url",
             return_value=b"# Test Content",
@@ -155,9 +151,7 @@ async def test_pull_version_cancellation(tmp_path: Path, mock_version_response):
     mock_client.get_version_with_files.return_value = mock_version_response
 
     with (
-        patch(
-            "shotgun.cli.spec.pull_service.SpecsClient", return_value=mock_client
-        ),
+        patch("shotgun.cli.spec.pull_service.SpecsClient", return_value=mock_client),
         patch(
             "shotgun.cli.spec.pull_service.download_file_from_url",
             return_value=b"# Test Content",
@@ -188,9 +182,7 @@ async def test_pull_version_empty_files(tmp_path: Path):
     mock_client = AsyncMock()
     mock_client.get_version_with_files.return_value = mock_response
 
-    with patch(
-        "shotgun.cli.spec.pull_service.SpecsClient", return_value=mock_client
-    ):
+    with patch("shotgun.cli.spec.pull_service.SpecsClient", return_value=mock_client):
         service = SpecPullService()
         result = await service.pull_version(
             version_id="version-123",
@@ -215,9 +207,7 @@ async def test_pull_version_backs_up_existing(tmp_path: Path, mock_version_respo
     mock_backup_path = str(tmp_path / "backup.zip")
 
     with (
-        patch(
-            "shotgun.cli.spec.pull_service.SpecsClient", return_value=mock_client
-        ),
+        patch("shotgun.cli.spec.pull_service.SpecsClient", return_value=mock_client),
         patch(
             "shotgun.cli.spec.pull_service.download_file_from_url",
             return_value=b"# Test Content",
@@ -294,9 +284,7 @@ async def test_pull_version_skips_file_without_url(tmp_path: Path):
     mock_client.get_version_with_files.return_value = mock_response
 
     with (
-        patch(
-            "shotgun.cli.spec.pull_service.SpecsClient", return_value=mock_client
-        ),
+        patch("shotgun.cli.spec.pull_service.SpecsClient", return_value=mock_client),
         patch(
             "shotgun.cli.spec.pull_service.download_file_from_url",
             return_value=b"# Test Content",
@@ -313,3 +301,136 @@ async def test_pull_version_skips_file_without_url(tmp_path: Path):
     mock_download.assert_called_once()
     assert (shotgun_dir / "spec.md").exists()
     assert not (shotgun_dir / "missing.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_pull_version_tracks_posthog_events(
+    tmp_path: Path, mock_version_response
+):
+    """Test PostHog events are tracked during successful pull."""
+    shotgun_dir = tmp_path / ".shotgun"
+
+    mock_client = AsyncMock()
+    mock_client.get_version_with_files.return_value = mock_version_response
+
+    with (
+        patch("shotgun.cli.spec.pull_service.SpecsClient", return_value=mock_client),
+        patch(
+            "shotgun.cli.spec.pull_service.download_file_from_url",
+            return_value=b"# Test Content",
+        ),
+        patch("shotgun.cli.spec.pull_service.track_event") as mock_track,
+    ):
+        service = SpecPullService()
+        result = await service.pull_version(
+            version_id="version-123",
+            shotgun_dir=shotgun_dir,
+            source=PullSource.TUI,
+        )
+
+    assert result.success is True
+
+    # Verify started event was tracked
+    mock_track.assert_any_call("spec_pull_started", {"source": "tui"})
+
+    # Verify completed event was tracked with correct properties
+    completed_calls = [
+        c for c in mock_track.call_args_list if c[0][0] == "spec_pull_completed"
+    ]
+    assert len(completed_calls) == 1
+    props = completed_calls[0][0][1]
+    assert props["source"] == "tui"
+    assert props["file_count"] == 2
+    assert "total_bytes" in props
+    assert "duration_seconds" in props
+    assert "had_backup" in props
+
+
+@pytest.mark.asyncio
+async def test_pull_version_tracks_failure_event(tmp_path: Path):
+    """Test PostHog failure event is tracked for empty version."""
+    shotgun_dir = tmp_path / ".shotgun"
+
+    mock_response = MagicMock(
+        version=MagicMock(id="version-123", is_latest=True),
+        spec_name="Empty Spec",
+        spec_id="spec-456",
+        workspace_id="workspace-789",
+        files=[],
+    )
+
+    mock_client = AsyncMock()
+    mock_client.get_version_with_files.return_value = mock_response
+
+    with (
+        patch("shotgun.cli.spec.pull_service.SpecsClient", return_value=mock_client),
+        patch("shotgun.cli.spec.pull_service.track_event") as mock_track,
+    ):
+        service = SpecPullService()
+        result = await service.pull_version(
+            version_id="version-123",
+            shotgun_dir=shotgun_dir,
+            source=PullSource.CLI,
+        )
+
+    assert result.success is False
+
+    # Verify started event was tracked
+    mock_track.assert_any_call("spec_pull_started", {"source": "cli"})
+
+    # Verify failed event was tracked
+    failed_calls = [
+        c for c in mock_track.call_args_list if c[0][0] == "spec_pull_failed"
+    ]
+    assert len(failed_calls) == 1
+    props = failed_calls[0][0][1]
+    assert props["source"] == "cli"
+    assert props["error_type"] == "EmptyVersion"
+    assert props["phase"] == "fetching"
+
+
+@pytest.mark.asyncio
+async def test_pull_version_tracks_cancelled_event(
+    tmp_path: Path, mock_version_response
+):
+    """Test PostHog cancelled event is tracked when pull is cancelled."""
+    shotgun_dir = tmp_path / ".shotgun"
+    cancel_after = 1
+    cancel_count = 0
+
+    def is_cancelled() -> bool:
+        nonlocal cancel_count
+        cancel_count += 1
+        return cancel_count > cancel_after
+
+    mock_client = AsyncMock()
+    mock_client.get_version_with_files.return_value = mock_version_response
+
+    with (
+        patch("shotgun.cli.spec.pull_service.SpecsClient", return_value=mock_client),
+        patch(
+            "shotgun.cli.spec.pull_service.download_file_from_url",
+            return_value=b"# Test Content",
+        ),
+        patch("shotgun.cli.spec.pull_service.track_event") as mock_track,
+        pytest.raises(CancelledError),
+    ):
+        service = SpecPullService()
+        await service.pull_version(
+            version_id="version-123",
+            shotgun_dir=shotgun_dir,
+            is_cancelled=is_cancelled,
+            source=PullSource.TUI,
+        )
+
+    # Verify started event was tracked
+    mock_track.assert_any_call("spec_pull_started", {"source": "tui"})
+
+    # Verify cancelled event was tracked
+    cancelled_calls = [
+        c for c in mock_track.call_args_list if c[0][0] == "spec_pull_cancelled"
+    ]
+    assert len(cancelled_calls) == 1
+    props = cancelled_calls[0][0][1]
+    assert props["source"] == "tui"
+    assert "phase" in props

--- a/test/unit/shotgun_web/shared_specs/test_upload_pipeline.py
+++ b/test/unit/shotgun_web/shared_specs/test_upload_pipeline.py
@@ -353,3 +353,117 @@ async def test_run_upload_pipeline_large_file(tmp_path: Path):
     assert result.files_uploaded == 1
     # 50MB = 50 * 1024 * 1024 bytes
     assert result.total_bytes == 50 * 1024 * 1024
+
+
+@pytest.mark.asyncio
+async def test_run_upload_pipeline_tracks_posthog_events(temp_shotgun_dir: Path):
+    """Test PostHog events are tracked during successful upload."""
+    mock_client = AsyncMock()
+    mock_client.initiate_file_upload = AsyncMock(
+        side_effect=lambda *args, **kwargs: _mock_file_upload_response(args[3])
+    )
+    mock_client.upload_file_to_presigned_url = AsyncMock()
+    mock_client.close_version = AsyncMock(return_value=_mock_version_close_response())
+
+    with (
+        patch(
+            "shotgun.shotgun_web.shared_specs.upload_pipeline.SpecsClient",
+            return_value=mock_client,
+        ),
+        patch(
+            "shotgun.shotgun_web.shared_specs.upload_pipeline.track_event"
+        ) as mock_track,
+    ):
+        result = await run_upload_pipeline(
+            workspace_id="ws-123",
+            spec_id="spec-123",
+            version_id="version-123",
+            project_root=temp_shotgun_dir,
+        )
+
+    assert result.success is True
+
+    # Verify started event was tracked
+    mock_track.assert_any_call("spec_upload_started")
+
+    # Verify completed event was tracked with correct properties
+    completed_calls = [
+        c for c in mock_track.call_args_list if c[0][0] == "spec_upload_completed"
+    ]
+    assert len(completed_calls) == 1
+    props = completed_calls[0][0][1]
+    assert props["file_count"] == 3
+    assert "total_bytes" in props
+    assert "duration_seconds" in props
+
+
+@pytest.mark.asyncio
+async def test_run_upload_pipeline_tracks_failure_event_empty_dir(tmp_path: Path):
+    """Test PostHog failure event is tracked for empty directory."""
+    shotgun_dir = tmp_path / ".shotgun"
+    shotgun_dir.mkdir()
+
+    with patch(
+        "shotgun.shotgun_web.shared_specs.upload_pipeline.track_event"
+    ) as mock_track:
+        result = await run_upload_pipeline(
+            workspace_id="ws-123",
+            spec_id="spec-123",
+            version_id="version-123",
+            project_root=tmp_path,
+        )
+
+    assert result.success is False
+
+    # Verify started event was tracked
+    mock_track.assert_any_call("spec_upload_started")
+
+    # Verify failed event was tracked
+    failed_calls = [
+        c for c in mock_track.call_args_list if c[0][0] == "spec_upload_failed"
+    ]
+    assert len(failed_calls) == 1
+    props = failed_calls[0][0][1]
+    assert props["error_type"] == "EmptyDirectory"
+    assert props["phase"] == "scanning"
+
+
+@pytest.mark.asyncio
+async def test_run_upload_pipeline_tracks_failure_event_upload_error(
+    temp_shotgun_dir: Path,
+):
+    """Test PostHog failure event is tracked for upload errors."""
+    mock_client = AsyncMock()
+    mock_client.initiate_file_upload = AsyncMock(
+        side_effect=RuntimeError("Network error")
+    )
+
+    with (
+        patch(
+            "shotgun.shotgun_web.shared_specs.upload_pipeline.SpecsClient",
+            return_value=mock_client,
+        ),
+        patch(
+            "shotgun.shotgun_web.shared_specs.upload_pipeline.track_event"
+        ) as mock_track,
+    ):
+        result = await run_upload_pipeline(
+            workspace_id="ws-123",
+            spec_id="spec-123",
+            version_id="version-123",
+            project_root=temp_shotgun_dir,
+        )
+
+    assert result.success is False
+
+    # Verify started event was tracked
+    mock_track.assert_any_call("spec_upload_started")
+
+    # Verify failed event was tracked
+    failed_calls = [
+        c for c in mock_track.call_args_list if c[0][0] == "spec_upload_failed"
+    ]
+    assert len(failed_calls) == 1
+    props = failed_calls[0][0][1]
+    assert props["error_type"] == "RuntimeError"
+    assert props["phase"] == "uploading"


### PR DESCRIPTION
## Summary
- Add PostHog tracking for spec pull operations (started, completed, failed, cancelled)
- Add PostHog tracking for spec upload operations (started, completed, failed)
- Add PostHog tracking for authentication flow (started, completed, failed, cancelled)
- Add `PullSource` and `PullPhase` StrEnums for type-safe analytics
- Uses existing `UploadPhase` enum for upload tracking consistency

## Privacy Compliance (NO PII)
All events only track safe properties:
- ✅ `file_count`, `total_bytes`, `duration_seconds`
- ✅ `error_type` (class name only, not error message)
- ✅ `phase` (which phase of operation)
- ✅ `source` ("cli" or "tui")
- ✅ `had_backup` (boolean)
- ❌ No spec names, file paths, email addresses, IDs, or error messages

## Test plan
- [x] All 934 unit tests pass
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)
- [x] Added 6 new tests for PostHog tracking (3 for pull, 3 for upload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)