### PR TITLE
fix: move inline import to module level in gemini web search

### DIFF
--- a/src/shotgun/agents/tools/web_search/gemini.py
+++ b/src/shotgun/agents/tools/web_search/gemini.py
@@ -1,7 +1,7 @@
 """Gemini web search tool implementation."""
 
 from opentelemetry import trace
-from pydantic_ai.messages import ModelMessage, ModelRequest
+from pydantic_ai.messages import ModelMessage, ModelRequest, TextPart
 from pydantic_ai.settings import ModelSettings
 
 from shotgun.agents.config import get_provider_model
@@ -82,8 +82,6 @@ async def gemini_web_search_tool(query: str) -> str:
         )
 
         # Extract text from response
-        from pydantic_ai.messages import TextPart
-
         result_text = "No content returned from search"
         if response.parts:
             for part in response.parts:


### PR DESCRIPTION
## Summary
- Move `TextPart` import from inside the function to module level imports in `gemini.py`
- Follows project convention of avoiding inline imports

## Test plan
- [x] Linting passes
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)