### PR TITLE
chore: migrate from kuzu to real_ladybug (LadybugDB)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "textual>=6.1.0",
     "textual-dev>=1.7.0",
     "textual-serve>=0.1.0",
-    "kuzu>=0.7.0",
+    "real_ladybug>=0.12.0",
     "tree-sitter>=0.21.0",
     "tree-sitter-python>=0.23.0",
     "tree-sitter-javascript>=0.23.0",
@@ -171,4 +171,4 @@ skip_covered = false
 show_missing = true
 
 [tool.uv.pip]
-only-binary = ["kuzu"]
+only-binary = ["real_ladybug"]

--- a/src/shotgun/codebase/core/change_detector.py
+++ b/src/shotgun/codebase/core/change_detector.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import aiofiles
-import kuzu
+import real_ladybug as kuzu
 
 from shotgun.logging_config import get_logger
 

--- a/src/shotgun/codebase/core/ingestor.py
+++ b/src/shotgun/codebase/core/ingestor.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 import aiofiles
-import kuzu
+import real_ladybug as kuzu
 from tree_sitter import Node, Parser, QueryCursor
 
 from shotgun.codebase.core.language_config import LANGUAGE_CONFIGS, get_language_config

--- a/src/shotgun/codebase/core/manager.py
+++ b/src/shotgun/codebase/core/manager.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 import anyio
-import kuzu
+import real_ladybug as kuzu
 from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
 

