### PR TITLE
feat: add evals package skeleton with model re-exports

### DIFF
--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,0 +1,1 @@
+"""Evaluation framework for Shotgun Pydantic-AI agents."""

--- a/evals/datasets/__init__.py
+++ b/evals/datasets/__init__.py
@@ -1,0 +1,1 @@
+"""Dataset loaders and case definitions."""

--- a/evals/evaluators/__init__.py
+++ b/evals/evaluators/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic and LLM-judge evaluators."""

--- a/evals/experiments/__init__.py
+++ b/evals/experiments/__init__.py
@@ -1,0 +1,1 @@
+"""Experiment configurations and runners."""

--- a/evals/fixtures/__init__.py
+++ b/evals/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Static fixtures and environment loaders."""

--- a/evals/models/__init__.py
+++ b/evals/models/__init__.py
@@ -1,0 +1,76 @@
+"""Re-exports all evaluation models from .shotgun/contracts/.
+
+This module provides a clean import path for all eval-related Pydantic models:
+    from evals.models import QACase, AgentToolCase, MetricName, CaseEvalResult
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add .shotgun/contracts to the Python path so we can import from it
+_contracts_path = Path(__file__).parent.parent.parent / ".shotgun" / "contracts"
+if str(_contracts_path) not in sys.path:
+    sys.path.insert(0, str(_contracts_path))
+
+# ruff: noqa: E402
+# Imports must come after sys.path manipulation
+from eval_cases import (  # noqa: E402
+    AgentToolCase,
+    AgentToolCaseMetadata,
+    ClarifyingQuestionPolicy,
+    Difficulty,
+    FileChangeExpectation,
+    QACase,
+    QACaseMetadata,
+    QADomain,
+    QAExpectation,
+    ScenarioType,
+    SourceType,
+    ToolUsageExpectation,
+)
+from eval_judge_outputs import (  # noqa: E402
+    FileChangeJudgeOutput,
+    FileChangeJudgeScores,
+    QAJudgeOutput,
+    QAJudgeScores,
+    ScoreScale,
+    ToolUseJudgeOutput,
+    ToolUseJudgeScores,
+)
+from eval_metrics import (  # noqa: E402
+    CaseEvalResult,
+    MetricName,
+    MetricValue,
+)
+
+__all__ = [
+    # Enums from eval_cases
+    "Difficulty",
+    "QADomain",
+    "ScenarioType",
+    "SourceType",
+    "ClarifyingQuestionPolicy",
+    # Q&A case models
+    "QAExpectation",
+    "QACaseMetadata",
+    "QACase",
+    # Agent/tool case models
+    "FileChangeExpectation",
+    "ToolUsageExpectation",
+    "AgentToolCaseMetadata",
+    "AgentToolCase",
+    # Metrics
+    "MetricName",
+    "MetricValue",
+    "CaseEvalResult",
+    # Judge outputs
+    "ScoreScale",
+    "QAJudgeScores",
+    "QAJudgeOutput",
+    "ToolUseJudgeScores",
+    "ToolUseJudgeOutput",
+    "FileChangeJudgeScores",
+    "FileChangeJudgeOutput",
+]

--- a/evals/reporting/__init__.py
+++ b/evals/reporting/__init__.py
@@ -1,0 +1,1 @@
+"""Metrics aggregation and result reporting."""

--- a/test/unit/evals/__init__.py
+++ b/test/unit/evals/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the evals package."""

--- a/test/unit/evals/conftest.py
+++ b/test/unit/evals/conftest.py
@@ -1,0 +1,12 @@
+"""Test configuration for evals package tests.
+
+Adds the evals package to sys.path since it's not part of the installed package.
+"""
+
+import sys
+from pathlib import Path
+
+# Add the repo root to sys.path so 'evals' package can be imported
+repo_root = Path(__file__).parent.parent.parent.parent
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))

