### PR TITLE
feat(router): add sub-agent awareness and streaming support (Stage 10)

### DIFF
--- a/src/shotgun/agents/common.py
+++ b/src/shotgun/agents/common.py
@@ -1,6 +1,6 @@
 """Common utilities for agent creation and management."""
 
-from collections.abc import Callable
+from collections.abc import AsyncIterable, Awaitable, Callable
 from pathlib import Path
 from typing import Any
 
@@ -418,6 +418,7 @@ def build_agent_system_prompt(
         f"agents/{agent_type}.j2",
         interactive_mode=ctx.deps.interactive_mode,
         mode=agent_type,
+        sub_agent_context=ctx.deps.sub_agent_context,
     )
 
     if agent_type == "research":
@@ -481,13 +482,33 @@ async def add_system_prompt_message(
     return message_history
 
 
+EventStreamHandler = Callable[
+    [RunContext[AgentDeps], AsyncIterable[Any]], Awaitable[None]
+]
+
+
 async def run_agent(
     agent: ShotgunAgent,
     prompt: str,
     deps: AgentDeps,
     message_history: list[ModelMessage] | None = None,
     usage_limits: UsageLimits | None = None,
+    event_stream_handler: EventStreamHandler | None = None,
 ) -> AgentRunResult[AgentResponse]:
+    """Run an agent with optional streaming support.
+
+    Args:
+        agent: The agent to run.
+        prompt: The prompt to send to the agent.
+        deps: Agent dependencies.
+        message_history: Optional message history to continue from.
+        usage_limits: Optional usage limits for the run.
+        event_stream_handler: Optional callback for streaming events.
+            When provided, enables real-time streaming of agent responses.
+
+    Returns:
+        The agent run result.
+    """
     # Clear file tracker for new run
     deps.file_tracker.clear()
     logger.debug("🔧 Cleared file tracker for new agent run")
@@ -500,6 +521,7 @@ async def run_agent(
         deps=deps,
         usage_limits=usage_limits,
         message_history=message_history,
+        event_stream_handler=event_stream_handler,
     )
 
     # Log file operations summary if any files were modified

--- a/src/shotgun/agents/export.py
+++ b/src/shotgun/agents/export.py
@@ -10,6 +10,7 @@ from shotgun.agents.models import ShotgunAgent
 from shotgun.logging_config import get_logger
 
 from .common import (
+    EventStreamHandler,
     add_system_status_message,
     build_agent_system_prompt,
     create_base_agent,
@@ -51,6 +52,7 @@ async def run_export_agent(
     instruction: str,
     deps: AgentDeps,
     message_history: list[ModelMessage] | None = None,
+    event_stream_handler: EventStreamHandler | None = None,
 ) -> AgentRunResult[AgentResponse]:
     """Export artifacts based on the given instruction.
 
@@ -59,6 +61,7 @@ async def run_export_agent(
         instruction: The export instruction
         deps: Agent dependencies
         message_history: Optional message history for conversation continuity
+        event_stream_handler: Optional callback for streaming events
 
     Returns:
         AgentRunResult containing the export process output
@@ -80,6 +83,7 @@ async def run_export_agent(
             deps=deps,
             message_history=message_history,
             usage_limits=usage_limits,
+            event_stream_handler=event_stream_handler,
         )
 
         logger.debug("✅ Export completed successfully")

--- a/src/shotgun/agents/plan.py
+++ b/src/shotgun/agents/plan.py
@@ -10,6 +10,7 @@ from shotgun.agents.models import ShotgunAgent
 from shotgun.logging_config import get_logger
 
 from .common import (
+    EventStreamHandler,
     add_system_status_message,
     build_agent_system_prompt,
     create_base_agent,
@@ -53,6 +54,7 @@ async def run_plan_agent(
     goal: str,
     deps: AgentDeps,
     message_history: list[ModelMessage] | None = None,
+    event_stream_handler: EventStreamHandler | None = None,
 ) -> AgentRunResult[AgentResponse]:
     """Create or update a plan based on the given goal using artifacts.
 
@@ -61,6 +63,7 @@ async def run_plan_agent(
         goal: The planning goal or instruction
         deps: Agent dependencies
         message_history: Optional message history for conversation continuity
+        event_stream_handler: Optional callback for streaming events
 
     Returns:
         AgentRunResult containing the planning process output
@@ -82,6 +85,7 @@ async def run_plan_agent(
             deps=deps,
             message_history=message_history,
             usage_limits=usage_limits,
+            event_stream_handler=event_stream_handler,
         )
 
         logger.debug("✅ Planning completed successfully")

--- a/src/shotgun/agents/research.py
+++ b/src/shotgun/agents/research.py
@@ -12,6 +12,7 @@ from shotgun.agents.models import ShotgunAgent
 from shotgun.logging_config import get_logger
 
 from .common import (
+    EventStreamHandler,
     add_system_status_message,
     build_agent_system_prompt,
     create_base_agent,
@@ -67,6 +68,7 @@ async def run_research_agent(
     query: str,
     deps: AgentDeps,
     message_history: list[ModelMessage] | None = None,
+    event_stream_handler: EventStreamHandler | None = None,
 ) -> AgentRunResult[AgentResponse]:
     """Perform research on the given query and update research artifacts.
 
@@ -74,6 +76,8 @@ async def run_research_agent(
         agent: The configured research agent
         query: The research query to investigate
         deps: Agent dependencies
+        message_history: Optional message history for conversation continuity
+        event_stream_handler: Optional callback for streaming events
 
     Returns:
         Summary of research findings
@@ -92,6 +96,7 @@ async def run_research_agent(
             deps=deps,
             message_history=message_history,
             usage_limits=usage_limits,
+            event_stream_handler=event_stream_handler,
         )
 
         logger.debug("✅ Research completed successfully")

--- a/src/shotgun/agents/router/models.py
+++ b/src/shotgun/agents/router/models.py
@@ -7,8 +7,14 @@ These models define the contracts between router, sub-agents, and UI.
 IMPORTANT: All tool inputs/outputs must use Pydantic models - no raw dict/list/tuple.
 """
 
+from collections.abc import AsyncIterable, Awaitable, Callable
 from enum import StrEnum
-from typing import Final
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:
+    from pydantic_ai import RunContext
+
+    from shotgun.agents.models import AgentDeps
 
 from pydantic import BaseModel, Field
 
@@ -312,6 +318,12 @@ from shotgun.agents.models import AgentDeps, AgentType, ShotgunAgent  # noqa: E4
 # Each entry is a tuple of (Agent instance, AgentDeps instance)
 SubAgentCacheEntry = tuple[ShotgunAgent, AgentDeps]
 
+# Type alias for event stream handler callback
+# Matches the signature expected by pydantic_ai's agent.run()
+EventStreamHandler = Callable[
+    ["RunContext[AgentDeps]", AsyncIterable[Any]], Awaitable[None]
+]
+
 
 class RouterDeps(AgentDeps):
     """
@@ -348,3 +360,11 @@ class RouterDeps(AgentDeps):
     # Set by create_plan tool when plan.needs_approval() returns True
     # Excluded from serialization as it's transient UI state
     pending_approval: PendingApproval | None = Field(default=None, exclude=True)
+    # Event stream handler for forwarding sub-agent streaming events to UI
+    # This is set by the AgentManager when running the router with streaming
+    # Excluded from serialization as it's a callable
+    parent_stream_handler: EventStreamHandler | None = Field(
+        default=None,
+        exclude=True,
+        description="Event stream handler from parent context for forwarding sub-agent events",
+    )

--- a/src/shotgun/agents/router/tools/delegation_tools.py
+++ b/src/shotgun/agents/router/tools/delegation_tools.py
@@ -216,12 +216,13 @@ async def _run_sub_agent(
     last_error: BaseException | None = None
     for attempt in range(MAX_RETRIES + 1):
         try:
-            # Run sub-agent with isolated message history
+            # Run sub-agent with isolated message history and streaming support
             result = await run_fn(
                 agent=agent,
                 query=prompt,  # Most agents use 'query' parameter
                 deps=sub_agent_deps,
                 message_history=[],  # Isolated context
+                event_stream_handler=deps.parent_stream_handler,  # Forward streaming
             )
 
             # Extract response text

--- a/src/shotgun/agents/specify.py
+++ b/src/shotgun/agents/specify.py
@@ -10,6 +10,7 @@ from shotgun.agents.models import ShotgunAgent
 from shotgun.logging_config import get_logger
 
 from .common import (
+    EventStreamHandler,
     add_system_status_message,
     build_agent_system_prompt,
     create_base_agent,
@@ -53,6 +54,7 @@ async def run_specify_agent(
     requirement: str,
     deps: AgentDeps,
     message_history: list[ModelMessage] | None = None,
+    event_stream_handler: EventStreamHandler | None = None,
 ) -> AgentRunResult[AgentResponse]:
     """Create or update specifications based on the given requirement.
 
@@ -61,6 +63,7 @@ async def run_specify_agent(
         requirement: The specification requirement or instruction
         deps: Agent dependencies
         message_history: Optional message history for conversation continuity
+        event_stream_handler: Optional callback for streaming events
 
     Returns:
         AgentRunResult containing the specification process output
@@ -82,6 +85,7 @@ async def run_specify_agent(
             deps=deps,
             message_history=message_history,
             usage_limits=usage_limits,
+            event_stream_handler=event_stream_handler,
         )
 
         logger.debug("✅ Specification completed successfully")

--- a/src/shotgun/agents/tasks.py
+++ b/src/shotgun/agents/tasks.py
@@ -10,6 +10,7 @@ from shotgun.agents.models import ShotgunAgent
 from shotgun.logging_config import get_logger
 
 from .common import (
+    EventStreamHandler,
     add_system_status_message,
     build_agent_system_prompt,
     create_base_agent,
@@ -51,6 +52,7 @@ async def run_tasks_agent(
     instruction: str,
     deps: AgentDeps,
     message_history: list[ModelMessage] | None = None,
+    event_stream_handler: EventStreamHandler | None = None,
 ) -> AgentRunResult[AgentResponse]:
     """Create or update tasks based on the given instruction.
 
@@ -59,6 +61,7 @@ async def run_tasks_agent(
         instruction: The task creation/update instruction
         deps: Agent dependencies
         message_history: Optional message history for conversation continuity
+        event_stream_handler: Optional callback for streaming events
 
     Returns:
         AgentRunResult containing the task creation process output
@@ -80,6 +83,7 @@ async def run_tasks_agent(
             deps=deps,
             message_history=message_history,
             usage_limits=usage_limits,
+            event_stream_handler=event_stream_handler,
         )
 
         logger.debug("✅ Task creation completed successfully")

--- a/src/shotgun/prompts/agents/export.j2
+++ b/src/shotgun/prompts/agents/export.j2
@@ -10,6 +10,8 @@ Your primary job is to generate Agents.md or CLAUDE.md files following the https
 
 {% include 'agents/partials/common_agent_system_prompt.j2' %}
 
+{% include 'agents/partials/router_delegation_mode.j2' %}
+
 ## MEMORY MANAGEMENT PROTOCOL
 
 - You can write to ANY file EXCEPT protected files

--- a/src/shotgun/prompts/agents/partials/router_delegation_mode.j2
+++ b/src/shotgun/prompts/agents/partials/router_delegation_mode.j2
@@ -1,0 +1,20 @@
+{% if sub_agent_context and sub_agent_context.is_router_delegated %}
+## ROUTER DELEGATION MODE
+
+You are being orchestrated by the Router agent. Adjust your behavior:
+
+**Current Task Context:**
+{% if sub_agent_context.plan_goal %}
+- Plan Goal: {{ sub_agent_context.plan_goal }}
+{% endif %}
+{% if sub_agent_context.current_step_title %}
+- Current Step: {{ sub_agent_context.current_step_title }}
+{% endif %}
+
+**Behavioral Adjustments:**
+- Be more concise - the router handles user communication
+- Focus only on your specific task - don't suggest handoffs to other agents
+- Return structured results without excessive explanations
+- Skip the greeting and pleasantries
+- Don't suggest using Shift+Tab to switch agents - the router handles orchestration
+{% endif %}

--- a/src/shotgun/prompts/agents/plan.j2
+++ b/src/shotgun/prompts/agents/plan.j2
@@ -6,6 +6,8 @@ Your job is to help create comprehensive, actionable plans for software projects
 
 {% include 'agents/partials/common_agent_system_prompt.j2' %}
 
+{% include 'agents/partials/router_delegation_mode.j2' %}
+
 ## YOUR SCOPE AND HANDOFFS
 
 You are the **Plan agent**. Your file is `plan.md` - this is the ONLY file you can write to.

--- a/src/shotgun/prompts/agents/research.j2
+++ b/src/shotgun/prompts/agents/research.j2
@@ -4,6 +4,8 @@ Your job is to help the user research various subjects related to their software
 
 {% include 'agents/partials/common_agent_system_prompt.j2' %}
 
+{% include 'agents/partials/router_delegation_mode.j2' %}
+
 ## YOUR SCOPE AND HANDOFFS
 
 You are the **Research agent**. Your files are `research.md` and `.shotgun/research/*` - these are the ONLY locations you can write to.

--- a/src/shotgun/prompts/agents/specify.j2
+++ b/src/shotgun/prompts/agents/specify.j2
@@ -6,6 +6,8 @@ Transform requirements into detailed, actionable specifications that development
 
 {% include 'agents/partials/common_agent_system_prompt.j2' %}
 
+{% include 'agents/partials/router_delegation_mode.j2' %}
+
 ## YOUR SCOPE AND HANDOFFS
 
 You are the **Specification agent**. Your files are `specification.md` and `.shotgun/contracts/*` - these are the ONLY files you can write to.

--- a/src/shotgun/prompts/agents/tasks.j2
+++ b/src/shotgun/prompts/agents/tasks.j2
@@ -4,6 +4,8 @@ Your job is to help create and manage actionable tasks for software projects and
 
 {% include 'agents/partials/common_agent_system_prompt.j2' %}
 
+{% include 'agents/partials/router_delegation_mode.j2' %}
+
 ## YOUR SCOPE AND HANDOFFS
 
 You are the **Tasks agent**. Your file is `tasks.md` - this is the ONLY file you can write to.

--- a/test/unit/agents/router/test_delegation.py
+++ b/test/unit/agents/router/test_delegation.py
@@ -50,6 +50,7 @@ def mock_router_deps():
     deps.max_iterations = 100
     deps.queue = Queue()  # Must be a Queue instance
     deps.tasks = []
+    deps.parent_stream_handler = None  # For streaming support
     return deps
 
 
@@ -531,3 +532,71 @@ async def test_sub_agent_cached_after_first_use(mock_context, mock_agent_result)
         # Second call - should reuse cached agent
         await _run_sub_agent(mock_context, AgentType.RESEARCH, "Task 2")
         assert create_call_count == 1  # Still 1 - no new creation
+
+
+# =============================================================================
+# Tests for streaming support (Stage 10)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_run_sub_agent_passes_stream_handler(mock_context, mock_agent_result):
+    """Test that parent_stream_handler is passed to sub-agent run function."""
+    mock_agent = MagicMock()
+    mock_sub_deps = _create_mock_sub_agent_deps()
+    mock_context.deps.sub_agent_cache = {}
+
+    # Set up a mock stream handler
+    mock_stream_handler = AsyncMock()
+    mock_context.deps.parent_stream_handler = mock_stream_handler
+
+    captured_kwargs = {}
+
+    async def capture_run_kwargs(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return mock_agent_result
+
+    with patch.dict(
+        "shotgun.agents.router.tools.delegation_tools.AGENT_FACTORIES",
+        {
+            AgentType.RESEARCH: (
+                AsyncMock(return_value=(mock_agent, mock_sub_deps)),
+                capture_run_kwargs,
+            )
+        },
+    ):
+        await _run_sub_agent(mock_context, AgentType.RESEARCH, "Test task")
+
+    # Verify that the event_stream_handler was passed
+    assert "event_stream_handler" in captured_kwargs
+    assert captured_kwargs["event_stream_handler"] is mock_stream_handler
+
+
+@pytest.mark.asyncio
+async def test_run_sub_agent_none_stream_handler(mock_context, mock_agent_result):
+    """Test that None stream handler is passed when not set."""
+    mock_agent = MagicMock()
+    mock_sub_deps = _create_mock_sub_agent_deps()
+    mock_context.deps.sub_agent_cache = {}
+    mock_context.deps.parent_stream_handler = None
+
+    captured_kwargs = {}
+
+    async def capture_run_kwargs(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return mock_agent_result
+
+    with patch.dict(
+        "shotgun.agents.router.tools.delegation_tools.AGENT_FACTORIES",
+        {
+            AgentType.RESEARCH: (
+                AsyncMock(return_value=(mock_agent, mock_sub_deps)),
+                capture_run_kwargs,
+            )
+        },
+    ):
+        await _run_sub_agent(mock_context, AgentType.RESEARCH, "Test task")
+
+    # Verify that event_stream_handler was passed but is None
+    assert "event_stream_handler" in captured_kwargs
+    assert captured_kwargs["event_stream_handler"] is None

--- a/test/unit/agents/test_common.py
+++ b/test/unit/agents/test_common.py
@@ -193,6 +193,7 @@ def test_build_agent_system_prompt_research_agent():
     """Test build_agent_system_prompt for research agent type."""
     mock_context = MagicMock()
     mock_context.deps.interactive_mode = True
+    mock_context.deps.sub_agent_context = None
 
     with patch("shotgun.agents.common.PromptLoader") as mock_loader_class:
         mock_loader = MagicMock()
@@ -206,6 +207,7 @@ def test_build_agent_system_prompt_research_agent():
             "agents/research.j2",
             interactive_mode=True,
             mode="research",
+            sub_agent_context=None,
         )
 
 
@@ -213,6 +215,7 @@ def test_build_agent_system_prompt_custom_context():
     """Test build_agent_system_prompt with custom context name."""
     mock_context = MagicMock()
     mock_context.deps.interactive_mode = False
+    mock_context.deps.sub_agent_context = None
 
     with patch("shotgun.agents.common.PromptLoader") as mock_loader_class:
         mock_loader = MagicMock()
@@ -226,6 +229,7 @@ def test_build_agent_system_prompt_custom_context():
             "agents/plan.j2",
             interactive_mode=False,
             mode="plan",
+            sub_agent_context=None,
         )
 
 
@@ -233,6 +237,7 @@ def test_build_agent_system_prompt_unknown_agent_type():
     """Test build_agent_system_prompt with unknown agent type."""
     mock_context = MagicMock()
     mock_context.deps.interactive_mode = True
+    mock_context.deps.sub_agent_context = None
 
     with patch("shotgun.agents.common.PromptLoader") as mock_loader_class:
         mock_loader = MagicMock()
@@ -246,6 +251,7 @@ def test_build_agent_system_prompt_unknown_agent_type():
             "agents/unknown.j2",
             interactive_mode=True,
             mode="unknown",
+            sub_agent_context=None,
         )
 
 

--- a/test/unit/agents/test_research_system_prompt.py
+++ b/test/unit/agents/test_research_system_prompt.py
@@ -14,6 +14,7 @@ def mock_context():
     context = MagicMock()
     context.deps = MagicMock(spec=AgentDeps)
     context.deps.interactive_mode = True
+    context.deps.sub_agent_context = None
     return context
 
 
@@ -58,6 +59,7 @@ def test_research_system_prompt_template_loading():
 
     mock_context = MagicMock()
     mock_context.deps.interactive_mode = True
+    mock_context.deps.sub_agent_context = None
 
     with patch("shotgun.agents.common.PromptLoader") as mock_loader_class:
         mock_loader = MagicMock()
@@ -71,5 +73,6 @@ def test_research_system_prompt_template_loading():
             "agents/research.j2",
             interactive_mode=True,
             mode="research",
+            sub_agent_context=None,
         )
         assert result == "Test system prompt"


### PR DESCRIPTION
## Summary

- Add `router_delegation_mode.j2` partial template that tells sub-agents they're being orchestrated by Router
- Pass `sub_agent_context` to all sub-agent prompts via `build_agent_system_prompt()`
- Add `EventStreamHandler` type and streaming support to `run_agent()` in common.py
- Update all 5 sub-agent run functions to accept `event_stream_handler` parameter
- Add `parent_stream_handler` field to `RouterDeps` for forwarding streaming events
- Update `_run_sub_agent()` to pass stream handler to sub-agents

## Test plan

- [x] Verify `router_delegation_mode.j2` template renders correctly when `sub_agent_context` is set
- [x] Verify all unit tests pass for delegation tools
- [x] Verify streaming handler is passed through delegation chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)