### PR TITLE
fix: prevent tasks agent from referencing nonexistent contract files

### DIFF
--- a/src/shotgun/prompts/agents/specify.j2
+++ b/src/shotgun/prompts/agents/specify.j2
@@ -50,6 +50,8 @@ specification.md is your prose documentation file. It should contain:
 - Configuration requirements described (e.g., "App needs database URL and API key in environment")
 - Testing strategies and acceptance criteria
 - References to contract files (e.g., "See contracts/user_models.py for User type definition")
+  - **IMPORTANT**: Only reference contract files that you have ALREADY created using `write_file()`
+  - Never reference contract files that don't exist - create them first, then reference them
 
 **DO NOT INCLUDE in specification.md:**
 - Code blocks, type definitions, or function signatures (those go in contracts/)
@@ -355,8 +357,9 @@ For specification tasks:
 2. **Check research**: Read `research.md` if it exists to understand technical context and findings
 3. **Analyze requirements**: Understand the functional and non-functional requirements
 4. **Define specifications**: Create detailed technical and functional specifications
-5. **Write TLDR section**: Start specification.md with a TLDR section summarizing key points, major features, and any key concerns
-6. **Structure documentation**: Use `write_file("specification.md", content)` to save comprehensive specifications
+5. **Create contract files FIRST**: If your spec will reference contract files, create them with `write_file("contracts/filename.ext", content)` BEFORE writing specification.md
+6. **Write TLDR section**: Start specification.md with a TLDR section summarizing key points, major features, and any key concerns
+7. **Structure documentation**: Use `write_file("specification.md", content)` to save comprehensive specifications - only reference contract files you've already created
 
 ## SPECIFICATION PRINCIPLES
 

--- a/src/shotgun/prompts/agents/tasks.j2
+++ b/src/shotgun/prompts/agents/tasks.j2
@@ -56,9 +56,10 @@ Example task format:
 For task management:
 1. **Load existing tasks**: ALWAYS first use `read_file("tasks.md")` to see what tasks already exist (if the file exists)
 2. **Review context**: Read `plan.md` and `specification.md` if they exist to understand project context
-3. **Analyze requirements**: Understand the current situation and user's task requirements
-4. **Create structured tasks**: Use `write_file("tasks.md", content)` to save organized tasks
-5. **Build incrementally**: Update and refine tasks based on new information
+3. **Verify paths exist**: Check the "Available Files" list in your System Status to see what files exist in `.shotgun/`. If a path doesn't exist, tasks must CREATE it, not modify files within it.
+4. **Analyze requirements**: Understand the current situation and user's task requirements
+5. **Create structured tasks**: Use `write_file("tasks.md", content)` to save organized tasks
+6. **Build incrementally**: Update and refine tasks based on new information
 
 ## TASK FORMAT
 
@@ -147,6 +148,14 @@ INTEGRATION WITH RESEARCH & PLAN:
 - Include tasks for addressing challenges identified in plan
 - Create validation/testing tasks for success criteria from plan
 - Break down high-level plan steps into granular, executable tasks
+
+PATH VERIFICATION (CRITICAL):
+- Before generating tasks that reference specific file paths in `.shotgun/`, check the "Available Files" list in your System Status
+- If specification.md references files under `.shotgun/contracts/` that don't appear in "Available Files", DO NOT generate tasks for those files
+  - The Specification agent is responsible for creating contract files, not downstream coding agents
+  - Tasks should reference files that EXIST or will be created in the project codebase (src/, tests/, etc.), not in `.shotgun/`
+- Only generate tasks for `.shotgun/` files if they appear in the "Available Files" list and the task is about modifying them
+- Do NOT generate tasks referencing `.shotgun/contracts/*` files unless those files already exist
 
 IMPORTANT RULES:
 - Make at most 1 tasks file write per request


### PR DESCRIPTION
## Summary

- Fixes issue where tasks.md references `.shotgun/contracts/*` files that don't exist
- Root cause: specification.md mentions contracts as planned locations, tasks agent generates tasks for them
- Tasks agent now checks "Available Files" before referencing `.shotgun/` paths
- Specification agent now must create contract files before referencing them

## Test plan

- [ ] Verify linting passes (`uv run ruff check .`)
- [ ] Verify type checking passes (`uv run mypy src/`)
- [ ] Manual test: Run tasks agent with a spec that references non-existent contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)