### PR TITLE
ci: parallelize docker build with slack notification

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -342,8 +342,8 @@ jobs:
 
   notify-slack:
     runs-on: ubuntu-latest
-    needs: [build-and-package, deploy-to-pypi, build-and-push-docker]
-    if: always() && needs.deploy-to-pypi.result == 'success' && needs.build-and-push-docker.result == 'success'
+    needs: [build-and-package, deploy-to-pypi]
+    if: always() && needs.deploy-to-pypi.result == 'success'
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Run Docker build and Slack notification in parallel after PyPI deploy completes
- Previously, Slack notification waited for Docker build to finish before sending
- This speeds up user notification about new releases since PyPI availability is what matters most

## Changes
- Removed `build-and-push-docker` from the `needs` array of `notify-slack` job
- Removed Docker build success check from the `if` condition

## Before
```
deploy-to-pypi → build-and-push-docker → notify-slack
```

## After
```
deploy-to-pypi → build-and-push-docker (parallel)
             └→ notify-slack (parallel)
```

## Test plan
- [ ] Verify workflow YAML syntax is valid
- [ ] Confirm job dependencies are correct in GitHub Actions visualization

🤖 Generated with [Claude Code](https://claude.com/claude-code)