--- a/test/unit/codebase/test_ladybug_compatibility.py
+++ b/test/unit/codebase/test_ladybug_compatibility.py
@@ -1,0 +1,269 @@
+"""Integration tests for LadybugDB (real_ladybug) compatibility.
+
+These tests verify that the migration from Kuzu to LadybugDB works correctly
+by testing all database operations used in the codebase.
+
+Note: These tests don't use @pytest.mark.integration because they don't require
+LLM configuration - they're pure database tests.
+"""
+
+from pathlib import Path
+
+import real_ladybug as kuzu
+
+
+def test_database_creation(tmp_path: Path):
+    """Test creating a LadybugDB database."""
+    db_path = tmp_path / "test.db"
+    db = kuzu.Database(str(db_path))
+    assert db is not None
+    db.close()
+
+
+def test_connection_creation(tmp_path: Path):
+    """Test creating a connection to a LadybugDB database."""
+    db_path = tmp_path / "test.db"
+    db = kuzu.Database(str(db_path))
+    conn = kuzu.Connection(db)
+    assert conn is not None
+    conn.close()
+    db.close()
+
+
+def test_schema_creation(tmp_path: Path):
+    """Test creating node and relationship tables matching our schema."""
+    db_path = tmp_path / "test.db"
+    db = kuzu.Database(str(db_path))
+    conn = kuzu.Connection(db)
+
+    # Create node tables matching our actual schema
+    conn.execute(
+        "CREATE NODE TABLE Project("
+        "name STRING PRIMARY KEY, "
+        "repo_path STRING, "
+        "graph_id STRING, "
+        "created_at INT64, "
+        "updated_at INT64"
+        ")"
+    )
+    conn.execute(
+        "CREATE NODE TABLE File(path STRING PRIMARY KEY, name STRING, extension STRING)"
+    )
+    conn.execute(
+        "CREATE NODE TABLE Module("
+        "qualified_name STRING PRIMARY KEY, "
+        "name STRING, "
+        "path STRING"
+        ")"
+    )
+    conn.execute(
+        "CREATE NODE TABLE Function("
+        "qualified_name STRING PRIMARY KEY, "
+        "name STRING, "
+        "docstring STRING"
+        ")"
+    )
+
+    # Create relationship tables
+    conn.execute("CREATE REL TABLE CONTAINS_FILE(FROM Project TO File)")
+    conn.execute("CREATE REL TABLE DEFINES_FUNC(FROM Module TO Function)")
+
+    conn.close()
+    db.close()
+
+
+def test_node_insertion_with_merge(tmp_path: Path):
+    """Test inserting nodes using MERGE (upsert behavior)."""
+    db_path = tmp_path / "test.db"
+    db = kuzu.Database(str(db_path))
+    conn = kuzu.Connection(db)
+
+    # Create table
+    conn.execute(
+        "CREATE NODE TABLE TestNode(id STRING PRIMARY KEY, name STRING, value INT64)"
+    )
+
+    # Insert using MERGE (our actual pattern)
+    conn.execute(
+        "MERGE (n:TestNode {id: $id}) SET n.name = $name, n.value = $value",
+        {"id": "test1", "name": "Test Node 1", "value": 42},
+    )
+
+    # Verify insertion
+    result = conn.execute("MATCH (n:TestNode) RETURN n.id, n.name, n.value")
+    rows = list(result)
+    assert len(rows) == 1
+    assert rows[0][0] == "test1"
+    assert rows[0][1] == "Test Node 1"
+    assert rows[0][2] == 42
+
+    # Test upsert behavior - same ID should update
+    conn.execute(
+        "MERGE (n:TestNode {id: $id}) SET n.name = $name, n.value = $value",
+        {"id": "test1", "name": "Updated Name", "value": 100},
+    )
+
+    result = conn.execute("MATCH (n:TestNode) RETURN n.id, n.name, n.value")
+    rows = list(result)
+    assert len(rows) == 1
+    assert rows[0][1] == "Updated Name"
+    assert rows[0][2] == 100
+
+    conn.close()
+    db.close()
+
+
+def test_relationship_creation(tmp_path: Path):
+    """Test creating relationships between nodes."""
+    db_path = tmp_path / "test.db"
+    db = kuzu.Database(str(db_path))
+    conn = kuzu.Connection(db)
+
+    # Create tables
+    conn.execute("CREATE NODE TABLE Author(name STRING PRIMARY KEY)")
+    conn.execute("CREATE NODE TABLE Book(title STRING PRIMARY KEY)")
+    conn.execute("CREATE REL TABLE WROTE(FROM Author TO Book)")
+
+    # Insert nodes
+    conn.execute("CREATE (a:Author {name: $name})", {"name": "Alice"})
+    conn.execute("CREATE (b:Book {title: $title})", {"title": "Wonderland"})
+
+    # Create relationship (our actual pattern)
+    conn.execute(
+        "MATCH (a:Author {name: $author}), (b:Book {title: $book}) "
+        "MERGE (a)-[:WROTE]->(b)",
+        {"author": "Alice", "book": "Wonderland"},
+    )
+
+    # Verify relationship
+    result = conn.execute("MATCH (a:Author)-[:WROTE]->(b:Book) RETURN a.name, b.title")
+    rows = list(result)
+    assert len(rows) == 1
+    assert rows[0][0] == "Alice"
+    assert rows[0][1] == "Wonderland"
+
+    conn.close()
+    db.close()
+
+
+def test_query_with_count(tmp_path: Path):
+    """Test queries with COUNT aggregation."""
+    db_path = tmp_path / "test.db"
+    db = kuzu.Database(str(db_path))
+    conn = kuzu.Connection(db)
+
+    conn.execute("CREATE NODE TABLE Item(id STRING PRIMARY KEY, type STRING)")
+
+    # Insert multiple items
+    for i in range(5):
+        conn.execute(
+            "CREATE (n:Item {id: $id, type: $type})",
+            {"id": f"item{i}", "type": "A" if i % 2 == 0 else "B"},
+        )
+
+    # Count all
+    result = conn.execute("MATCH (n:Item) RETURN COUNT(n) as count")
+    rows = list(result)
+    assert rows[0][0] == 5
+
+    # Count by type
+    result = conn.execute(
+        "MATCH (n:Item) WHERE n.type = $type RETURN COUNT(n) as count",
+        {"type": "A"},
+    )
+    rows = list(result)
+    assert rows[0][0] == 3
+
+    conn.close()
+    db.close()
+
+
+def test_detach_delete(tmp_path: Path):
+    """Test DETACH DELETE for node removal with relationships."""
+    db_path = tmp_path / "test.db"
+    db = kuzu.Database(str(db_path))
+    conn = kuzu.Connection(db)
+
+    # Create tables
+    conn.execute("CREATE NODE TABLE Parent(name STRING PRIMARY KEY)")
+    conn.execute("CREATE NODE TABLE Child(name STRING PRIMARY KEY)")
+    conn.execute("CREATE REL TABLE HAS_CHILD(FROM Parent TO Child)")
+
+    # Insert nodes and relationships
+    conn.execute("CREATE (p:Parent {name: 'Parent1'})")
+    conn.execute("CREATE (c:Child {name: 'Child1'})")
+    conn.execute(
+        "MATCH (p:Parent {name: 'Parent1'}), (c:Child {name: 'Child1'}) "
+        "CREATE (p)-[:HAS_CHILD]->(c)"
+    )
+
+    # Verify relationship exists
+    result = conn.execute("MATCH (p:Parent)-[:HAS_CHILD]->(c:Child) RETURN COUNT(*)")
+    assert list(result)[0][0] == 1
+
+    # DETACH DELETE the child (removes node and all connected relationships)
+    conn.execute("MATCH (c:Child {name: 'Child1'}) DETACH DELETE c")
+
+    # Verify child is gone
+    result = conn.execute("MATCH (c:Child) RETURN COUNT(*)")
+    assert list(result)[0][0] == 0
+
+    # Verify relationship is gone
+    result = conn.execute("MATCH (p:Parent)-[:HAS_CHILD]->(c:Child) RETURN COUNT(*)")
+    assert list(result)[0][0] == 0
+
+    conn.close()
+    db.close()
+
+
+def test_multiple_connections(tmp_path: Path):
+    """Test that multiple connections to the same database work."""
+    db_path = tmp_path / "test.db"
+    db = kuzu.Database(str(db_path))
+
+    # Create multiple connections
+    conn1 = kuzu.Connection(db)
+    conn2 = kuzu.Connection(db)
+
+    # Create table with first connection
+    conn1.execute("CREATE NODE TABLE SharedTable(id STRING PRIMARY KEY)")
+    conn1.execute("CREATE (n:SharedTable {id: 'from_conn1'})")
+
+    # Query with second connection
+    result = conn2.execute("MATCH (n:SharedTable) RETURN n.id")
+    rows = list(result)
+    assert len(rows) == 1
+    assert rows[0][0] == "from_conn1"
+
+    conn1.close()
+    conn2.close()
+    db.close()
+
+
+def test_result_iteration(tmp_path: Path):
+    """Test iterating over query results (our actual pattern)."""
+    db_path = tmp_path / "test.db"
+    db = kuzu.Database(str(db_path))
+    conn = kuzu.Connection(db)
+
+    conn.execute("CREATE NODE TABLE Data(id INT64 PRIMARY KEY, value STRING)")
+
+    for i in range(10):
+        conn.execute(
+            "CREATE (n:Data {id: $id, value: $value})",
+            {"id": i, "value": f"value_{i}"},
+        )
+
+    result = conn.execute("MATCH (n:Data) RETURN n.id, n.value ORDER BY n.id")
+
+    # Iterate like we do in manager.py
+    collected = []
+    for row in result:
+        collected.append({"id": row[0], "value": row[1]})
+
+    assert len(collected) == 10
+    assert collected[0] == {"id": 0, "value": "value_0"}
+    assert collected[9] == {"id": 9, "value": "value_9"}
+
+    conn.close()
+    db.close()

