### PR TITLE
feat(router): polish and cleanup for Router MVP (Stage 13)

### DIFF
--- a/src/shotgun/agents/router/tools/plan_tools.py
+++ b/src/shotgun/agents/router/tools/plan_tools.py
@@ -89,13 +89,17 @@ async def create_plan(
     if ctx.deps.router_mode == RouterMode.PLANNING and plan.needs_approval():
         ctx.deps.pending_approval = PendingApproval(plan=plan)
         ctx.deps.approval_status = PlanApprovalStatus.PENDING
+        # Plan is NOT executing yet - user must approve first
+        ctx.deps.is_executing = False
         logger.debug(
             "Set pending approval for plan with %d steps",
             len(steps),
         )
     else:
-        # Single-step plans or Drafting mode - skip approval
+        # Single-step plans or Drafting mode - skip approval and start executing
         ctx.deps.approval_status = PlanApprovalStatus.SKIPPED
+        ctx.deps.is_executing = True
+        logger.debug("Plan approved automatically, is_executing=True")
 
     logger.info(
         "Created execution plan with %d steps: %s",
@@ -149,9 +153,13 @@ async def mark_step_done(
             ):
                 plan.current_step_index += 1
 
+            # Check if plan is complete
+            if plan.is_complete():
+                ctx.deps.is_executing = False
+                logger.debug("Plan complete, is_executing=False")
             # Set pending checkpoint for Planning mode
             # The TUI will detect this and show the StepCheckpointWidget
-            if ctx.deps.router_mode == RouterMode.PLANNING:
+            elif ctx.deps.router_mode == RouterMode.PLANNING:
                 next_step = plan.next_step()
                 ctx.deps.pending_checkpoint = PendingCheckpoint(
                     completed_step=step, next_step=next_step

--- a/src/shotgun/tui/components/status_bar.py
+++ b/src/shotgun/tui/components/status_bar.py
@@ -37,12 +37,12 @@ class StatusBar(Widget):
             return (
                 "[$foreground-muted][bold $text]esc[/] to stop • "
                 "[bold $text]enter[/] to send • [bold $text]ctrl+j[/] for newline • "
-                "[bold $text]ctrl+p[/] command palette • [bold $text]shift+tab[/] cycle modes • "
+                "[bold $text]ctrl+p[/] command palette • [bold $text]shift+tab[/] toggle mode • "
                 "/help for commands[/]"
             )
         else:
             return (
                 "[$foreground-muted][bold $text]enter[/] to send • "
                 "[bold $text]ctrl+j[/] for newline • [bold $text]ctrl+p[/] command palette • "
-                "[bold $text]shift+tab[/] cycle modes • /help for commands[/]"
+                "[bold $text]shift+tab[/] toggle mode • /help for commands[/]"
             )

--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -414,27 +414,15 @@ class ChatScreen(Screen[None]):
         return None
 
     def action_toggle_mode(self) -> None:
-        """Toggle mode - Router mode toggle OR legacy agent cycling."""
+        """Toggle between Planning and Drafting modes for Router."""
+        from shotgun.agents.router.models import RouterDeps, RouterMode
+
         # Prevent mode switching during Q&A
         if self.qa_mode:
             self.agent_manager.add_hint_message(
                 HintMessage(message="⚠️ Cannot switch modes while answering questions")
             )
             return
-
-        # Check if using Router agent
-        from shotgun.agents.router.models import RouterDeps
-
-        if isinstance(self.deps, RouterDeps):
-            # Router mode: toggle Planning ↔ Drafting
-            self._toggle_router_mode()
-        else:
-            # Legacy mode: cycle through agents
-            self._cycle_legacy_agents()
-
-    def _toggle_router_mode(self) -> None:
-        """Toggle between Planning and Drafting modes for Router."""
-        from shotgun.agents.router.models import RouterDeps, RouterMode
 
         if not isinstance(self.deps, RouterDeps):
             return
@@ -443,6 +431,13 @@ class ChatScreen(Screen[None]):
         if self.deps.is_executing:
             self.agent_manager.add_hint_message(
                 HintMessage(message="⚠️ Cannot switch modes during plan execution")
+            )
+            return
+
+        # Prevent mode switching while sub-agent is active
+        if self.deps.active_sub_agent is not None:
+            self.agent_manager.add_hint_message(
+                HintMessage(message="⚠️ Cannot switch modes while sub-agent is running")
             )
             return
 
@@ -464,20 +459,6 @@ class ChatScreen(Screen[None]):
 
         # Update UI
         self.widget_coordinator.update_for_mode_change(self.mode)
-        self.call_later(lambda: self.widget_coordinator.update_prompt_input(focus=True))
-
-    def _cycle_legacy_agents(self) -> None:
-        """Cycle through legacy 5-agent system."""
-        modes = [
-            AgentType.RESEARCH,
-            AgentType.SPECIFY,
-            AgentType.PLAN,
-            AgentType.TASKS,
-            AgentType.EXPORT,
-        ]
-        self.mode = modes[(modes.index(self.mode) + 1) % len(modes)]
-        self.agent_manager.set_agent(self.mode)
-        # Re-focus input after mode change
         self.call_later(lambda: self.widget_coordinator.update_prompt_input(focus=True))
 
     def _save_router_mode(self, mode: str) -> None:

--- a/src/shotgun/tui/screens/chat_screen/command_providers.py
+++ b/src/shotgun/tui/screens/chat_screen/command_providers.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, cast
 
 from textual.command import DiscoveryHit, Hit, Provider
 
-from shotgun.agents.models import AgentType
 from shotgun.codebase.models import CodebaseGraph
 from shotgun.tui.screens.chat_screen.hint_message import HintMessage
 from shotgun.tui.screens.model_picker import ModelPickerScreen
@@ -11,92 +10,6 @@ from shotgun.tui.screens.provider_config import ProviderConfigScreen
 
 if TYPE_CHECKING:
     from shotgun.tui.screens.chat import ChatScreen
-
-
-class AgentModeProvider(Provider):
-    """Command provider for agent mode switching."""
-
-    @property
-    def chat_screen(self) -> "ChatScreen":
-        from shotgun.tui.screens.chat import ChatScreen
-
-        return cast(ChatScreen, self.screen)
-
-    def set_mode(self, mode: AgentType) -> None:
-        """Switch to research mode."""
-        self.chat_screen.mode = mode
-
-    async def discover(self) -> AsyncGenerator[DiscoveryHit, None]:
-        """Provide default mode switching commands when palette opens."""
-        yield DiscoveryHit(
-            "Switch to Research Mode",
-            lambda: self.set_mode(AgentType.RESEARCH),
-            help="🔬 Research topics with web search and synthesize findings",
-        )
-        yield DiscoveryHit(
-            "Switch to Specify Mode",
-            lambda: self.set_mode(AgentType.SPECIFY),
-            help="📝 Create detailed specifications and requirements documents",
-        )
-        yield DiscoveryHit(
-            "Switch to Plan Mode",
-            lambda: self.set_mode(AgentType.PLAN),
-            help="📋 Create comprehensive, actionable plans with milestones",
-        )
-        yield DiscoveryHit(
-            "Switch to Tasks Mode",
-            lambda: self.set_mode(AgentType.TASKS),
-            help="✅ Generate specific, actionable tasks from research and plans",
-        )
-        yield DiscoveryHit(
-            "Switch to Export Mode",
-            lambda: self.set_mode(AgentType.EXPORT),
-            help="📤 Export artifacts and findings to various formats",
-        )
-
-    async def search(self, query: str) -> AsyncGenerator[Hit, None]:
-        """Search for mode commands."""
-        matcher = self.matcher(query)
-
-        commands = [
-            (
-                "Switch to Research Mode",
-                "🔬 Research topics with web search and synthesize findings",
-                lambda: self.set_mode(AgentType.RESEARCH),
-                AgentType.RESEARCH,
-            ),
-            (
-                "Switch to Specify Mode",
-                "📝 Create detailed specifications and requirements documents",
-                lambda: self.set_mode(AgentType.SPECIFY),
-                AgentType.SPECIFY,
-            ),
-            (
-                "Switch to Plan Mode",
-                "📋 Create comprehensive, actionable plans with milestones",
-                lambda: self.set_mode(AgentType.PLAN),
-                AgentType.PLAN,
-            ),
-            (
-                "Switch to Tasks Mode",
-                "✅ Generate specific, actionable tasks from research and plans",
-                lambda: self.set_mode(AgentType.TASKS),
-                AgentType.TASKS,
-            ),
-            (
-                "Switch to Export Mode",
-                "📤 Export artifacts and findings to various formats",
-                lambda: self.set_mode(AgentType.EXPORT),
-                AgentType.EXPORT,
-            ),
-        ]
-
-        for title, help_text, callback, mode in commands:
-            if self.chat_screen.mode == mode:
-                continue
-            score = matcher.match(title)
-            if score > 0:
-                yield Hit(score, matcher.highlight(title), callback, help=help_text)
 
 
 class UsageProvider(Provider):

--- a/src/shotgun/tui/screens/onboarding.py
+++ b/src/shotgun/tui/screens/onboarding.py
@@ -427,40 +427,45 @@ Here are some helpful resources to get you up to speed with Shotgun:
 """
 
     def _page_2_modes(self) -> str:
-        """Page 2: Explanation of the 5 modes."""
+        """Page 2: Explanation of the Router and its modes."""
         return """
-## Understanding Shotgun's 5 Modes
+## Understanding Shotgun's Router
 
-Shotgun has 5 specialized modes, each designed for specific tasks. Each mode writes to its own dedicated file in `.shotgun/`:
+Shotgun uses an intelligent **Router** that orchestrates your workflow automatically. Just describe what you need, and the Router will coordinate research, specifications, planning, and tasks for you.
 
-### 🔬 Research Mode
-Research topics with web search and synthesize findings. Perfect for gathering information and exploring new concepts.
+### Two Operating Modes
 
-**Writes to:** `.shotgun/research.md`
+The Router operates in two modes, which you can toggle with `Shift+Tab`:
 
-### 📝 Specify Mode
-Create detailed specifications and requirements documents. Great for planning features and documenting requirements.
+### 📋 Planning Mode (Default)
+- **Incremental execution**: Does one step at a time
+- **Asks clarifying questions** before complex tasks
+- **Shows plan for approval** before executing multi-step work
+- **Confirms before cascading** changes to dependent files
 
-**Writes to:** `.shotgun/specification.md`
+Best for: Complex tasks, learning the workflow, staying in control
 
-### 📋 Plan Mode
-Create comprehensive, actionable plans with milestones. Ideal for breaking down large projects into manageable steps.
+### ✍️ Drafting Mode
+- **Auto-executes** plans without stopping for approval
+- **Makes reasonable assumptions** instead of asking questions
+- **Updates all dependent files** automatically
 
-**Writes to:** `.shotgun/plan.md`
-
-### ✅ Tasks Mode
-Generate specific, actionable tasks from research and plans. Best for getting concrete next steps and action items.
-
-**Writes to:** `.shotgun/tasks.md`
-
-### 📤 Export Mode
-Export artifacts and findings to various formats. Creates documentation like Claude.md (AI instructions), Agent.md (agent specs), PRDs, and other deliverables. Can write to any file in `.shotgun/` except the mode-specific files above.
-
-**Writes to:** `.shotgun/Claude.md`, `.shotgun/Agent.md`, `.shotgun/PRD.md`, etc.
+Best for: Routine tasks, experienced users, speed-focused work
 
 ---
 
-**Tip:** You can switch between modes using `Shift+Tab` or `Ctrl+P` to open the command palette!
+### Files Created
+
+The Router manages these files in `.shotgun/`:
+- `research.md` - Research findings
+- `specification.md` - Detailed specifications
+- `plan.md` - Implementation plans
+- `tasks.md` - Actionable task lists
+- `exports/` - Documentation exports
+
+---
+
+**Tip:** Press `Shift+Tab` to toggle between Planning and Drafting modes!
 """
 
     def _page_3_prompts(self) -> str:
@@ -485,12 +490,11 @@ Provide relevant context about what you're trying to accomplish:
 
 > "I'm working on the payment flow. I need to add support for refunds."
 
-### 4. Use the Right Mode
-Switch to the appropriate mode for your task:
-- Use **Research** for exploration
-- Use **Specify** for requirements
-- Use **Plan** for implementation strategy
-- Use **Tasks** for actionable next steps
+### 4. Let the Router Guide You
+The Router will automatically coordinate the right workflow:
+- Describe what you want to accomplish
+- In Planning mode, it will ask clarifying questions first
+- In Drafting mode, it will execute immediately
 
 ---
 

--- a/src/shotgun/tui/utils/mode_progress.py
+++ b/src/shotgun/tui/utils/mode_progress.py
@@ -113,93 +113,24 @@ class ModeProgressChecker:
 
 
 class PlaceholderHints:
-    """Manages dynamic placeholder hints for each mode based on progress."""
+    """Manages dynamic placeholder hints for the Router agent."""
 
-    # Placeholder variations for each mode and state
+    # Placeholder variations for Router mode
     HINTS = {
-        # Research mode
-        AgentType.RESEARCH: {
+        AgentType.ROUTER: {
             False: [
-                "Research a product or idea (SHIFT+TAB to cycle modes)",
-                "What would you like to explore? Start your research journey here (SHIFT+TAB to switch modes)",
-                "Dive into discovery mode - research anything that sparks curiosity (SHIFT+TAB for mode menu)",
-                "Ready to investigate? Feed me your burning questions (SHIFT+TAB to explore other modes)",
-                " 🔍 The research rabbit hole awaits! What shall we uncover? (SHIFT+TAB for mode carousel)",
+                "What would you like to work on? (SHIFT+TAB to toggle Planning/Drafting)",
+                "Ask me to research, plan, or implement anything (SHIFT+TAB toggles mode)",
+                "Describe your goal and I'll help break it down (SHIFT+TAB for mode toggle)",
+                "Ready to help with research, specs, plans, or tasks (SHIFT+TAB toggles mode)",
+                "Tell me what you need - I'll coordinate the work (SHIFT+TAB for Planning/Drafting)",
             ],
             True: [
-                "Research complete! SHIFT+TAB to move to Specify mode",
-                "Great research! Time to specify (SHIFT+TAB to Specify mode)",
-                "Research done! Ready to create specifications (SHIFT+TAB to Specify)",
-                "Findings gathered! Move to specifications (SHIFT+TAB for Specify mode)",
-                " 🎯 Research complete! Advance to Specify mode (SHIFT+TAB)",
-            ],
-        },
-        # Specify mode
-        AgentType.SPECIFY: {
-            False: [
-                "Create detailed specifications and requirements (SHIFT+TAB to switch modes)",
-                "Define your project specifications here (SHIFT+TAB to navigate modes)",
-                "Time to get specific - write comprehensive specs (SHIFT+TAB for mode options)",
-                "Specification station: Document requirements and designs (SHIFT+TAB to change modes)",
-                " 📋 Spec-tacular time! Let's architect your ideas (SHIFT+TAB for mode magic)",
-            ],
-            True: [
-                "Specifications complete! SHIFT+TAB to create a Plan",
-                "Specs ready! Time to plan (SHIFT+TAB to Plan mode)",
-                "Requirements defined! Move to planning (SHIFT+TAB to Plan)",
-                "Specifications done! Create your roadmap (SHIFT+TAB for Plan mode)",
-                " 🚀 Specs complete! Advance to Plan mode (SHIFT+TAB)",
-            ],
-        },
-        # Tasks mode
-        AgentType.TASKS: {
-            False: [
-                "Break down your project into actionable tasks (SHIFT+TAB for modes)",
-                "Task creation time! Define your implementation steps (SHIFT+TAB to switch)",
-                "Ready to get tactical? Create your task list (SHIFT+TAB for mode options)",
-                "Task command center: Organize your work items (SHIFT+TAB to navigate)",
-                " ✅ Task mode activated! Break it down into bite-sized pieces (SHIFT+TAB)",
-            ],
-            True: [
-                "Tasks defined! Ready to export or cycle back (SHIFT+TAB)",
-                "Task list complete! Export your work (SHIFT+TAB to Export)",
-                "All tasks created! Time to export (SHIFT+TAB for Export mode)",
-                "Implementation plan ready! Export everything (SHIFT+TAB to Export)",
-                " 🎊 Tasks complete! Export your masterpiece (SHIFT+TAB)",
-            ],
-        },
-        # Export mode
-        AgentType.EXPORT: {
-            False: [
-                "Export your complete project documentation (SHIFT+TAB for modes)",
-                "Ready to package everything? Export time! (SHIFT+TAB to switch)",
-                "Export station: Generate deliverables (SHIFT+TAB for mode menu)",
-                "Time to share your work! Export documents (SHIFT+TAB to navigate)",
-                " 📦 Export mode! Package and share your creation (SHIFT+TAB)",
-            ],
-            True: [
-                "Exported! Start new research or continue refining (SHIFT+TAB)",
-                "Export complete! New cycle begins (SHIFT+TAB to Research)",
-                "All exported! Ready for another round (SHIFT+TAB for Research)",
-                "Documents exported! Start fresh (SHIFT+TAB to Research mode)",
-                " 🎉 Export complete! Begin a new adventure (SHIFT+TAB)",
-            ],
-        },
-        # Plan mode
-        AgentType.PLAN: {
-            False: [
-                "Create a strategic plan for your project (SHIFT+TAB for modes)",
-                "Planning phase: Map out your roadmap (SHIFT+TAB to switch)",
-                "Time to strategize! Create your project plan (SHIFT+TAB for options)",
-                "Plan your approach and milestones (SHIFT+TAB to navigate)",
-                " 🗺️ Plan mode! Chart your course to success (SHIFT+TAB)",
-            ],
-            True: [
-                "Plan complete! Move to Tasks mode (SHIFT+TAB)",
-                "Strategy ready! Time for tasks (SHIFT+TAB to Tasks mode)",
-                "Roadmap done! Create task list (SHIFT+TAB for Tasks)",
-                "Planning complete! Break into tasks (SHIFT+TAB to Tasks)",
-                " ⚡ Plan ready! Advance to Tasks mode (SHIFT+TAB)",
+                "Continue working or start something new (SHIFT+TAB toggles mode)",
+                "What's next? (SHIFT+TAB to toggle Planning/Drafting)",
+                "Ready for the next task (SHIFT+TAB toggles Planning/Drafting)",
+                "Let's keep going! (SHIFT+TAB to toggle mode)",
+                "What else can I help with? (SHIFT+TAB for mode toggle)",
             ],
         },
     }
@@ -224,19 +155,22 @@ class PlaceholderHints:
         Returns:
             A contextual hint string for the placeholder.
         """
+        # Always use Router hints since Router is the only user-facing agent
+        mode_key = AgentType.ROUTER
+
         # Default hint if mode not configured
-        if current_mode not in self.HINTS:
-            return f"Enter your {current_mode.value} mode prompt (SHIFT+TAB to switch modes)"
+        if mode_key not in self.HINTS:
+            return "Enter your prompt (SHIFT+TAB to toggle Planning/Drafting mode)"
 
         # For placeholder text, we default to "no content" state (initial hints)
         # This avoids async file system checks in the UI rendering path
         has_content = False
 
         # Get hint variations for this mode and state
-        hints_list = self.HINTS[current_mode][has_content]
+        hints_list = self.HINTS[mode_key][has_content]
 
         # Cache key for this mode and state
-        cache_key = (current_mode, has_content)
+        cache_key = (mode_key, has_content)
 
         # Force refresh or first time
         if force_refresh or cache_key not in self._cached_hints:

--- a/test/unit/agents/router/test_full_workflow.py
+++ b/test/unit/agents/router/test_full_workflow.py
@@ -1,0 +1,297 @@
+"""Integration tests for Router agent full workflow.
+
+These tests verify the complete router workflow including:
+- Plan creation and state management
+- Planning vs Drafting mode behavior
+- is_executing flag lifecycle
+- Checkpoint and approval handling
+
+Note: These tests use real RouterDeps but mock the LLM to focus on
+workflow mechanics. They test the end-to-end plan workflow.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic_ai import RunContext
+
+from shotgun.agents.models import FileOperationTracker
+from shotgun.agents.router.models import (
+    CreatePlanInput,
+    ExecutionPlan,
+    ExecutionStep,
+    ExecutionStepInput,
+    MarkStepDoneInput,
+    PlanApprovalStatus,
+    RouterDeps,
+    RouterMode,
+)
+from shotgun.agents.router.tools.plan_tools import create_plan, mark_step_done
+
+
+@pytest.fixture
+def router_deps():
+    """Create mock RouterDeps for testing."""
+    deps = MagicMock(spec=RouterDeps)
+    deps.router_mode = RouterMode.PLANNING
+    deps.current_plan = None
+    deps.file_tracker = FileOperationTracker()
+    deps.pending_approval = None
+    deps.pending_checkpoint = None
+    deps.is_executing = False
+    deps.active_sub_agent = None
+    deps.on_plan_changed = None
+    deps.approval_status = PlanApprovalStatus.SKIPPED  # Default
+    return deps
+
+
+@pytest.fixture
+def run_context(router_deps):
+    """Create a mock RunContext with mock RouterDeps."""
+    ctx = MagicMock(spec=RunContext)
+    ctx.deps = router_deps
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_router_creates_execution_plan(run_context):
+    """Router creates an ExecutionPlan from user request."""
+    input_data = CreatePlanInput(
+        goal="Implement user authentication",
+        steps=[
+            ExecutionStepInput(
+                id="research",
+                title="Research auth patterns",
+                objective="Find best practices for auth",
+            ),
+            ExecutionStepInput(
+                id="spec",
+                title="Write specification",
+                objective="Document auth requirements",
+            ),
+            ExecutionStepInput(
+                id="tasks",
+                title="Create tasks",
+                objective="Break down implementation",
+            ),
+        ],
+    )
+
+    result = await create_plan(run_context, input_data)
+
+    assert result.success is True
+    assert run_context.deps.current_plan is not None
+    assert run_context.deps.current_plan.goal == "Implement user authentication"
+    assert len(run_context.deps.current_plan.steps) == 3
+    assert run_context.deps.current_plan.current_step_index == 0
+
+
+@pytest.mark.asyncio
+async def test_router_planning_mode_creates_pending_approval(run_context):
+    """Planning mode creates pending approval for multi-step plans."""
+    run_context.deps.router_mode = RouterMode.PLANNING
+
+    input_data = CreatePlanInput(
+        goal="Build feature",
+        steps=[
+            ExecutionStepInput(id="step-1", title="Step 1", objective="First"),
+            ExecutionStepInput(id="step-2", title="Step 2", objective="Second"),
+        ],
+    )
+
+    await create_plan(run_context, input_data)
+
+    # Should have pending approval
+    assert run_context.deps.pending_approval is not None
+    assert run_context.deps.approval_status == PlanApprovalStatus.PENDING
+    # Should NOT be executing yet (waiting for approval)
+    assert run_context.deps.is_executing is False
+
+
+@pytest.mark.asyncio
+async def test_router_planning_mode_creates_checkpoints(run_context):
+    """Planning mode creates checkpoints after completing steps."""
+    run_context.deps.router_mode = RouterMode.PLANNING
+    run_context.deps.is_executing = True
+
+    # Create a plan
+    plan = ExecutionPlan(
+        goal="Test plan",
+        steps=[
+            ExecutionStep(id="step-1", title="First", objective="Do first"),
+            ExecutionStep(id="step-2", title="Second", objective="Do second"),
+            ExecutionStep(id="step-3", title="Third", objective="Do third"),
+        ],
+        current_step_index=0,
+    )
+    run_context.deps.current_plan = plan
+
+    # Mark first step done
+    result = await mark_step_done(run_context, MarkStepDoneInput(step_id="step-1"))
+
+    assert result.success is True
+    # Should have pending checkpoint
+    assert run_context.deps.pending_checkpoint is not None
+    checkpoint = run_context.deps.pending_checkpoint
+    assert checkpoint.completed_step.id == "step-1"
+    assert checkpoint.next_step is not None
+    assert checkpoint.next_step.id == "step-3"
+
+
+@pytest.mark.asyncio
+async def test_router_drafting_mode_skips_approval(run_context):
+    """Drafting mode skips approval and starts executing immediately."""
+    run_context.deps.router_mode = RouterMode.DRAFTING
+
+    input_data = CreatePlanInput(
+        goal="Quick task",
+        steps=[
+            ExecutionStepInput(id="step-1", title="Step 1", objective="First"),
+            ExecutionStepInput(id="step-2", title="Step 2", objective="Second"),
+        ],
+    )
+
+    await create_plan(run_context, input_data)
+
+    # Should NOT have pending approval in Drafting mode
+    assert run_context.deps.pending_approval is None
+    assert run_context.deps.approval_status == PlanApprovalStatus.SKIPPED
+    # Should be executing immediately
+    assert run_context.deps.is_executing is True
+
+
+@pytest.mark.asyncio
+async def test_router_drafting_mode_skips_checkpoints(run_context):
+    """Drafting mode executes without checkpoints."""
+    run_context.deps.router_mode = RouterMode.DRAFTING
+    run_context.deps.is_executing = True
+
+    # Create a plan
+    plan = ExecutionPlan(
+        goal="Quick plan",
+        steps=[
+            ExecutionStep(id="step-1", title="First", objective="Do first"),
+            ExecutionStep(id="step-2", title="Second", objective="Do second"),
+        ],
+        current_step_index=0,
+    )
+    run_context.deps.current_plan = plan
+
+    # Mark first step done
+    await mark_step_done(run_context, MarkStepDoneInput(step_id="step-1"))
+
+    # Should NOT have pending checkpoint in Drafting mode
+    assert run_context.deps.pending_checkpoint is None
+
+
+@pytest.mark.asyncio
+async def test_is_executing_flag_lifecycle_single_step(run_context):
+    """is_executing flag is set correctly for single-step plans."""
+    run_context.deps.router_mode = RouterMode.PLANNING
+
+    # Create single-step plan (auto-approved)
+    input_data = CreatePlanInput(
+        goal="Simple task",
+        steps=[
+            ExecutionStepInput(id="step-1", title="Do it", objective="Just do it"),
+        ],
+    )
+
+    await create_plan(run_context, input_data)
+
+    # Single-step plans start executing immediately
+    assert run_context.deps.is_executing is True
+
+    # Complete the step
+    await mark_step_done(run_context, MarkStepDoneInput(step_id="step-1"))
+
+    # Should be false after plan completes
+    assert run_context.deps.is_executing is False
+
+
+@pytest.mark.asyncio
+async def test_is_executing_flag_lifecycle_multi_step(run_context):
+    """is_executing flag lifecycle for multi-step plans."""
+    run_context.deps.router_mode = RouterMode.DRAFTING  # Auto-execute
+
+    # Create multi-step plan
+    input_data = CreatePlanInput(
+        goal="Multi-step task",
+        steps=[
+            ExecutionStepInput(id="step-1", title="First", objective="Do first"),
+            ExecutionStepInput(id="step-2", title="Second", objective="Do second"),
+        ],
+    )
+
+    await create_plan(run_context, input_data)
+
+    # Should be executing (drafting mode auto-approves)
+    assert run_context.deps.is_executing is True
+
+    # Complete first step
+    await mark_step_done(run_context, MarkStepDoneInput(step_id="step-1"))
+
+    # Should still be executing (not complete)
+    assert run_context.deps.is_executing is True
+
+    # Complete second step
+    await mark_step_done(run_context, MarkStepDoneInput(step_id="step-2"))
+
+    # Should be false after plan completes
+    assert run_context.deps.is_executing is False
+
+
+@pytest.mark.asyncio
+async def test_plan_complete_detection(run_context):
+    """Test that plan completion is properly detected."""
+    run_context.deps.router_mode = RouterMode.DRAFTING
+    run_context.deps.is_executing = True
+
+    # Create a 3-step plan
+    plan = ExecutionPlan(
+        goal="Test completion",
+        steps=[
+            ExecutionStep(id="step-1", title="Step 1", objective="First"),
+            ExecutionStep(id="step-2", title="Step 2", objective="Second"),
+            ExecutionStep(id="step-3", title="Step 3", objective="Third"),
+        ],
+        current_step_index=0,
+    )
+    run_context.deps.current_plan = plan
+
+    # Verify plan is not complete
+    assert plan.is_complete() is False
+
+    # Complete all steps
+    await mark_step_done(run_context, MarkStepDoneInput(step_id="step-1"))
+    assert plan.is_complete() is False
+
+    await mark_step_done(run_context, MarkStepDoneInput(step_id="step-2"))
+    assert plan.is_complete() is False
+
+    await mark_step_done(run_context, MarkStepDoneInput(step_id="step-3"))
+    assert plan.is_complete() is True
+    assert run_context.deps.is_executing is False
+
+
+@pytest.mark.asyncio
+async def test_plan_panel_callback_invoked(run_context):
+    """Test that on_plan_changed callback is invoked on plan modifications."""
+    callback = MagicMock()
+    run_context.deps.on_plan_changed = callback
+
+    # Create plan
+    input_data = CreatePlanInput(
+        goal="Test callback",
+        steps=[
+            ExecutionStepInput(id="step-1", title="Step", objective="Test"),
+        ],
+    )
+
+    await create_plan(run_context, input_data)
+
+    # Callback should have been invoked with the plan
+    callback.assert_called_once()
+    call_args = callback.call_args[0]
+    assert call_args[0] is not None
+    assert call_args[0].goal == "Test callback"

--- a/test/unit/agents/router/test_plan_tools.py
+++ b/test/unit/agents/router/test_plan_tools.py
@@ -381,3 +381,100 @@ async def test_mark_step_done_skips_checkpoint_in_drafting_mode(
     assert result.success is True
     # Pending checkpoint should NOT be set in Drafting mode
     assert mock_context.deps.pending_checkpoint is None
+
+
+# Tests for is_executing flag behavior
+
+
+@pytest.mark.asyncio
+async def test_create_plan_sets_is_executing_for_single_step(mock_context):
+    """Test that creating a single-step plan sets is_executing=True."""
+    mock_context.deps.is_executing = False
+
+    input_data = CreatePlanInput(
+        goal="Simple task",
+        steps=[
+            ExecutionStepInput(id="step-1", title="Do it", objective="Just do it"),
+        ],
+    )
+
+    await create_plan(mock_context, input_data)
+
+    # Single-step plans skip approval and start executing immediately
+    assert mock_context.deps.is_executing is True
+
+
+@pytest.mark.asyncio
+async def test_create_plan_sets_is_executing_for_drafting_mode(mock_context):
+    """Test that creating a multi-step plan in Drafting mode sets is_executing=True."""
+    mock_context.deps.router_mode = RouterMode.DRAFTING
+    mock_context.deps.is_executing = False
+
+    input_data = CreatePlanInput(
+        goal="Multi-step task",
+        steps=[
+            ExecutionStepInput(id="step-1", title="Step 1", objective="First step"),
+            ExecutionStepInput(id="step-2", title="Step 2", objective="Second step"),
+        ],
+    )
+
+    await create_plan(mock_context, input_data)
+
+    # Drafting mode skips approval and starts executing immediately
+    assert mock_context.deps.is_executing is True
+
+
+@pytest.mark.asyncio
+async def test_create_plan_does_not_set_is_executing_for_multi_step_planning(
+    mock_context,
+):
+    """Test that creating a multi-step plan in Planning mode does NOT set is_executing."""
+    mock_context.deps.router_mode = RouterMode.PLANNING
+    mock_context.deps.is_executing = False
+
+    input_data = CreatePlanInput(
+        goal="Multi-step task",
+        steps=[
+            ExecutionStepInput(id="step-1", title="Step 1", objective="First step"),
+            ExecutionStepInput(id="step-2", title="Step 2", objective="Second step"),
+        ],
+    )
+
+    await create_plan(mock_context, input_data)
+
+    # Multi-step plans in Planning mode need approval first
+    assert mock_context.deps.is_executing is False
+
+
+@pytest.mark.asyncio
+async def test_mark_step_done_clears_is_executing_when_plan_complete(
+    mock_context, sample_plan
+):
+    """Test that completing the last step sets is_executing=False."""
+    mock_context.deps.current_plan = sample_plan
+    mock_context.deps.is_executing = True
+
+    # Mark all steps done
+    await mark_step_done(mock_context, MarkStepDoneInput(step_id="step-1"))
+    await mark_step_done(mock_context, MarkStepDoneInput(step_id="step-2"))
+    await mark_step_done(mock_context, MarkStepDoneInput(step_id="step-3"))
+
+    # Plan is now complete, is_executing should be False
+    assert sample_plan.is_complete() is True
+    assert mock_context.deps.is_executing is False
+
+
+@pytest.mark.asyncio
+async def test_mark_step_done_keeps_is_executing_when_plan_not_complete(
+    mock_context, sample_plan
+):
+    """Test that completing a non-final step keeps is_executing=True."""
+    mock_context.deps.current_plan = sample_plan
+    mock_context.deps.is_executing = True
+
+    # Mark first step done (not the last)
+    await mark_step_done(mock_context, MarkStepDoneInput(step_id="step-1"))
+
+    # Plan is not complete, is_executing should still be True
+    assert sample_plan.is_complete() is False
+    assert mock_context.deps.is_executing is True


### PR DESCRIPTION
## Summary

- Remove deprecated agent switching UI (`_cycle_legacy_agents()`, `AgentModeProvider`)
- Update status bar hint from "cycle modes" to "toggle mode"
- Simplify `mode_progress.py` to Router-only hints (removed 5-agent hints)
- Update onboarding docs to explain Router workflow and Planning/Drafting modes
- Fix `is_executing` flag lifecycle in `plan_tools.py` (was never set to True)
- Add `active_sub_agent` guard to prevent mode switching during sub-agent delegation

## Test plan

- [x] All 1152 unit tests pass
- [x] New `test_full_workflow.py` tests plan creation, approval, checkpoints, and mode behavior
- [x] New `is_executing` flag tests verify correct lifecycle management
- [ ] Manual: Run TUI and verify SHIFT+TAB toggles between Planning/Drafting modes
- [ ] Manual: Verify mode cannot be switched during plan execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)