### PR TITLE
refactor(router): remove codebase and file write tools, delegate to sub-agents

### DIFF
--- a/src/shotgun/agents/router/router.py
+++ b/src/shotgun/agents/router/router.py
@@ -32,16 +32,7 @@ from shotgun.agents.router.tools import (
     mark_step_done,
     remove_step,
 )
-from shotgun.agents.tools import (
-    append_file,
-    codebase_shell,
-    directory_lister,
-    file_read,
-    query_graph,
-    read_file,
-    retrieve_code,
-    write_file,
-)
+from shotgun.agents.tools import read_file
 from shotgun.logging_config import get_logger
 from shotgun.sdk.services import get_codebase_service
 from shotgun.utils import ensure_shotgun_directory_exists
@@ -131,17 +122,12 @@ async def create_router_agent(
     agent.tool(delegate_to_tasks)
     agent.tool(delegate_to_export)
 
-    # Register common file management tools
-    agent.tool(write_file)
-    agent.tool(append_file)
+    # Register read-only file access for .shotgun/ directory
     agent.tool(read_file)
 
-    # Register codebase understanding tools
-    agent.tool(query_graph)
-    agent.tool(retrieve_code)
-    agent.tool(file_read)
-    agent.tool(directory_lister)
-    agent.tool(codebase_shell)
+    # Note: The Router does NOT have write_file, append_file, or codebase tools.
+    # All file modifications and codebase understanding must be delegated to
+    # the appropriate sub-agent (Research, Specify, Plan, Tasks, Export).
 
     logger.debug("Router agent tools registered")
     logger.info(

--- a/src/shotgun/agents/router/tools/delegation_tools.py
+++ b/src/shotgun/agents/router/tools/delegation_tools.py
@@ -29,6 +29,7 @@ from shotgun.agents.router.models import (
 )
 from shotgun.agents.specify import create_specify_agent, run_specify_agent
 from shotgun.agents.tasks import create_tasks_agent, run_tasks_agent
+from shotgun.agents.tools.registry import ToolCategory, register_tool
 from shotgun.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -296,6 +297,11 @@ async def _run_sub_agent(
 # =============================================================================
 
 
+@register_tool(
+    category=ToolCategory.DELEGATION,
+    display_text="Delegating to Research agent",
+    key_arg="task",
+)
 async def delegate_to_research(
     ctx: RunContext[RouterDeps],
     input: DelegationInput,
@@ -323,6 +329,11 @@ async def delegate_to_research(
     )
 
 
+@register_tool(
+    category=ToolCategory.DELEGATION,
+    display_text="Delegating to Specification agent",
+    key_arg="task",
+)
 async def delegate_to_specification(
     ctx: RunContext[RouterDeps],
     input: DelegationInput,
@@ -349,6 +360,11 @@ async def delegate_to_specification(
     )
 
 
+@register_tool(
+    category=ToolCategory.DELEGATION,
+    display_text="Delegating to Plan agent",
+    key_arg="task",
+)
 async def delegate_to_plan(
     ctx: RunContext[RouterDeps],
     input: DelegationInput,
@@ -375,6 +391,11 @@ async def delegate_to_plan(
     )
 
 
+@register_tool(
+    category=ToolCategory.DELEGATION,
+    display_text="Delegating to Tasks agent",
+    key_arg="task",
+)
 async def delegate_to_tasks(
     ctx: RunContext[RouterDeps],
     input: DelegationInput,
@@ -401,6 +422,11 @@ async def delegate_to_tasks(
     )
 
 
+@register_tool(
+    category=ToolCategory.DELEGATION,
+    display_text="Delegating to Export agent",
+    key_arg="task",
+)
 async def delegate_to_export(
     ctx: RunContext[RouterDeps],
     input: DelegationInput,

--- a/src/shotgun/agents/tools/registry.py
+++ b/src/shotgun/agents/tools/registry.py
@@ -31,6 +31,7 @@ class ToolCategory(StrEnum):
     WEB_RESEARCH = "web_research"
     AGENT_RESPONSE = "agent_response"
     PLANNING = "planning"
+    DELEGATION = "delegation"
     UNKNOWN = "unknown"
 
 

--- a/src/shotgun/prompts/agents/router.j2
+++ b/src/shotgun/prompts/agents/router.j2
@@ -210,23 +210,36 @@ Your execution plan is shown in the System Status message above. You don't need 
 
 ## SUB-AGENT DELEGATION
 
-You orchestrate specialized sub-agents through delegation tools:
+You are an orchestrator. You do NOT have tools to write files or analyze the codebase directly. You MUST delegate all work to the appropriate sub-agent.
 
-| Tool | Sub-Agent | Use For |
-|------|-----------|---------|
-| `delegate_to_research` | Research Agent | Finding information, web search, analyzing code |
-| `delegate_to_specification` | Specification Agent | Writing/updating specification.md, creating contracts |
-| `delegate_to_plan` | Plan Agent | Writing/updating plan.md with implementation steps |
-| `delegate_to_tasks` | Tasks Agent | Writing/updating tasks.md with actionable tasks |
-| `delegate_to_export` | Export Agent | Exporting artifacts, generating outputs |
+### Agent File Ownership
 
-### How to Delegate
+Each sub-agent owns specific files and capabilities. Always delegate to the correct agent:
 
-1. Use `delegate_to_research` when you need to gather information or analyze code
-2. Use `delegate_to_specification` when updating the specification or creating contracts
-3. Use `delegate_to_plan` when updating the implementation plan
-4. Use `delegate_to_tasks` when updating the task list
-5. Use `delegate_to_export` when exporting deliverables
+**Research Agent** (`delegate_to_research`)
+- Writes to: `research.md`, `research/` folder
+- Capabilities: Web search, codebase analysis, knowledge graph queries, reading source files
+- Use for: Gathering information, analyzing code, answering questions about the codebase
+
+**Specification Agent** (`delegate_to_specification`)
+- Writes to: `specification.md`, `contracts/` folder
+- Capabilities: Writing specifications, creating Pydantic contracts
+- Use for: Defining requirements, API contracts, data models
+
+**Plan Agent** (`delegate_to_plan`)
+- Writes to: `plan.md`
+- Capabilities: Creating implementation plans with stages
+- Use for: Breaking down work into implementation stages
+
+**Tasks Agent** (`delegate_to_tasks`)
+- Writes to: `tasks.md`
+- Capabilities: Creating actionable task lists
+- Use for: Generating specific development tasks from plans
+
+**Export Agent** (`delegate_to_export`)
+- Writes to: `exports/` folder
+- Capabilities: Generating deliverables, exporting artifacts
+- Use for: Creating final outputs and documentation
 
 ### Delegation Input
 
@@ -250,13 +263,12 @@ Each delegation returns:
 - Provide clear, detailed tasks with enough context in the `task` field
 - Check `files_modified` to know what cascade confirmation may be needed
 - If `has_questions` is True, relay those questions to the user before proceeding
-- You can still use file tools directly for simple reads/edits
 
 ## FILE ACCESS
 
-You have read access to all files in .shotgun/. For writing:
-- Use appropriate caution based on the file's role in the pipeline
-- Remember RULE 3: confirm before cascading to dependent files
+You have **read-only** access to files in `.shotgun/` using `read_file`.
+
+You **cannot** write or modify files directly. To modify any file, delegate to the appropriate sub-agent based on the file ownership above.
 
 ## RESPONSE FORMAT
 

--- a/src/shotgun/tui/screens/chat_screen/history/formatters.py
+++ b/src/shotgun/tui/screens/chat_screen/history/formatters.py
@@ -30,6 +30,53 @@ class ToolFormatter:
         return args if isinstance(args, dict) else {}
 
     @classmethod
+    def _extract_key_arg(
+        cls,
+        args: dict[str, object],
+        key_arg: str,
+        tool_name: str | None = None,
+    ) -> str | None:
+        """Extract key argument value, handling nested args and special cases.
+
+        Supports:
+        - Direct key access: key_arg="query" -> args["query"]
+        - Nested access: key_arg="task" -> args["input"]["task"] (for Pydantic model inputs)
+        - Special handling for codebase_shell
+
+        Args:
+            args: Parsed tool arguments dict
+            key_arg: The key argument to extract
+            tool_name: Optional tool name for special handling
+
+        Returns:
+            The extracted value as a string, or None if not found
+        """
+        if not args or not isinstance(args, dict):
+            return None
+
+        # Special handling for codebase_shell which needs command + args
+        if tool_name == "codebase_shell" and "command" in args:
+            command = args.get("command", "")
+            cmd_args = args.get("args", [])
+            if isinstance(cmd_args, list):
+                args_str = " ".join(str(arg) for arg in cmd_args)
+            else:
+                args_str = ""
+            return f"{command} {args_str}".strip()
+
+        # Direct key access
+        if key_arg in args:
+            return str(args[key_arg])
+
+        # Try nested access through "input" (for Pydantic model inputs)
+        if "input" in args and isinstance(args["input"], dict):
+            input_dict = args["input"]
+            if key_arg in input_dict:
+                return str(input_dict[key_arg])
+
+        return None
+
+    @classmethod
     def format_tool_call_part(cls, part: ToolCallPart) -> str:
         """Format a tool call part using the tool display registry."""
         # Look up the display config for this tool
@@ -44,19 +91,10 @@ class ToolFormatter:
             args = cls.parse_args(part.args)
 
             # Get the key argument value
-            if args and isinstance(args, dict) and display_config.key_arg in args:
-                # Special handling for codebase_shell which needs command + args
-                if part.tool_name == "codebase_shell" and "command" in args:
-                    command = args.get("command", "")
-                    cmd_args = args.get("args", [])
-                    if isinstance(cmd_args, list):
-                        args_str = " ".join(str(arg) for arg in cmd_args)
-                    else:
-                        args_str = ""
-                    key_value = f"{command} {args_str}".strip()
-                else:
-                    key_value = str(args[display_config.key_arg])
-
+            key_value = cls._extract_key_arg(
+                args, display_config.key_arg, part.tool_name
+            )
+            if key_value:
                 # Format: "display_text: key_value"
                 return f"{display_config.display_text}: {cls.truncate(key_value)}"
             else:
@@ -95,8 +133,8 @@ class ToolFormatter:
 
             args = cls.parse_args(part.args)
             # Get the key argument value
-            if args and isinstance(args, dict) and display_config.key_arg in args:
-                key_value = str(args[display_config.key_arg])
+            key_value = cls._extract_key_arg(args, display_config.key_arg)
+            if key_value:
                 # Format: "display_text: key_value"
                 return f"{display_config.display_text}: {cls.truncate(key_value)}"
             else:


### PR DESCRIPTION
## Summary

- Remove codebase understanding tools from Router (query_graph, retrieve_code, file_read, directory_lister, codebase_shell)
- Remove write_file and append_file from Router (keep read_file for reading .shotgun/ files)
- Update router prompt with clear agent file ownership guidance so it knows which sub-agent to delegate to
- Add DELEGATION tool category and @register_tool decorators for proper TUI display
- Update ToolFormatter to handle nested Pydantic model args (input.task)

The Router should act as a pure orchestrator. All codebase understanding must be delegated to the Research agent, and all file modifications must go through the appropriate sub-agent based on file ownership.

## Test plan

- [x] All 116 router unit tests pass
- [x] Linting and type checking pass
- [ ] Manual testing with TUI to verify delegation tools display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)