--- a/uv.lock
+++ b/uv.lock
@@ -1272,35 +1272,6 @@ wheels = [
 ]
 
 [[package]]
-name = "kuzu"
-version = "0.11.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/0c/f141a81485729a072dc527b474e7580d5632309c68ad1a5aa6ed9ac45387/kuzu-0.11.3.tar.gz", hash = "sha256:e7bea3ca30c4bb462792eedcaa7f2125c800b243bb4a872e1eedc16917c1967a", size = 19430620, upload-time = "2025-10-10T13:36:54.984Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/1b/65d3974551f10d100ca4682b1e4beff23a9c5b7555c6ea552a3855555cc0/kuzu-0.11.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:836739dced9f61912a80bb7ad1df2159cef456c5b5cfe92f15394b9c51a785cb", size = 4094223, upload-time = "2025-10-10T13:35:56.023Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/e8/0efbc4812796468ca47273fc53c21c63706bc5f7bc4fa3459918d323ced8/kuzu-0.11.3-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:8d4f0e4085d3a85b0e7a8e337082bec6a3cf8c92c9a35209ffe53b2ed212ab08", size = 4519024, upload-time = "2025-10-10T13:35:57.665Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/b2/07e81d9f1858a592d1ddc1f02a483718cdfac3315bbca019b13b2ddd8c3e/kuzu-0.11.3-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1419ada227d15107c2b2536c66ae715c59876585d434b1918c17598956dcd5f7", size = 6796096, upload-time = "2025-10-10T13:35:59.174Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/e0/8ea0d289ef6840fbd00e642657ed07d03690a97a01676e2b79d5c3e9ddf8/kuzu-0.11.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef094001d319804fcc8eb72775a184f1119d84af1bace29581a003bd806c36cd", size = 7616892, upload-time = "2025-10-10T13:36:00.866Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/d6/9ea65a74c9140e13d7f68dd9d8f95f42b55b9d7750e7a20df3d9b2f09734/kuzu-0.11.3-cp311-cp311-win_amd64.whl", hash = "sha256:eb0858ec8084b10badeae37e730fbe0c3b2846dfe3508001d123087de262efbb", size = 4712696, upload-time = "2025-10-10T13:36:02.607Z" },
-    { url = "https://files.pythonhosted.org/packages/64/88/ed193fd0ddfdbdde6c79e96b96df3b760fe48b2626e7151d81a1ed90fd9f/kuzu-0.11.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d865ca31506867cf1ccf50c094c44de96de94bc77ffb350bfcaca0e4c5e469da", size = 4093637, upload-time = "2025-10-10T13:36:04.206Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/6d/06e02828b78297d6d99ff3dfb0ab7b5ec5d075053aae33b53189437bbb66/kuzu-0.11.3-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:109372bc16ce6724f88e0312bc686e34145e330d69b163b22ba92f4d3d96b48f", size = 4520482, upload-time = "2025-10-10T13:36:06.302Z" },
-    { url = "https://files.pythonhosted.org/packages/72/d5/0939a953860a8b373bef7b8a66a4571b27ff9faeb22672d2cd2cf3b6ba15/kuzu-0.11.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d6274da6c470c001b7d332ec78a076395b009c2f267914640884fd6fa78bf47d", size = 6795398, upload-time = "2025-10-10T13:36:08Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/5d/8e3dfb89aa3f70f63aa283c523f2dd2ac90a1b3ed990643e3a89909236f9/kuzu-0.11.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1bb3b833ca2d1d919423cb3e0150592c2587562ab85259277f622e6f06e0b487", size = 7615389, upload-time = "2025-10-10T13:36:09.809Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/19/c8e93185d6142f01b2e6daec4ad537dfd32afd1f69894889769b725b08c1/kuzu-0.11.3-cp312-cp312-win_amd64.whl", hash = "sha256:605909f744763775b8647014a03526d7f928a7b5a62a8b8c1d1e7bbdaf9dbb6c", size = 4714355, upload-time = "2025-10-10T13:36:11.527Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/e4/2c0e222a9b0605745234fec2774a25dd2e472699931f683f15d28ab8c076/kuzu-0.11.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e20ab3e3b20ccf75219872feb86582f959e313eeb59f51131adf4c91ebfabe30", size = 4093664, upload-time = "2025-10-10T13:36:13.116Z" },
-    { url = "https://files.pythonhosted.org/packages/88/05/3020ed9a0a7b492597f211f805233b77ef37266a23c27efc40bb7cb37402/kuzu-0.11.3-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:054479d3ce71410b8af2f5fa6aa37883db7fea5b25606af8d3bd7cf717aa5395", size = 4520498, upload-time = "2025-10-10T13:36:14.933Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/66/1a502700a7f2863f8f60621a412a7074d7eda9e92f18fd1d8d86905aa4d3/kuzu-0.11.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:143a37f1ae38b6b4337ccfcf42fa4f779a897223fff9c6c29f1a5a5a86911300", size = 6795804, upload-time = "2025-10-10T13:36:16.55Z" },
-    { url = "https://files.pythonhosted.org/packages/79/c2/1ea8cdc05946cb5906a7ebb451d7268e501ebb51ebecc0437969f8c07450/kuzu-0.11.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:548bfb3045d89bce1fbe89f4a890d636789671abfa80cbde2054c671e6069133", size = 7615668, upload-time = "2025-10-10T13:36:18.882Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/c3/336d6181f8f50126cf3d7186b3c5479f9f49d973145f79bed45cf87a9bb7/kuzu-0.11.3-cp313-cp313-win_amd64.whl", hash = "sha256:87bf6c369f182a59e5b8a38b3ca288b90fab2827577d9b0d2170a202c42bc8f5", size = 4714372, upload-time = "2025-10-10T13:36:20.877Z" },
-    { url = "https://files.pythonhosted.org/packages/94/db/e7e6cada6dc924eb8939bd35c5f724f5de4fc430a64d6d9e71b75cd0c271/kuzu-0.11.3-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb5c165bc5838059e498e8325939fc6bac075e1941157e8df6ebdd710135d43b", size = 6798556, upload-time = "2025-10-10T13:36:22.472Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/68/a0fa02134cb255c80b5ed5bb5f6130fbbc75a8ae8be4fd6ea6eb6bc8014b/kuzu-0.11.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:88c73dfd3d6a1fb374031050b725236fa9dd9a95424b09b20086a3d274bed51f", size = 7620378, upload-time = "2025-10-10T13:36:24.453Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/b7/2a4569984995f09476dbf1ef2e0a7298aa9fdb8896f2e8195d80e11786f4/kuzu-0.11.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9d2752a9e37adda6aef3bf041932ae3a1cf74ca7e893bbbacdd5e62b3ac6f8c2", size = 6795649, upload-time = "2025-10-10T13:36:26.15Z" },
-    { url = "https://files.pythonhosted.org/packages/77/13/df6e06a7d7506743c3a6cfbe50ee3f9d3fc58228e2a2fcbe7e74e7c17b00/kuzu-0.11.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86be7d113e4e2c6761b1701079af8aeffc04c6981517f2d6aa393e883cc46036", size = 7615882, upload-time = "2025-10-10T13:36:28.215Z" },
-    { url = "https://files.pythonhosted.org/packages/32/85/c52c3b167edcc67da3b8788a20a2fb5b4f045060cbe1aed6121ce3ce83d3/kuzu-0.11.3-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d72ebd88e231b562e7a60ff88d200825d53e78a681bddd7f8d77b78126a5060c", size = 6798657, upload-time = "2025-10-10T13:36:29.935Z" },
-    { url = "https://files.pythonhosted.org/packages/06/be/5b4ff168718165c2ff5848ab79e22ecce72ad00522afee6820d390cb0753/kuzu-0.11.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64c7ec822906bdee154eb38d93e64f184d8f94b30bbeaceaa252725f2b9efab3", size = 7620394, upload-time = "2025-10-10T13:36:31.69Z" },
-]
-
-[[package]]
 name = "lefthook"
 version = "2.0.8"
 source = { registry = "https://pypi.org/simple" }
