### PR TITLE
feat: index .shotgun folder in codebase indexing

### DIFF
--- a/src/shotgun/codebase/core/ingestor.py
+++ b/src/shotgun/codebase/core/ingestor.py
@@ -62,13 +62,20 @@ IGNORE_PATTERNS = BASE_IGNORE_DIRECTORIES | BUILD_ARTIFACT_DIRECTORIES
 # Directory prefixes that should always be ignored
 IGNORED_DIRECTORY_PREFIXES = (".",)
 
+# Directories starting with "." that should NOT be ignored (allowlist)
+# .shotgun/ contains user-generated artifacts that should be indexed
+ALLOWED_DOT_DIRECTORIES = {".shotgun"}
+
 
 def should_ignore_directory(name: str, ignore_patterns: set[str] | None = None) -> bool:
     """Return True if the directory name should be ignored."""
     patterns = IGNORE_PATTERNS if ignore_patterns is None else ignore_patterns
     if name in patterns:
         return True
-    return name.startswith(IGNORED_DIRECTORY_PREFIXES)
+    # Check if directory starts with ignored prefix but is in allowlist
+    if name.startswith(IGNORED_DIRECTORY_PREFIXES):
+        return name not in ALLOWED_DOT_DIRECTORIES
+    return False
 
 
 def is_path_ignored(path: Path, ignore_patterns: set[str] | None = None) -> bool:

--- a/test/unit/codebase/test_ingestor.py
+++ b/test/unit/codebase/test_ingestor.py
@@ -225,6 +225,9 @@ def test_path_should_be_ignored():
         ("src/main.py", False),
         ("test/test_file.py", False),
         (".venv/lib/python3.9/site-packages/pkg", True),
+        # .shotgun directory should NOT be ignored (allowlisted)
+        (".shotgun/research.md", False),
+        (".shotgun/spec.md", False),
     ]
 
     for path, should_ignore in test_cases:
@@ -233,10 +236,15 @@ def test_path_should_be_ignored():
 
 
 def test_should_ignore_directory_prefixes():
-    """Directories starting with dot should always be ignored."""
+    """Directories starting with dot should be ignored except allowlisted ones."""
+    # Regular dot directories should be ignored
     assert should_ignore_directory(".cache", IGNORE_PATTERNS)
     assert should_ignore_directory(".storybook", IGNORE_PATTERNS)
     assert should_ignore_directory(".git", IGNORE_PATTERNS)
+    assert should_ignore_directory(".venv", IGNORE_PATTERNS)
+
+    # .shotgun directory should NOT be ignored (allowlisted)
+    assert not should_ignore_directory(".shotgun", IGNORE_PATTERNS)
 
 
 @patch("shotgun.codebase.core.ingestor.os.walk")


### PR DESCRIPTION
## Summary

- Add `.shotgun` to the allowlist of dot-prefixed directories that should be indexed
- The `.shotgun/` folder contains user-generated artifacts (research notes, specifications, plans) that should be searchable via the codebase index

## Changes

- Add `ALLOWED_DOT_DIRECTORIES` set with ".shotgun" in `ingestor.py`
- Update `should_ignore_directory()` to check allowlist before ignoring directories starting with "."
- Add tests for `.shotgun` directory and path handling

## Test plan

- [x] `test_should_ignore_directory_prefixes` - verifies `.shotgun` is NOT ignored while other dot directories are
- [x] `test_path_should_be_ignored` - verifies paths like `.shotgun/research.md` are NOT ignored
- [x] All linting and type checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)