### PR TITLE
feat(router): add plan approval UI for Planning mode (Stage 7)

### DIFF
--- a/src/shotgun/agents/router/models.py
+++ b/src/shotgun/agents/router/models.py
@@ -272,6 +272,16 @@ class PendingCascade(BaseModel):
     )
 
 
+class PendingApproval(BaseModel):
+    """Pending approval state for Planning mode multi-step plans.
+
+    Set by create_plan tool when plan.needs_approval() returns True
+    (i.e., the plan has more than one step) in Planning mode.
+    """
+
+    plan: "ExecutionPlan" = Field(..., description="The plan that needs user approval")
+
+
 # =============================================================================
 # File Dependency Map (for Cascade Confirmation)
 # =============================================================================
@@ -334,3 +344,7 @@ class RouterDeps(AgentDeps):
     # Set when a file with dependents is modified
     # Excluded from serialization as it's transient UI state
     pending_cascade: PendingCascade | None = Field(default=None, exclude=True)
+    # Approval state for Planning mode multi-step plans
+    # Set by create_plan tool when plan.needs_approval() returns True
+    # Excluded from serialization as it's transient UI state
+    pending_approval: PendingApproval | None = Field(default=None, exclude=True)

--- a/src/shotgun/agents/router/tools/plan_tools.py
+++ b/src/shotgun/agents/router/tools/plan_tools.py
@@ -15,7 +15,9 @@ from shotgun.agents.router.models import (
     ExecutionPlan,
     ExecutionStep,
     MarkStepDoneInput,
+    PendingApproval,
     PendingCheckpoint,
+    PlanApprovalStatus,
     RemoveStepInput,
     RouterDeps,
     RouterMode,
@@ -68,6 +70,20 @@ async def create_plan(
     )
 
     ctx.deps.current_plan = plan
+
+    # Set pending approval for multi-step plans in Planning mode
+    # The TUI will detect this and show the PlanApprovalWidget
+    if ctx.deps.router_mode == RouterMode.PLANNING and plan.needs_approval():
+        ctx.deps.pending_approval = PendingApproval(plan=plan)
+        ctx.deps.approval_status = PlanApprovalStatus.PENDING
+        logger.debug(
+            "Set pending approval for plan with %d steps",
+            len(steps),
+        )
+    else:
+        # Single-step plans or Drafting mode - skip approval
+        ctx.deps.approval_status = PlanApprovalStatus.SKIPPED
+
     logger.info(
         "Created execution plan with %d steps: %s",
         len(steps),

--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -51,7 +51,13 @@ from shotgun.agents.models import (
     AgentType,
     FileOperationTracker,
 )
-from shotgun.agents.router.models import CascadeScope, RouterDeps, RouterMode
+from shotgun.agents.router.models import (
+    CascadeScope,
+    ExecutionPlan,
+    PlanApprovalStatus,
+    RouterDeps,
+    RouterMode,
+)
 from shotgun.agents.runner import AgentRunner
 from shotgun.codebase.core.manager import (
     CodebaseAlreadyIndexedError,
@@ -96,6 +102,9 @@ from shotgun.tui.screens.chat_screen.messages import (
     CheckpointContinue,
     CheckpointModify,
     CheckpointStop,
+    PlanApprovalRequired,
+    PlanApproved,
+    PlanRejected,
     StepCompleted,
 )
 from shotgun.tui.screens.confirmation_dialog import ConfirmationDialog
@@ -109,6 +118,7 @@ from shotgun.tui.screens.shared_specs import (
 from shotgun.tui.services.conversation_service import ConversationService
 from shotgun.tui.state.processing_state import ProcessingStateManager
 from shotgun.tui.utils.mode_progress import PlaceholderHints
+from shotgun.tui.widgets.approval_widget import PlanApprovalWidget
 from shotgun.tui.widgets.cascade_confirmation_widget import CascadeConfirmationWidget
 from shotgun.tui.widgets.step_checkpoint_widget import StepCheckpointWidget
 from shotgun.tui.widgets.widget_coordinator import WidgetCoordinator
@@ -183,6 +193,9 @@ class ChatScreen(Screen[None]):
 
     # Cascade confirmation widget (Planning mode)
     _cascade_widget: CascadeConfirmationWidget | None = None
+
+    # Plan approval widget (Planning mode)
+    _approval_widget: PlanApprovalWidget | None = None
 
     def __init__(
         self,
@@ -1569,6 +1582,9 @@ class ChatScreen(Screen[None]):
             if self.deps.llm_model.is_shotgun_account:
                 await self._check_low_balance_warning()
 
+        # Check for pending approval (Planning mode multi-step plan creation)
+        self._check_pending_approval()
+
         # Check for pending checkpoint (Planning mode step completion)
         self._check_pending_checkpoint()
 
@@ -1904,3 +1920,100 @@ class ChatScreen(Screen[None]):
                 dependent_files=cascade.dependent_files,
             )
         )
+
+    # =========================================================================
+    # Plan Approval Handlers (Planning Mode - Stage 7)
+    # =========================================================================
+
+    @on(PlanApprovalRequired)
+    def handle_plan_approval_required(self, event: PlanApprovalRequired) -> None:
+        """Show approval widget when a multi-step plan is created.
+
+        In Planning mode, after creating a plan with multiple steps,
+        this shows the PlanApprovalWidget to let the user decide
+        whether to proceed or clarify.
+        """
+        if not isinstance(self.deps, RouterDeps):
+            return
+        if self.deps.router_mode != RouterMode.PLANNING:
+            return
+
+        # Show approval widget
+        self._show_approval_widget(event.plan)
+
+    @on(PlanApproved)
+    def handle_plan_approved(self) -> None:
+        """Begin plan execution when user approves."""
+        self._hide_approval_widget()
+
+        if isinstance(self.deps, RouterDeps):
+            self.deps.approval_status = PlanApprovalStatus.APPROVED
+            self.deps.is_executing = True
+
+            # Begin execution of the first step
+            plan = self.deps.current_plan
+            if plan and plan.current_step():
+                first_step = plan.current_step()
+                if first_step:
+                    self.run_agent(f"Execute step: {first_step.title}")
+            else:
+                self.widget_coordinator.update_prompt_input(focus=True)
+
+    @on(PlanRejected)
+    def handle_plan_rejected(self) -> None:
+        """Return to prompt input for clarification when user rejects plan."""
+        self._hide_approval_widget()
+
+        if isinstance(self.deps, RouterDeps):
+            self.deps.approval_status = PlanApprovalStatus.REJECTED
+            # Clear the plan since user wants to modify
+            self.deps.current_plan = None
+
+        self.mount_hint("ℹ️ Plan cancelled. Please clarify what you'd like to do.")
+        self.widget_coordinator.update_prompt_input(focus=True)
+
+    def _show_approval_widget(self, plan: ExecutionPlan) -> None:
+        """Replace PromptInput with PlanApprovalWidget.
+
+        Args:
+            plan: The execution plan that needs user approval.
+        """
+        # Create the approval widget
+        self._approval_widget = PlanApprovalWidget(plan)
+
+        # Hide PromptInput
+        prompt_input = self.query_one(PromptInput)
+        prompt_input.display = False
+
+        # Mount approval widget in footer
+        footer = self.query_one("#footer")
+        footer.mount(self._approval_widget, after=prompt_input)
+
+    def _hide_approval_widget(self) -> None:
+        """Remove approval widget, restore PromptInput."""
+        if self._approval_widget:
+            self._approval_widget.remove()
+            self._approval_widget = None
+
+        # Show PromptInput
+        prompt_input = self.query_one(PromptInput)
+        prompt_input.display = True
+
+    def _check_pending_approval(self) -> None:
+        """Check if there's a pending approval and post PlanApprovalRequired if so.
+
+        This is called after each agent run to check if create_plan
+        set a pending approval in Planning mode.
+        """
+        if not isinstance(self.deps, RouterDeps):
+            return
+
+        if self.deps.pending_approval is None:
+            return
+
+        # Extract approval data and clear the pending state
+        approval = self.deps.pending_approval
+        self.deps.pending_approval = None
+
+        # Post the PlanApprovalRequired message to trigger the approval UI
+        self.post_message(PlanApprovalRequired(plan=approval.plan))

--- a/src/shotgun/tui/screens/chat_screen/messages.py
+++ b/src/shotgun/tui/screens/chat_screen/messages.py
@@ -7,7 +7,7 @@ and cascade confirmation in the Router's Planning mode.
 
 from textual.message import Message
 
-from shotgun.agents.router.models import CascadeScope, ExecutionStep
+from shotgun.agents.router.models import CascadeScope, ExecutionPlan, ExecutionStep
 
 __all__ = [
     # Step checkpoint messages (Stage 4)
@@ -19,6 +19,10 @@ __all__ = [
     "CascadeConfirmationRequired",
     "CascadeConfirmed",
     "CascadeDeclined",
+    # Plan approval messages (Stage 7)
+    "PlanApprovalRequired",
+    "PlanApproved",
+    "PlanRejected",
 ]
 
 
@@ -106,4 +110,40 @@ class CascadeDeclined(Message):
 
     This message indicates the user does not want to update dependent
     files and will handle them manually.
+    """
+
+
+# =============================================================================
+# Plan Approval Messages (Stage 7)
+# =============================================================================
+
+
+class PlanApprovalRequired(Message):
+    """Posted when a multi-step plan is created and needs user approval.
+
+    In Planning mode, after the router creates a plan with multiple steps,
+    this message triggers the approval UI to appear.
+
+    Attributes:
+        plan: The execution plan that needs user approval.
+    """
+
+    def __init__(self, plan: ExecutionPlan) -> None:
+        super().__init__()
+        self.plan = plan
+
+
+class PlanApproved(Message):
+    """Posted when user approves the plan.
+
+    This message indicates the user wants to proceed with executing
+    the plan ("Go Ahead").
+    """
+
+
+class PlanRejected(Message):
+    """Posted when user rejects the plan to clarify/modify.
+
+    This message indicates the user wants to return to the prompt input
+    to modify or clarify the request ("No, Let Me Clarify").
     """

--- a/src/shotgun/tui/widgets/approval_widget.py
+++ b/src/shotgun/tui/widgets/approval_widget.py
@@ -1,0 +1,143 @@
+"""Plan approval widget for Planning mode.
+
+This widget displays when a multi-step plan is created in Planning mode,
+allowing the user to approve or reject the plan before execution begins.
+"""
+
+from textual import events, on
+from textual.app import ComposeResult
+from textual.containers import Horizontal
+from textual.css.query import NoMatches
+from textual.widget import Widget
+from textual.widgets import Button, Static
+
+from shotgun.agents.router.models import ExecutionPlan
+from shotgun.tui.screens.chat_screen.messages import (
+    PlanApproved,
+    PlanRejected,
+)
+
+
+class PlanApprovalWidget(Widget):
+    """Widget for plan approval in Planning mode.
+
+    Displays the execution plan summary with goal and steps,
+    and provides action buttons for the user to approve or reject.
+
+    Attributes:
+        plan: The execution plan that needs user approval.
+    """
+
+    DEFAULT_CSS = """
+        PlanApprovalWidget {
+            background: $secondary-background-darken-1;
+            height: auto;
+            margin: 1;
+            padding: 1;
+        }
+
+        PlanApprovalWidget .approval-header {
+            margin-bottom: 1;
+        }
+
+        PlanApprovalWidget .plan-goal {
+            color: $text;
+            margin-bottom: 1;
+        }
+
+        PlanApprovalWidget .plan-steps-label {
+            color: $text-muted;
+        }
+
+        PlanApprovalWidget .step-item {
+            color: $text;
+            margin-left: 2;
+        }
+
+        PlanApprovalWidget .approval-buttons {
+            height: auto;
+            width: 100%;
+            margin-top: 1;
+        }
+
+        PlanApprovalWidget Button {
+            margin-right: 1;
+            min-width: 18;
+        }
+
+        PlanApprovalWidget #btn-approve {
+            background: $success;
+        }
+
+        PlanApprovalWidget #btn-reject {
+            background: $error;
+        }
+    """
+
+    def __init__(self, plan: ExecutionPlan) -> None:
+        """Initialize the approval widget.
+
+        Args:
+            plan: The execution plan that needs user approval.
+        """
+        super().__init__()
+        self.plan = plan
+
+    def compose(self) -> ComposeResult:
+        """Compose the approval widget layout."""
+        # Header with step count
+        yield Static(
+            f"[bold]📋 Plan created with {len(self.plan.steps)} steps[/]",
+            classes="approval-header",
+        )
+
+        # Goal
+        yield Static(
+            f"[dim]Goal:[/] {self.plan.goal}",
+            classes="plan-goal",
+        )
+
+        # Steps list
+        yield Static("[dim]Steps:[/]", classes="plan-steps-label")
+        for i, step in enumerate(self.plan.steps, 1):
+            yield Static(
+                f"{i}. {step.title}",
+                classes="step-item",
+            )
+
+        # Action buttons
+        with Horizontal(classes="approval-buttons"):
+            yield Button("✓ Go Ahead", id="btn-approve")
+            yield Button("✗ No, Let Me Clarify", id="btn-reject")
+
+    def on_mount(self) -> None:
+        """Auto-focus the Go Ahead button on mount."""
+        try:
+            approve_btn = self.query_one("#btn-approve", Button)
+            approve_btn.focus()
+        except NoMatches:
+            pass
+
+    @on(Button.Pressed, "#btn-approve")
+    def handle_approve(self) -> None:
+        """Handle Go Ahead button press."""
+        self.post_message(PlanApproved())
+
+    @on(Button.Pressed, "#btn-reject")
+    def handle_reject(self) -> None:
+        """Handle No, Let Me Clarify button press."""
+        self.post_message(PlanRejected())
+
+    def on_key(self, event: events.Key) -> None:
+        """Handle keyboard shortcuts for approval actions.
+
+        Shortcuts:
+            Enter/Y: Approve plan (Go Ahead)
+            Escape/N: Reject plan (No, Let Me Clarify)
+        """
+        if event.key in ("enter", "y", "Y"):
+            self.post_message(PlanApproved())
+            event.stop()
+        elif event.key in ("escape", "n", "N"):
+            self.post_message(PlanRejected())
+            event.stop()

--- a/test/unit/tui/widgets/test_approval_widget.py
+++ b/test/unit/tui/widgets/test_approval_widget.py
@@ -1,0 +1,299 @@
+"""Unit tests for PlanApprovalWidget."""
+
+import pytest
+
+from shotgun.agents.router.models import ExecutionPlan, ExecutionStep
+from shotgun.tui.screens.chat_screen.messages import (
+    PlanApproved,
+    PlanRejected,
+)
+from shotgun.tui.widgets.approval_widget import PlanApprovalWidget
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def multi_step_plan() -> ExecutionPlan:
+    """Create a sample multi-step plan for testing."""
+    return ExecutionPlan(
+        goal="Implement OAuth authentication",
+        steps=[
+            ExecutionStep(
+                id="research-oauth",
+                title="Research OAuth providers",
+                objective="Research available OAuth providers and their integration patterns",
+                done=False,
+            ),
+            ExecutionStep(
+                id="implement-oauth",
+                title="Implement OAuth flow",
+                objective="Implement OAuth 2.0 authentication flow",
+                done=False,
+            ),
+            ExecutionStep(
+                id="test-oauth",
+                title="Write OAuth tests",
+                objective="Write unit tests for OAuth implementation",
+                done=False,
+            ),
+        ],
+        current_step_index=0,
+    )
+
+
+# =============================================================================
+# Property Tests
+# =============================================================================
+
+
+async def test_approval_widget_stores_plan(multi_step_plan: ExecutionPlan) -> None:
+    """Test that the approval widget stores the plan."""
+    widget = PlanApprovalWidget(multi_step_plan)
+    assert widget.plan == multi_step_plan
+
+
+async def test_approval_widget_plan_has_correct_goal(
+    multi_step_plan: ExecutionPlan,
+) -> None:
+    """Test that the stored plan has the correct goal."""
+    widget = PlanApprovalWidget(multi_step_plan)
+    assert widget.plan.goal == "Implement OAuth authentication"
+
+
+async def test_approval_widget_plan_has_correct_step_count(
+    multi_step_plan: ExecutionPlan,
+) -> None:
+    """Test that the stored plan has the correct number of steps."""
+    widget = PlanApprovalWidget(multi_step_plan)
+    assert len(widget.plan.steps) == 3
+
+
+# =============================================================================
+# Button Tests
+# =============================================================================
+
+
+async def test_approval_widget_has_two_buttons(
+    multi_step_plan: ExecutionPlan,
+) -> None:
+    """Test that the widget has approve and reject buttons."""
+    from textual.app import App
+
+    class TestApp(App):
+        def compose(self):
+            yield PlanApprovalWidget(multi_step_plan)
+
+    async with TestApp().run_test() as pilot:
+        buttons = pilot.app.query("Button")
+        assert len(buttons) == 2
+
+        button_ids = {btn.id for btn in buttons}
+        assert "btn-approve" in button_ids
+        assert "btn-reject" in button_ids
+
+
+# =============================================================================
+# Message Tests - Button Clicks
+# =============================================================================
+
+
+async def test_approve_button_posts_plan_approved(
+    multi_step_plan: ExecutionPlan,
+) -> None:
+    """Test that clicking Go Ahead posts PlanApproved message."""
+    from textual.app import App
+
+    messages_received: list = []
+
+    class TestApp(App):
+        def compose(self):
+            yield PlanApprovalWidget(multi_step_plan)
+
+        def on_plan_approved(self, event: PlanApproved) -> None:
+            messages_received.append(event)
+
+    async with TestApp().run_test() as pilot:
+        await pilot.click("#btn-approve")
+
+        assert len(messages_received) == 1
+        assert isinstance(messages_received[0], PlanApproved)
+
+
+async def test_reject_button_posts_plan_rejected(
+    multi_step_plan: ExecutionPlan,
+) -> None:
+    """Test that clicking No, Let Me Clarify posts PlanRejected message."""
+    from textual.app import App
+
+    messages_received: list = []
+
+    class TestApp(App):
+        def compose(self):
+            yield PlanApprovalWidget(multi_step_plan)
+
+        def on_plan_rejected(self, event: PlanRejected) -> None:
+            messages_received.append(event)
+
+    async with TestApp().run_test() as pilot:
+        await pilot.click("#btn-reject")
+
+        assert len(messages_received) == 1
+        assert isinstance(messages_received[0], PlanRejected)
+
+
+# =============================================================================
+# Keyboard Shortcut Tests
+# =============================================================================
+
+
+async def test_keyboard_shortcut_enter_posts_approved(
+    multi_step_plan: ExecutionPlan,
+) -> None:
+    """Test that pressing Enter triggers approve action."""
+    from textual.app import App
+
+    messages_received: list = []
+
+    class TestApp(App):
+        def compose(self):
+            yield PlanApprovalWidget(multi_step_plan)
+
+        def on_plan_approved(self, event: PlanApproved) -> None:
+            messages_received.append(event)
+
+    async with TestApp().run_test() as pilot:
+        await pilot.press("enter")
+
+        assert len(messages_received) == 1
+        assert isinstance(messages_received[0], PlanApproved)
+
+
+async def test_keyboard_shortcut_y_posts_approved(
+    multi_step_plan: ExecutionPlan,
+) -> None:
+    """Test that pressing 'y' triggers approve action."""
+    from textual.app import App
+
+    messages_received: list = []
+
+    class TestApp(App):
+        def compose(self):
+            yield PlanApprovalWidget(multi_step_plan)
+
+        def on_plan_approved(self, event: PlanApproved) -> None:
+            messages_received.append(event)
+
+    async with TestApp().run_test() as pilot:
+        await pilot.press("y")
+
+        assert len(messages_received) == 1
+        assert isinstance(messages_received[0], PlanApproved)
+
+
+async def test_keyboard_shortcut_upper_y_posts_approved(
+    multi_step_plan: ExecutionPlan,
+) -> None:
+    """Test that pressing 'Y' triggers approve action."""
+    from textual.app import App
+
+    messages_received: list = []
+
+    class TestApp(App):
+        def compose(self):
+            yield PlanApprovalWidget(multi_step_plan)
+
+        def on_plan_approved(self, event: PlanApproved) -> None:
+            messages_received.append(event)
+
+    async with TestApp().run_test() as pilot:
+        await pilot.press("Y")
+
+        assert len(messages_received) == 1
+        assert isinstance(messages_received[0], PlanApproved)
+
+
+async def test_keyboard_shortcut_escape_posts_rejected(
+    multi_step_plan: ExecutionPlan,
+) -> None:
+    """Test that pressing Escape triggers reject action."""
+    from textual.app import App
+
+    messages_received: list = []
+
+    class TestApp(App):
+        def compose(self):
+            yield PlanApprovalWidget(multi_step_plan)
+
+        def on_plan_rejected(self, event: PlanRejected) -> None:
+            messages_received.append(event)
+
+    async with TestApp().run_test() as pilot:
+        await pilot.press("escape")
+
+        assert len(messages_received) == 1
+        assert isinstance(messages_received[0], PlanRejected)
+
+
+async def test_keyboard_shortcut_n_posts_rejected(
+    multi_step_plan: ExecutionPlan,
+) -> None:
+    """Test that pressing 'n' triggers reject action."""
+    from textual.app import App
+
+    messages_received: list = []
+
+    class TestApp(App):
+        def compose(self):
+            yield PlanApprovalWidget(multi_step_plan)
+
+        def on_plan_rejected(self, event: PlanRejected) -> None:
+            messages_received.append(event)
+
+    async with TestApp().run_test() as pilot:
+        await pilot.press("n")
+
+        assert len(messages_received) == 1
+        assert isinstance(messages_received[0], PlanRejected)
+
+
+async def test_keyboard_shortcut_upper_n_posts_rejected(
+    multi_step_plan: ExecutionPlan,
+) -> None:
+    """Test that pressing 'N' triggers reject action."""
+    from textual.app import App
+
+    messages_received: list = []
+
+    class TestApp(App):
+        def compose(self):
+            yield PlanApprovalWidget(multi_step_plan)
+
+        def on_plan_rejected(self, event: PlanRejected) -> None:
+            messages_received.append(event)
+
+    async with TestApp().run_test() as pilot:
+        await pilot.press("N")
+
+        assert len(messages_received) == 1
+        assert isinstance(messages_received[0], PlanRejected)
+
+
+# =============================================================================
+# Focus Tests
+# =============================================================================
+
+
+async def test_approve_button_auto_focused_on_mount(
+    multi_step_plan: ExecutionPlan,
+) -> None:
+    """Test that the Go Ahead button is auto-focused on mount."""
+    from textual.app import App
+    from textual.widgets import Button
+
+    class TestApp(App):
+        def compose(self):
+            yield PlanApprovalWidget(multi_step_plan)
+
+    async with TestApp().run_test() as pilot:
+        approve_btn = pilot.app.query_one("#btn-approve", Button)
+        assert approve_btn.has_focus


### PR DESCRIPTION
## Summary
- Add plan approval UI that shows when multi-step plans are created in Planning mode
- Users can approve ("Go Ahead") or reject ("No, Let Me Clarify") before execution begins
- Implement PlanApprovalWidget with keyboard shortcuts (Enter/Y to approve, Escape/N to reject)

## Changes
- Add `PlanApprovalRequired`, `PlanApproved`, `PlanRejected` message types
- Add `PendingApproval` model and field to `RouterDeps`
- Update `create_plan` tool to set `pending_approval` for multi-step plans in Planning mode
- Create `PlanApprovalWidget` following existing widget patterns
- Add ChatScreen handlers and `_check_pending_approval()` integration
- Add 13 unit tests with 93% code coverage

## Test plan
- [x] All 13 new widget tests pass
- [x] All 78 existing router tests pass
- [x] All 45 existing TUI widget tests pass
- [x] Linting passes (`ruff check`)
- [x] Formatting passes (`ruff format --check`)
- [x] Type checking passes (`mypy src/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)