@@ -2515,6 +2486,32 @@ wheels = [
 ]
 
 [[package]]
+name = "real-ladybug"
+version = "0.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/c4/0a622b302b694ccf6a5176f7ab5b509ad2b0e461d43ea104f43ff32c4fd3/real_ladybug-0.12.2.tar.gz", hash = "sha256:60663417d6657c77514707e8078ce041393646f73c9f6e258105561b0a4fcda3", size = 9924895, upload-time = "2025-11-14T21:44:11.818Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/83/1e8b19a774156074178af1ad2b54ffd94bd507992bf1a5501e211f285694/real_ladybug-0.12.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f5480ed1088c4d43dde51c9c3ba578222f027a78e766887ad66e1babc991f93", size = 3780749, upload-time = "2025-11-14T21:43:35.773Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/77/4fe04f3d475235168328aba117452550059386822b268739af79f3cf65ea/real_ladybug-0.12.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c60a17f74f3ef329848cf0194a763aea7e2156ac3ee5c27366dedf03f77b814c", size = 6332080, upload-time = "2025-11-14T21:43:37.953Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f9/02212dc3baaafab21ae3fdb3ac8365a5978929b35b17cf3c938319b68f16/real_ladybug-0.12.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8cb97181bc29e8f4bd823ac1d1731aa344668e14e34e9ebb6e6f16e685726ba6", size = 7128196, upload-time = "2025-11-14T21:43:40.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/11/c04e8abfe6fb31e42822f6754596bcb5a3d43df6b3a1babe6c445364f5d1/real_ladybug-0.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6a20142ce42b6e4b8b76403032929bb1f7bd11ec4bcc406bfa2c844f76745551", size = 7537404, upload-time = "2025-11-14T21:43:42.132Z" },
+    { url = "https://files.pythonhosted.org/packages/45/39/df0e98abd74abd527d879f6d6da49c066e2edb883370ae3c2d6b8d6efa4d/real_ladybug-0.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:50a67899250f3f468923b4622a9cc36d7617cbf38961b30b1a980d8ec583a689", size = 8231567, upload-time = "2025-11-14T21:43:44.823Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5b/e0b3c2a8ccef3629ee6f6659b74663987a335e75bc0ed194dd421ab60ce5/real_ladybug-0.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:12713ab6775fc43d6a13ebeb21e8254bd171592dc862304cb10f4c61f2b8956e", size = 4783241, upload-time = "2025-11-14T21:43:46.469Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/79/502f43b19fe548492c789c6d9e131ba057149b67f6bf37a4230f1dbbde1e/real_ladybug-0.12.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:397031926188330b03495c052b818ad8a9c6346749e0ed775f349d721207d2d5", size = 3780312, upload-time = "2025-11-14T21:43:48.124Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/69/8be38832042e77efa51ad6462e446ac44dc7cf0334524f3fc13bfdabf036/real_ladybug-0.12.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f14686a9a456a00e371e951226d3d4b6ec8076c56a534e933dea12ecebea230a", size = 6331319, upload-time = "2025-11-14T21:43:49.882Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ff/3b20ff92c752824f14507964190441d07a114eae2c2e3bbf2063fabd9fc1/real_ladybug-0.12.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd979aed1aa6e52c1c792a77bf83509910e6697d892ba517310831f0f1209bf7", size = 7127875, upload-time = "2025-11-14T21:43:51.705Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/43/359b33e45b5d4961cd3b3f5f18d0719750254c2a44f25ceaf39710aeb7b2/real_ladybug-0.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a1cf447e3130b7d33a34e3ead4846a6fed8a2e24c67cdbc648fc23aed4ea7807", size = 7536566, upload-time = "2025-11-14T21:43:53.734Z" },
+    { url = "https://files.pythonhosted.org/packages/22/51/218e54829960083e72b5554b2ca0bc195598ceb5c76ff7a2cdc99386bd84/real_ladybug-0.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d54e02b3a1ddd6ba72c8cc37f7cef24055f1d9f51d0f634d36c1954f5e7d4ef7", size = 8229219, upload-time = "2025-11-14T21:43:56.015Z" },
+    { url = "https://files.pythonhosted.org/packages/02/14/5a65851b1b10040e8bd8cd11415a5c0f0af53b461534e974616a6363b83c/real_ladybug-0.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:7804cb641fcc8da91ad49df61cba37fb16cbe47da660de72175306ee88d116c7", size = 4783955, upload-time = "2025-11-14T21:43:58.084Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/55/286759524d431ed8440e7de7e139b66cd10be9ccd78fe3fef7b7f0732ac8/real_ladybug-0.12.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d53ba5d0d86d4a070222b321693828a49fa78174ed5f4decf5b999dfadf66863", size = 3780396, upload-time = "2025-11-14T21:43:59.773Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7c/c4c916725656b3f6029e8d218cec78a2cad3c150c0a7bbe15b6fc65f6459/real_ladybug-0.12.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:861b423e092af2b1b49747b9067e4a0d4c09cfe20298342d0a15269a535a1c41", size = 6331373, upload-time = "2025-11-14T21:44:01.763Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/54/df42f95b20759fb5adbc33744504309f6b639266fd7508d103537d8d58b7/real_ladybug-0.12.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4b37cc107f42be0ef6e3e7f94b309f61cd798e5883eb2b2b18a7dbc4f8ac533", size = 7127678, upload-time = "2025-11-14T21:44:03.832Z" },
+    { url = "https://files.pythonhosted.org/packages/74/6a/9f928bd77612d3942ff29e2c68880fb5f402291c89c52aeb47924c24d7b1/real_ladybug-0.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9eac1aa289aad31ef760f6fa55aa005d0a86ff8bd361ca3fe0124d2d5c18e5e0", size = 7536790, upload-time = "2025-11-14T21:44:05.897Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/bb/f7620c98d56862ad214eeb079e39541f6a5add1f01c2e313c6a676bc129a/real_ladybug-0.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2fc0648431a4799c292f2b88efdd80e459cecf68148ed79400384883ef293c53", size = 8228993, upload-time = "2025-11-14T21:44:07.711Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5e/ec8ad324f76ef82af5b759726828eafa222790a318d5ace3b0b76ccef69a/real_ladybug-0.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:cd342f60ca7ed30221c73d5ce638d7b7bf6033890c974ff0c6e501b4a1c86a58", size = 4783733, upload-time = "2025-11-14T21:44:09.973Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2915,7 +2912,6 @@ dependencies = [
     { name = "genai-prices" },
     { name = "httpx" },
     { name = "jinja2" },
-    { name = "kuzu" },
     { name = "logfire" },
     { name = "openai" },
     { name = "packaging" },
@@ -2923,6 +2919,7 @@ dependencies = [
     { name = "pydantic-ai" },
     { name = "pydantic-settings" },
     { name = "pyperclip" },
+    { name = "real-ladybug" },
     { name = "rich" },
     { name = "sentencepiece" },
     { name = "sentry-sdk", extra = ["pure-eval"] },
@@ -2971,7 +2968,6 @@ requires-dist = [
     { name = "genai-prices", specifier = ">=0.0.27" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
-    { name = "kuzu", specifier = ">=0.7.0" },
     { name = "lefthook", marker = "extra == 'dev'", specifier = ">=1.12.0" },
     { name = "logfire", specifier = ">=2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
@@ -2981,6 +2977,7 @@ requires-dist = [
     { name = "pydantic-ai", specifier = ">=1.26.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pyperclip", specifier = ">=1.10.0" },
+    { name = "real-ladybug", specifier = ">=0.12.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0" },
     { name = "sentencepiece", specifier = ">=0.2.0" },


### PR DESCRIPTION
## Summary

- Kuzu is no longer maintained - LadybugDB is its continuation under new ownership
- LadybugDB is available on PyPI as `real_ladybug` (v0.12.2)
- The API is identical since it's "formerly known as Kuzu"

## Changes

- Replace `kuzu>=0.7.0` with `real_ladybug>=0.12.0` in dependencies
- Update `only-binary` config for `real_ladybug`
- Use `import real_ladybug as kuzu` aliasing to minimize code changes
- Add 9 compatibility tests for LadybugDB database operations

## Test plan

- [x] All 9 new LadybugDB compatibility tests pass
- [x] All 222 codebase unit tests pass
- [x] Ruff linting passes
- [x] Mypy type checking passes
- [x] Full unit test suite (945 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)