### PR TITLE
feat(tui): always start in Planning mode

### DIFF
--- a/src/shotgun/tui/dependencies.py
+++ b/src/shotgun/tui/dependencies.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from pydantic_ai import RunContext
 
-from shotgun.agents.config import get_config_manager, get_provider_model
+from shotgun.agents.config import get_provider_model
 from shotgun.agents.config.models import ModelConfig
 from shotgun.agents.models import AgentDeps
 from shotgun.agents.router.models import RouterDeps, RouterMode
@@ -68,7 +68,7 @@ async def create_default_router_deps() -> RouterDeps:
 
     This creates a RouterDeps configuration suitable for interactive
     TUI usage with:
-    - Router mode loaded from config (default: PLANNING)
+    - Router mode always starts in PLANNING (not persisted)
     - Interactive mode enabled
     - TUI context flag set
     - Filtered codebase service (restricted to CWD)
@@ -79,16 +79,11 @@ async def create_default_router_deps() -> RouterDeps:
     """
     model_config, codebase_service = await _get_tui_config()
 
-    # Load router mode from config (default to PLANNING)
-    config_manager = get_config_manager()
-    config = await config_manager.load()
-    router_mode = RouterMode(config.router_mode)
-
     return RouterDeps(
         interactive_mode=True,
         is_tui_context=True,
         llm_model=model_config,
         codebase_service=codebase_service,
         system_prompt_fn=_placeholder_system_prompt_fn,
-        router_mode=router_mode,
+        router_mode=RouterMode.PLANNING,
     )

--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -39,7 +39,6 @@ from shotgun.agents.agent_manager import (
     ToolExecutionStartedMessage,
     ToolStreamingProgressMessage,
 )
-from shotgun.agents.config import get_config_manager
 from shotgun.agents.config.models import MODEL_SPECS
 from shotgun.agents.conversation import ConversationManager
 from shotgun.agents.conversation.history.compaction import apply_persistent_compaction
@@ -272,9 +271,6 @@ class ChatScreen(Screen[None]):
         # Bind spinner to processing state manager
         self.processing_state.bind_spinner(self.query_one("#spinner", Spinner))
 
-        # Load saved router mode if using Router agent
-        self.call_later(self._load_saved_router_mode)
-
         # Load conversation history if --continue flag was provided
         # Use call_later to handle async exists() check
         if self.continue_session:
@@ -450,9 +446,6 @@ class ChatScreen(Screen[None]):
             self.deps.approval_status = PlanApprovalStatus.SKIPPED
             self.deps.is_executing = False
 
-        # Persist mode (fire-and-forget)
-        self._save_router_mode(self.deps.router_mode.value)
-
         # Show mode change feedback
         self.agent_manager.add_hint_message(
             HintMessage(message=f"Switched to {mode_name} mode")
@@ -461,30 +454,6 @@ class ChatScreen(Screen[None]):
         # Update UI
         self.widget_coordinator.update_for_mode_change(self.mode)
         self.call_later(lambda: self.widget_coordinator.update_prompt_input(focus=True))
-
-    def _save_router_mode(self, mode: str) -> None:
-        """Save router mode to config (fire-and-forget)."""
-
-        async def _save() -> None:
-            config_manager = get_config_manager()
-            await config_manager.set_router_mode(mode)
-
-        asyncio.create_task(_save())
-
-    async def _load_saved_router_mode(self) -> None:
-        """Load saved router mode from config."""
-        from shotgun.agents.router.models import RouterDeps, RouterMode
-
-        if isinstance(self.deps, RouterDeps):
-            config_manager = get_config_manager()
-            saved_mode = await config_manager.get_router_mode()
-
-            if saved_mode == "drafting":
-                self.deps.router_mode = RouterMode.DRAFTING
-            else:
-                self.deps.router_mode = RouterMode.PLANNING
-
-            logger.debug("Loaded router mode from config: %s", saved_mode)
 
     async def action_show_usage(self) -> None:
         usage_hint = self.agent_manager.get_usage_hint()
@@ -2032,7 +2001,6 @@ class ChatScreen(Screen[None]):
 
             # Switch to Drafting mode when plan is approved
             self.deps.router_mode = RouterMode.DRAFTING
-            self._save_router_mode(RouterMode.DRAFTING.value)
             self.widget_coordinator.update_for_mode_change(self.mode)
 
             # Begin execution of the first step


### PR DESCRIPTION
## Summary
- Make Planning mode the default when the app starts up
- Remove router mode persistence - each session starts fresh in Planning mode
- Remove unused config loading/saving code for router mode

## Test plan
- [ ] Start the app and verify it's in Planning mode
- [ ] Toggle to Drafting mode and verify it works
- [ ] Restart the app and verify it starts in Planning mode again (not Drafting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)