### PR TITLE
feat(router): add file delete tool and sub-agent streaming improvements

### DIFF
--- a/src/shotgun/agents/agent_manager.py
+++ b/src/shotgun/agents/agent_manager.py
@@ -674,6 +674,11 @@ class AgentManager(Widget):
 
         deps.agent_mode = self._current_agent_type
 
+        # For router agent, set up the parent stream handler so sub-agents can stream
+        if self._current_agent_type == AgentType.ROUTER:
+            if isinstance(deps, RouterDeps):
+                deps.parent_stream_handler = self._handle_event_stream  # type: ignore[assignment]
+
         # Filter out system prompts from other agent types
         from pydantic_ai.messages import ModelRequestPart
 

--- a/src/shotgun/agents/tools/file_management.py
+++ b/src/shotgun/agents/tools/file_management.py
@@ -285,3 +285,48 @@ async def append_file(ctx: RunContext[AgentDeps], filename: str, content: str) -
         Success message or error message
     """
     return await write_file(ctx, filename, content, mode="a")
+
+
+@register_tool(
+    category=ToolCategory.ARTIFACT_MANAGEMENT,
+    display_text="Deleting file",
+    key_arg="filename",
+)
+async def delete_file(ctx: RunContext[AgentDeps], filename: str) -> str:
+    """Delete a file from the .shotgun directory.
+
+    Uses the same permission model as write_file - agents can only delete
+    files they have permission to write to.
+
+    Args:
+        filename: Relative path to file within .shotgun directory
+
+    Returns:
+        Success message or error message
+
+    Raises:
+        ValueError: If path is outside .shotgun directory or agent lacks permission
+        FileNotFoundError: If file does not exist
+    """
+    logger.debug("🔧 Deleting file: %s", filename)
+
+    try:
+        # Use agent-scoped validation (same as write_file)
+        file_path = _validate_agent_scoped_path(filename, ctx.deps.agent_mode)
+
+        if not await aiofiles.os.path.exists(file_path):
+            raise FileNotFoundError(f"File not found: {filename}")
+
+        # Delete the file
+        await aiofiles.os.remove(file_path)
+        logger.debug("🗑️ Deleted file: %s", filename)
+
+        # Track the file operation
+        ctx.deps.file_tracker.add_operation(file_path, FileOperationType.DELETED)
+
+        return f"Successfully deleted {filename}"
+
+    except Exception as e:
+        error_msg = f"Error deleting file '{filename}': {str(e)}"
+        logger.error("❌ File delete failed: %s", error_msg)
+        return error_msg

--- a/src/shotgun/prompts/agents/router.j2
+++ b/src/shotgun/prompts/agents/router.j2
@@ -292,28 +292,35 @@ Each sub-agent owns specific files and capabilities. Always delegate to the corr
 
 **Research Agent** (`delegate_to_research`)
 - Writes to: `research.md`, `research/` folder
+- Can delete: `research.md`, files in `research/` folder
 - Capabilities: Web search, codebase analysis, knowledge graph queries, reading source files
 - Use for: Gathering information, analyzing code, answering questions about the codebase
 
 **Specification Agent** (`delegate_to_specification`)
 - Writes to: `specification.md`, `contracts/` folder
+- Can delete: `specification.md`, files in `contracts/` folder
 - Capabilities: Writing specifications, creating Pydantic contracts
 - Use for: Defining requirements, API contracts, data models
 
 **Plan Agent** (`delegate_to_plan`)
 - Writes to: `plan.md`
+- Can delete: `plan.md`
 - Capabilities: Creating implementation plans with stages
 - Use for: Breaking down work into implementation stages
 
 **Tasks Agent** (`delegate_to_tasks`)
 - Writes to: `tasks.md`
+- Can delete: `tasks.md`
 - Capabilities: Creating actionable task lists
 - Use for: Generating specific development tasks from plans
 
 **Export Agent** (`delegate_to_export`)
 - Writes to: `exports/` folder
+- Can delete: Files in `exports/` folder (cannot delete protected files: research.md, specification.md, plan.md, tasks.md)
 - Capabilities: Generating deliverables, exporting artifacts
 - Use for: Creating final outputs and documentation
+
+To delete a file, delegate to the agent that owns it with a task like "Delete research/old-notes.md".
 
 ### Delegation Input
 

--- a/src/shotgun/tui/screens/chat_screen/history/agent_response.py
+++ b/src/shotgun/tui/screens/chat_screen/history/agent_response.py
@@ -18,9 +18,10 @@ from .formatters import ToolFormatter
 class AgentResponseWidget(Widget):
     """Widget that displays agent responses in the chat history."""
 
-    def __init__(self, item: ModelResponse | None) -> None:
+    def __init__(self, item: ModelResponse | None, is_sub_agent: bool = False) -> None:
         super().__init__()
         self.item = item
+        self.is_sub_agent = is_sub_agent
 
     def compose(self) -> ComposeResult:
         self.display = self.item is not None
@@ -35,11 +36,14 @@ class AgentResponseWidget(Widget):
         if self.item is None:
             return ""
 
+        # Use different prefix for sub-agent responses
+        prefix = "**⏺** " if not self.is_sub_agent else "  **↳** "
+
         for idx, part in enumerate(self.item.parts):
             if isinstance(part, TextPart):
-                # Only show the circle prefix if there's actual content
+                # Only show the prefix if there's actual content
                 if part.content and part.content.strip():
-                    acc += f"**⏺** {part.content}\n\n"
+                    acc += f"{prefix}{part.content}\n\n"
             elif isinstance(part, ToolCallPart):
                 parts_str = ToolFormatter.format_tool_call_part(part)
                 if parts_str:  # Only add if there's actual content

--- a/src/shotgun/tui/screens/chat_screen/history/partial_response.py
+++ b/src/shotgun/tui/screens/chat_screen/history/partial_response.py
@@ -5,6 +5,8 @@ from textual.app import ComposeResult
 from textual.reactive import reactive
 from textual.widget import Widget
 
+from shotgun.tui.protocols import ActiveSubAgentProvider
+
 from .agent_response import AgentResponseWidget
 from .user_question import UserQuestionWidget
 
@@ -27,11 +29,19 @@ class PartialResponseWidget(Widget):  # TODO: doesn't work lol
         super().__init__()
         self.item = item
 
+    def _is_sub_agent_active(self) -> bool:
+        """Check if a sub-agent is currently active."""
+        if isinstance(self.screen, ActiveSubAgentProvider):
+            return self.screen.active_sub_agent is not None
+        return False
+
     def compose(self) -> ComposeResult:
         if self.item is None:
             pass
         elif self.item.kind == "response":
-            yield AgentResponseWidget(self.item)
+            yield AgentResponseWidget(
+                self.item, is_sub_agent=self._is_sub_agent_active()
+            )
         elif self.item.kind == "request":
             yield UserQuestionWidget(self.item)
 

--- a/test/unit/test_file_management.py
+++ b/test/unit/test_file_management.py
@@ -9,6 +9,7 @@ import pytest
 from shotgun.agents.tools.file_management import (
     _validate_shotgun_path,
     append_file,
+    delete_file,
     read_file,
     write_file,
 )
@@ -558,3 +559,227 @@ class TestIntegrationScenarios:
                         mock_ctx, malicious_path, "malicious"
                     )
                     assert "Error writing file" in append_result
+
+
+@pytest.mark.asyncio
+async def test_delete_file_successful():
+    """Test successful file deletion."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with patch(
+            "shotgun.agents.tools.file_management.get_shotgun_base_path"
+        ) as mock_base:
+            shotgun_dir = Path(temp_dir) / ".shotgun"
+            shotgun_dir.mkdir()
+            mock_base.return_value = shotgun_dir
+
+            # Create test file
+            test_file = shotgun_dir / "to_delete.md"
+            test_file.write_text("content to delete", encoding="utf-8")
+            assert test_file.exists()
+
+            # Create mock context with file tracker
+            mock_ctx = MagicMock()
+            mock_tracker = MagicMock()
+            mock_ctx.deps.file_tracker = mock_tracker
+            mock_ctx.deps.agent_mode = None
+
+            result = await delete_file(mock_ctx, "to_delete.md")
+
+            assert result == "Successfully deleted to_delete.md"
+            assert not test_file.exists()
+
+            # Verify tracker was called with DELETED operation
+            mock_tracker.add_operation.assert_called_once()
+            call_args = mock_tracker.add_operation.call_args
+            assert call_args[0][1].value == "deleted"
+
+
+@pytest.mark.asyncio
+async def test_delete_file_not_found():
+    """Test deletion of non-existent file."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with patch(
+            "shotgun.agents.tools.file_management.get_shotgun_base_path"
+        ) as mock_base:
+            shotgun_dir = Path(temp_dir) / ".shotgun"
+            shotgun_dir.mkdir()
+            mock_base.return_value = shotgun_dir
+
+            # Create mock context
+            mock_ctx = MagicMock()
+            mock_ctx.deps.file_tracker = MagicMock()
+            mock_ctx.deps.agent_mode = None
+
+            result = await delete_file(mock_ctx, "nonexistent.md")
+
+            assert "File not found: nonexistent.md" in result
+
+
+@pytest.mark.asyncio
+async def test_delete_file_path_traversal_blocked():
+    """Test that path traversal attacks are blocked for delete."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with patch(
+            "shotgun.agents.tools.file_management.get_shotgun_base_path"
+        ) as mock_base:
+            shotgun_dir = Path(temp_dir) / ".shotgun"
+            shotgun_dir.mkdir()
+            mock_base.return_value = shotgun_dir
+
+            # Create mock context
+            mock_ctx = MagicMock()
+            mock_ctx.deps.file_tracker = MagicMock()
+            mock_ctx.deps.agent_mode = None
+
+            result = await delete_file(mock_ctx, "../../../etc/passwd")
+
+            assert "Error deleting file" in result
+            assert "Access denied" in result
+
+
+@pytest.mark.asyncio
+async def test_delete_file_agent_permission_denied():
+    """Test that agent cannot delete files outside their scope."""
+    from shotgun.agents.models import AgentType
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with patch(
+            "shotgun.agents.tools.file_management.get_shotgun_base_path"
+        ) as mock_base:
+            shotgun_dir = Path(temp_dir) / ".shotgun"
+            shotgun_dir.mkdir()
+            mock_base.return_value = shotgun_dir
+
+            # Create a file that research agent shouldn't be able to delete
+            plan_file = shotgun_dir / "plan.md"
+            plan_file.write_text("plan content", encoding="utf-8")
+
+            # Create mock context with RESEARCH agent mode
+            mock_ctx = MagicMock()
+            mock_ctx.deps.file_tracker = MagicMock()
+            mock_ctx.deps.agent_mode = AgentType.RESEARCH
+
+            result = await delete_file(mock_ctx, "plan.md")
+
+            assert "Error deleting file" in result
+            # File should still exist
+            assert plan_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_file_agent_permission_allowed():
+    """Test that agent can delete files within their scope."""
+    from shotgun.agents.models import AgentType
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with patch(
+            "shotgun.agents.tools.file_management.get_shotgun_base_path"
+        ) as mock_base:
+            shotgun_dir = Path(temp_dir) / ".shotgun"
+            shotgun_dir.mkdir()
+            mock_base.return_value = shotgun_dir
+
+            # Create a file that research agent can delete
+            research_file = shotgun_dir / "research.md"
+            research_file.write_text("research content", encoding="utf-8")
+
+            # Create mock context with RESEARCH agent mode
+            mock_ctx = MagicMock()
+            mock_tracker = MagicMock()
+            mock_ctx.deps.file_tracker = mock_tracker
+            mock_ctx.deps.agent_mode = AgentType.RESEARCH
+
+            result = await delete_file(mock_ctx, "research.md")
+
+            assert result == "Successfully deleted research.md"
+            assert not research_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_file_nested_in_allowed_directory():
+    """Test deletion of file in nested directory within agent scope."""
+    from shotgun.agents.models import AgentType
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with patch(
+            "shotgun.agents.tools.file_management.get_shotgun_base_path"
+        ) as mock_base:
+            shotgun_dir = Path(temp_dir) / ".shotgun"
+            shotgun_dir.mkdir()
+            mock_base.return_value = shotgun_dir
+
+            # Create nested file in research directory
+            research_dir = shotgun_dir / "research"
+            research_dir.mkdir()
+            nested_file = research_dir / "notes.md"
+            nested_file.write_text("nested notes", encoding="utf-8")
+
+            # Create mock context with RESEARCH agent mode
+            mock_ctx = MagicMock()
+            mock_tracker = MagicMock()
+            mock_ctx.deps.file_tracker = mock_tracker
+            mock_ctx.deps.agent_mode = AgentType.RESEARCH
+
+            result = await delete_file(mock_ctx, "research/notes.md")
+
+            assert result == "Successfully deleted research/notes.md"
+            assert not nested_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_file_export_agent_cannot_delete_protected():
+    """Test that export agent cannot delete protected files."""
+    from shotgun.agents.models import AgentType
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with patch(
+            "shotgun.agents.tools.file_management.get_shotgun_base_path"
+        ) as mock_base:
+            shotgun_dir = Path(temp_dir) / ".shotgun"
+            shotgun_dir.mkdir()
+            mock_base.return_value = shotgun_dir
+
+            # Create protected file
+            protected_file = shotgun_dir / "research.md"
+            protected_file.write_text("protected content", encoding="utf-8")
+
+            # Create mock context with EXPORT agent mode
+            mock_ctx = MagicMock()
+            mock_ctx.deps.file_tracker = MagicMock()
+            mock_ctx.deps.agent_mode = AgentType.EXPORT
+
+            result = await delete_file(mock_ctx, "research.md")
+
+            assert "Error deleting file" in result
+            assert "protected file" in result.lower()
+            # File should still exist
+            assert protected_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_file_export_agent_can_delete_unprotected():
+    """Test that export agent can delete non-protected files."""
+    from shotgun.agents.models import AgentType
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with patch(
+            "shotgun.agents.tools.file_management.get_shotgun_base_path"
+        ) as mock_base:
+            shotgun_dir = Path(temp_dir) / ".shotgun"
+            shotgun_dir.mkdir()
+            mock_base.return_value = shotgun_dir
+
+            # Create non-protected file
+            other_file = shotgun_dir / "output.txt"
+            other_file.write_text("output content", encoding="utf-8")
+
+            # Create mock context with EXPORT agent mode
+            mock_ctx = MagicMock()
+            mock_tracker = MagicMock()
+            mock_ctx.deps.file_tracker = mock_tracker
+            mock_ctx.deps.agent_mode = AgentType.EXPORT
+
+            result = await delete_file(mock_ctx, "output.txt")
+
+            assert result == "Successfully deleted output.txt"
+            assert not other_file.exists()


