### PR TITLE
refactor(agents): use ShotgunAgent type alias across codebase

### DIFF
--- a/src/shotgun/agents/agent_manager.py
+++ b/src/shotgun/agents/agent_manager.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from shotgun.agents.conversation import ConversationState
 
 from pydantic_ai import (
-    Agent,
     RunContext,
     UsageLimits,
 )
@@ -64,6 +63,7 @@ from shotgun.agents.models import (
     AgentType,
     FileOperation,
     FileOperationTracker,
+    ShotgunAgent,
 )
 from shotgun.posthog_telemetry import track_event
 from shotgun.tui.screens.chat_screen.hint_message import HintMessage
@@ -312,15 +312,15 @@ class AgentManager(Widget):
         )
 
         # Lazy initialization - agents created on first access
-        self._research_agent: Agent[AgentDeps, AgentResponse] | None = None
+        self._research_agent: ShotgunAgent | None = None
         self._research_deps: AgentDeps | None = None
-        self._plan_agent: Agent[AgentDeps, AgentResponse] | None = None
+        self._plan_agent: ShotgunAgent | None = None
         self._plan_deps: AgentDeps | None = None
-        self._tasks_agent: Agent[AgentDeps, AgentResponse] | None = None
+        self._tasks_agent: ShotgunAgent | None = None
         self._tasks_deps: AgentDeps | None = None
-        self._specify_agent: Agent[AgentDeps, AgentResponse] | None = None
+        self._specify_agent: ShotgunAgent | None = None
         self._specify_deps: AgentDeps | None = None
-        self._export_agent: Agent[AgentDeps, AgentResponse] | None = None
+        self._export_agent: ShotgunAgent | None = None
         self._export_deps: AgentDeps | None = None
         self._agents_initialized = False
 
@@ -361,7 +361,7 @@ class AgentManager(Widget):
         self._agents_initialized = True
 
     @property