--- a/test/unit/evals/test_models.py
+++ b/test/unit/evals/test_models.py
@@ -1,0 +1,164 @@
+"""Tests verifying that evals.models re-exports work correctly."""
+
+from __future__ import annotations
+
+
+def test_import_qa_case() -> None:
+    """Verify QACase can be imported from evals.models."""
+    from evals.models import QACase
+
+    assert QACase is not None
+
+
+def test_import_agent_tool_case() -> None:
+    """Verify AgentToolCase can be imported from evals.models."""
+    from evals.models import AgentToolCase
+
+    assert AgentToolCase is not None
+
+
+def test_import_metric_name() -> None:
+    """Verify MetricName can be imported from evals.models."""
+    from evals.models import MetricName
+
+    assert MetricName is not None
+
+
+def test_import_case_eval_result() -> None:
+    """Verify CaseEvalResult can be imported from evals.models."""
+    from evals.models import CaseEvalResult
+
+    assert CaseEvalResult is not None
+
+
+def test_import_all_enums() -> None:
+    """Verify all enum types can be imported from evals.models."""
+    from evals.models import (
+        ClarifyingQuestionPolicy,
+        Difficulty,
+        QADomain,
+        ScenarioType,
+        SourceType,
+    )
+
+    assert Difficulty.EASY == "easy"
+    assert QADomain.CODE == "code"
+    assert ScenarioType.BUGFIX == "bugfix"
+    assert SourceType.HAND_AUTHORED == "hand_authored"
+    assert ClarifyingQuestionPolicy.MUST_ASK == "must_ask"
+
+
+def test_import_all_case_models() -> None:
+    """Verify all case-related models can be imported from evals.models."""
+    from evals.models import (
+        AgentToolCase,
+        AgentToolCaseMetadata,
+        FileChangeExpectation,
+        QACase,
+        QACaseMetadata,
+        QAExpectation,
+        ToolUsageExpectation,
+    )
+
+    assert QAExpectation is not None
+    assert QACaseMetadata is not None
+    assert QACase is not None
+    assert FileChangeExpectation is not None
+    assert ToolUsageExpectation is not None
+    assert AgentToolCaseMetadata is not None
+    assert AgentToolCase is not None
+
+
+def test_import_all_metric_models() -> None:
+    """Verify all metric-related models can be imported from evals.models."""
+    from evals.models import CaseEvalResult, MetricName, MetricValue
+
+    assert MetricName is not None
+    assert MetricValue is not None
+    assert CaseEvalResult is not None
+
+
+def test_import_all_judge_outputs() -> None:
+    """Verify all judge output models can be imported from evals.models."""
+    from evals.models import (
+        FileChangeJudgeOutput,
+        FileChangeJudgeScores,
+        QAJudgeOutput,
+        QAJudgeScores,
+        ScoreScale,
+        ToolUseJudgeOutput,
+        ToolUseJudgeScores,
+    )
+
+    assert ScoreScale is not None
+    assert QAJudgeScores is not None
+    assert QAJudgeOutput is not None
+    assert ToolUseJudgeScores is not None
+    assert ToolUseJudgeOutput is not None
+    assert FileChangeJudgeScores is not None
+    assert FileChangeJudgeOutput is not None
+
+
+def test_qa_case_instantiation() -> None:
+    """Verify QACase can be instantiated with valid data."""
+    from evals.models import QACase, QAExpectation
+
+    case = QACase(
+        case_id="test-001",
+        question="Which agent edits plan.md?",
+        expectation=QAExpectation(
+            reference_answer="The Plan agent edits plan.md.",
+        ),
+    )
+    assert case.case_id == "test-001"
+    assert case.question == "Which agent edits plan.md?"
+
+
+def test_agent_tool_case_instantiation() -> None:
+    """Verify AgentToolCase can be instantiated with valid data."""
+    from evals.models import AgentToolCase, FileChangeExpectation
+
+    case = AgentToolCase(
+        case_id="agent-001",
+        task_description="Add a new section to specification.md",
+        environment_id="shotgun_mvp",
+        file_change_expectations=[
+            FileChangeExpectation(
+                path=".shotgun/specification.md",
+                must_change=True,
+            )
+        ],
+    )
+    assert case.case_id == "agent-001"
+    assert case.environment_id == "shotgun_mvp"
+
+
+def test_metric_value_instantiation() -> None:
+    """Verify MetricValue can be instantiated with valid data."""
+    from evals.models import MetricName, MetricValue
+
+    metric = MetricValue(
+        name=MetricName.QA_ACCURACY,
+        numeric_value=0.95,
+        boolean_value=True,
+    )
+    assert metric.name == MetricName.QA_ACCURACY
+    assert metric.numeric_value == 0.95
+
+
+def test_case_eval_result_instantiation() -> None:
+    """Verify CaseEvalResult can be instantiated with valid data."""
+    from evals.models import CaseEvalResult, MetricName, MetricValue
+
+    result = CaseEvalResult(
+        case_id="test-001",
+        dataset_id="core_qa",
+        metrics={
+            MetricName.QA_ACCURACY: MetricValue(
+                name=MetricName.QA_ACCURACY,
+                numeric_value=1.0,
+            )
+        },
+    )
+    assert result.case_id == "test-001"
+    assert MetricName.QA_ACCURACY in result.metrics


### PR DESCRIPTION
## Summary
- Create `evals/` package at repo root with subpackage stubs (datasets, evaluators, fixtures, experiments, reporting)
- Add `models/` module that re-exports all contract types from `.shotgun/contracts/`
- Add test suite with 12 tests verifying all imports work correctly

This is Stage 1 of the eval system implementation as defined in `.shotgun/tasks.md`.

## Test plan
- [x] All 12 import tests pass
- [x] `python -c "from evals.models import QACase, AgentToolCase, MetricName, CaseEvalResult"` works
- [x] Linting passes (`ruff check evals/ test/unit/evals/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)