### PR DESCRIPTION
## Summary
- Add `delete_file` tool to file management with same permission model as `write_file`
- Fix sub-agent streaming by properly setting `parent_stream_handler` on RouterDeps
- Add visual indicator (`↳` prefix) for sub-agent streaming responses in TUI

## Changes
1. **New `delete_file` tool** (`src/shotgun/agents/tools/file_management.py`)
   - Uses same `_validate_agent_scoped_path` as write operations
   - Tracks deletions via `FileOperationTracker` with `FileOperationType.DELETED`
   - Properly registered with `@register_tool` for TUI display

2. **Sub-agent streaming fix** (`src/shotgun/agents/agent_manager.py`)
   - Set `parent_stream_handler` on RouterDeps before running router agent
   - Sub-agents now forward streaming events to TUI

3. **Visual indicator for sub-agents** (`src/shotgun/tui/screens/chat_screen/history/`)
   - Normal responses: `⏺ response text`
   - Sub-agent responses: `  ↳ response text`

4. **Router prompt update** (`src/shotgun/prompts/agents/router.j2`)
   - Document "Can delete:" capability for each agent

## Test plan
- [x] All 1164 unit tests pass
- [x] Linter passes
- [x] Type checker passes
- [ ] Manual test: Use router to delegate file deletion to sub-agent
- [ ] Manual test: Verify sub-agent streaming shows ↳ prefix in TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)