-    def research_agent(self) -> Agent[AgentDeps, AgentResponse]:
+    def research_agent(self) -> ShotgunAgent:
         """Get research agent (must call _ensure_agents_initialized first)."""
         if self._research_agent is None:
             raise RuntimeError(
@@ -379,7 +379,7 @@ class AgentManager(Widget):
         return self._research_deps
 
     @property
-    def plan_agent(self) -> Agent[AgentDeps, AgentResponse]:
+    def plan_agent(self) -> ShotgunAgent:
         """Get plan agent (must call _ensure_agents_initialized first)."""
         if self._plan_agent is None:
             raise RuntimeError(
@@ -397,7 +397,7 @@ class AgentManager(Widget):
         return self._plan_deps
 
     @property
-    def tasks_agent(self) -> Agent[AgentDeps, AgentResponse]:
+    def tasks_agent(self) -> ShotgunAgent:
         """Get tasks agent (must call _ensure_agents_initialized first)."""
         if self._tasks_agent is None:
             raise RuntimeError(
@@ -415,7 +415,7 @@ class AgentManager(Widget):
         return self._tasks_deps
 
     @property
-    def specify_agent(self) -> Agent[AgentDeps, AgentResponse]:
+    def specify_agent(self) -> ShotgunAgent:
         """Get specify agent (must call _ensure_agents_initialized first)."""
         if self._specify_agent is None:
             raise RuntimeError(
@@ -433,7 +433,7 @@ class AgentManager(Widget):
         return self._specify_deps
 
     @property
-    def export_agent(self) -> Agent[AgentDeps, AgentResponse]:
+    def export_agent(self) -> ShotgunAgent:
         """Get export agent (must call _ensure_agents_initialized first)."""
         if self._export_agent is None:
             raise RuntimeError(
@@ -451,7 +451,7 @@ class AgentManager(Widget):
         return self._export_deps
 
     @property
-    def current_agent(self) -> Agent[AgentDeps, AgentResponse]:
+    def current_agent(self) -> ShotgunAgent:
         """Get the currently active agent.
 
         Returns:
@@ -459,7 +459,7 @@ class AgentManager(Widget):
         """
         return self._get_agent(self._current_agent_type)
 
-    def _get_agent(self, agent_type: AgentType) -> Agent[AgentDeps, AgentResponse]:
+    def _get_agent(self, agent_type: AgentType) -> ShotgunAgent:
         """Get agent by type.
 
         Args:
@@ -545,7 +545,7 @@ class AgentManager(Widget):
     )
     async def _run_agent_with_retry(
         self,
-        agent: Agent[AgentDeps, AgentResponse],
+        agent: ShotgunAgent,
         prompt: str | None,
         deps: AgentDeps,
         usage_limits: UsageLimits | None,

--- a/src/shotgun/agents/common.py
+++ b/src/shotgun/agents/common.py
@@ -17,7 +17,7 @@ from pydantic_ai.messages import (
 )
 
 from shotgun.agents.config import ProviderType, get_provider_model
-from shotgun.agents.models import AgentResponse, AgentType
+from shotgun.agents.models import AgentResponse, AgentType, ShotgunAgent
 from shotgun.logging_config import get_logger
 from shotgun.prompts import PromptLoader
 from shotgun.sdk.services import get_codebase_service
@@ -111,7 +111,7 @@ async def create_base_agent(
     additional_tools: list[Any] | None = None,
     provider: ProviderType | None = None,
     agent_mode: AgentType | None = None,
-) -> tuple[Agent[AgentDeps, AgentResponse], AgentDeps]:
+) -> tuple[ShotgunAgent, AgentDeps]:
     """Create a base agent with common configuration.
 
     Args:
@@ -482,7 +482,7 @@ async def add_system_prompt_message(
 
 
 async def run_agent(
-    agent: Agent[AgentDeps, AgentResponse],
+    agent: ShotgunAgent,
     prompt: str,
     deps: AgentDeps,
     message_history: list[ModelMessage] | None = None,

--- a/src/shotgun/agents/export.py
+++ b/src/shotgun/agents/export.py
@@ -2,13 +2,11 @@
 
 from functools import partial
 
-from pydantic_ai import (
-    Agent,
-)
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.messages import ModelMessage
 
 from shotgun.agents.config import ProviderType
+from shotgun.agents.models import ShotgunAgent
 from shotgun.logging_config import get_logger
 
 from .common import (
@@ -25,7 +23,7 @@ logger = get_logger(__name__)
 
 async def create_export_agent(
     agent_runtime_options: AgentRuntimeOptions, provider: ProviderType | None = None
-) -> tuple[Agent[AgentDeps, AgentResponse], AgentDeps]:
+) -> tuple[ShotgunAgent, AgentDeps]:
     """Create an export agent with file management capabilities.
 
     Args:
@@ -49,7 +47,7 @@ async def create_export_agent(
 
 
 async def run_export_agent(
-    agent: Agent[AgentDeps, AgentResponse],
+    agent: ShotgunAgent,
     instruction: str,
     deps: AgentDeps,
     message_history: list[ModelMessage] | None = None,

--- a/src/shotgun/agents/plan.py
+++ b/src/shotgun/agents/plan.py
@@ -2,13 +2,11 @@
 
 from functools import partial
 
-from pydantic_ai import (
-    Agent,
-)
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.messages import ModelMessage
 
 from shotgun.agents.config import ProviderType
+from shotgun.agents.models import ShotgunAgent
 from shotgun.logging_config import get_logger
 
 from .common import (
@@ -25,7 +23,7 @@ logger = get_logger(__name__)
 
 async def create_plan_agent(
     agent_runtime_options: AgentRuntimeOptions, provider: ProviderType | None = None
-) -> tuple[Agent[AgentDeps, AgentResponse], AgentDeps]:
+) -> tuple[ShotgunAgent, AgentDeps]:
     """Create a plan agent with artifact management capabilities.
 
     Args:
@@ -51,7 +49,7 @@ async def create_plan_agent(
 
 
 async def run_plan_agent(
-    agent: Agent[AgentDeps, AgentResponse],
+    agent: ShotgunAgent,
     goal: str,
     deps: AgentDeps,
     message_history: list[ModelMessage] | None = None,

--- a/src/shotgun/agents/research.py
+++ b/src/shotgun/agents/research.py
@@ -2,15 +2,13 @@
 
 from functools import partial
 
-from pydantic_ai import (
-    Agent,
-)
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.messages import (
     ModelMessage,
 )
 
 from shotgun.agents.config import ProviderType
+from shotgun.agents.models import ShotgunAgent
 from shotgun.logging_config import get_logger
 
 from .common import (
@@ -28,7 +26,7 @@ logger = get_logger(__name__)
 
 async def create_research_agent(
     agent_runtime_options: AgentRuntimeOptions, provider: ProviderType | None = None
-) -> tuple[Agent[AgentDeps, AgentResponse], AgentDeps]:
+) -> tuple[ShotgunAgent, AgentDeps]:
     """Create a research agent with web search and artifact management capabilities.
 
     Args:
@@ -65,7 +63,7 @@ async def create_research_agent(
 
 
 async def run_research_agent(
-    agent: Agent[AgentDeps, AgentResponse],
+    agent: ShotgunAgent,
     query: str,
     deps: AgentDeps,
     message_history: list[ModelMessage] | None = None,

--- a/src/shotgun/agents/specify.py
+++ b/src/shotgun/agents/specify.py
@@ -2,13 +2,11 @@
 
 from functools import partial
 
-from pydantic_ai import (
-    Agent,
-)
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.messages import ModelMessage
 
 from shotgun.agents.config import ProviderType
+from shotgun.agents.models import ShotgunAgent
 from shotgun.logging_config import get_logger
 
 from .common import (
@@ -25,7 +23,7 @@ logger = get_logger(__name__)
 
 async def create_specify_agent(
     agent_runtime_options: AgentRuntimeOptions, provider: ProviderType | None = None
-) -> tuple[Agent[AgentDeps, AgentResponse], AgentDeps]:
+) -> tuple[ShotgunAgent, AgentDeps]:
     """Create a specify agent with artifact management capabilities.
 
     Args:
@@ -51,7 +49,7 @@ async def create_specify_agent(
 
 
 async def run_specify_agent(
-    agent: Agent[AgentDeps, AgentResponse],
+    agent: ShotgunAgent,
     requirement: str,
     deps: AgentDeps,
     message_history: list[ModelMessage] | None = None,

--- a/src/shotgun/agents/tasks.py
+++ b/src/shotgun/agents/tasks.py
@@ -2,13 +2,11 @@
 
 from functools import partial
 
-from pydantic_ai import (
-    Agent,
-)
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.messages import ModelMessage
 
 from shotgun.agents.config import ProviderType
+from shotgun.agents.models import ShotgunAgent
 from shotgun.logging_config import get_logger
 
 from .common import (
@@ -25,7 +23,7 @@ logger = get_logger(__name__)
 
 async def create_tasks_agent(
     agent_runtime_options: AgentRuntimeOptions, provider: ProviderType | None = None
-) -> tuple[Agent[AgentDeps, AgentResponse], AgentDeps]:
+) -> tuple[ShotgunAgent, AgentDeps]:
     """Create a tasks agent with file management capabilities.
 
     Args:
@@ -49,7 +47,7 @@ async def create_tasks_agent(
 
 
 async def run_tasks_agent(
-    agent: Agent[AgentDeps, AgentResponse],
+    agent: ShotgunAgent,
     instruction: str,
     deps: AgentDeps,
     message_history: list[ModelMessage] | None = None,


### PR DESCRIPTION
## Summary
- Replace all 25 occurrences of `Agent[AgentDeps, AgentResponse]` with the `ShotgunAgent` type alias
- Improves DRYness and consistency across the agents codebase
- Makes the type more discoverable and easier to update if needed

## Files Updated
| File | Usages Replaced |
|------|-----------------|
| agent_manager.py | 13 |
| common.py | 2 |
| research.py | 2 |
| plan.py | 2 |
| tasks.py | 2 |
| specify.py | 2 |
| export.py | 2 |

## Test plan
- [x] All unit tests pass (226 tests)
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)