### PR TITLE
fix(tui): defer plan approval widget when Q&A mode is active

### DIFF
--- a/src/shotgun/agents/agent_manager.py
+++ b/src/shotgun/agents/agent_manager.py
@@ -918,6 +918,8 @@ class AgentManager(Widget):
                 self.ui_message_history.append(
                     HintMessage(message=f"💡 {agent_response.clarifying_questions[0]}")
                 )
+                # Add plan hint for router if plan exists (single question is non-blocking)
+                self._maybe_add_plan_hint(deps)
             else:
                 # Multiple questions (2+) - enter Q&A mode
                 self._qa_questions = agent_response.clarifying_questions
@@ -947,9 +949,8 @@ class AgentManager(Widget):
                         response_text=agent_response.response,
                     )
                 )
-
-            # Add plan hint for router if plan exists
-            self._maybe_add_plan_hint(deps)
+                # NOTE: Don't add plan hint here - defer until Q&A completes
+                # The plan hint will be added after the user answers all questions
 
             # Post UI update with hint messages (file operations will be posted after compaction)
             logger.debug("Posting UI update for Q&A mode with hint messages")

--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -2095,6 +2095,13 @@ class ChatScreen(Screen[None]):
             logger.debug("[PLAN] Not RouterDeps, skipping pending approval check")
             return
 
+        # Don't show plan approval while user is answering questions.
+        # The pending approval will remain set and be checked again
+        # after Q&A completes (when run_agent is called with answers).
+        if self.qa_mode:
+            logger.debug("[PLAN] Q&A mode active, deferring plan approval")
+            return
+
         if self.deps.pending_approval is None:
             logger.debug("[PLAN] No pending approval")
             return


### PR DESCRIPTION
## Summary

- When the router returns both a plan AND clarifying questions, defer showing the plan approval widget
- The pending approval remains set and is checked again after Q&A completes
- This allows users to answer Q&A questions before being asked to approve the plan

## Test plan

- [ ] Manual test: Start a request in Planning mode that produces both a plan AND clarifying questions
- [ ] Verify: Plan approval widget does NOT appear while Q&A questions are displayed
- [ ] Verify: User can type answers to Q&A questions
- [ ] Verify: After answering all questions, if the next router turn has no questions, plan approval widget appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)