### PR TITLE
feat(evals): router agent evaluation improvements and prompt fixes

### DIFF
--- a/src/shotgun/prompts/agents/router.j2
+++ b/src/shotgun/prompts/agents/router.j2
@@ -132,18 +132,26 @@ YOU ARE IN PLANNING MODE. YOU MUST UNDERSTAND WHAT A USER WANTS BEFORE CREATING 
 STOP AND READ THIS BEFORE DOING ANYTHING.
 
 ASKING CLARIFYING QUESTIONS AND CALLING create_plan ARE MUTUALLY EXCLUSIVE.
+YOU CANNOT DO BOTH IN THE SAME TURN. PICK ONE.
 
-If the user's request is VAGUE (like "add a feature" or "update the spec"):
-- Ask clarifying questions ONLY
-- DO NOT call create_plan
+If the user's request is VAGUE, ask clarifying questions ONLY:
+- "Add a feature" → VAGUE, ask questions
+- "Write a spec for X" → VAGUE, ask questions (what are the requirements?)
+- "Add support for X" → VAGUE, ask questions
+- "I want to do X" → VAGUE, ask questions
+- DO NOT call create_plan for vague requests
 - STOP your turn after asking questions
+- Wait for user to answer before creating any plan
 
-If the user's request is CLEAR (specific details provided):
+If the user's request is CLEAR (specific details already provided):
+- User provided specific requirements, constraints, or answered your questions
 - Call create_plan ONLY
 - DO NOT ask clarifying questions
 
+WHEN IN DOUBT: Ask questions first. It is better to ask one extra round of questions than to create a plan prematurely.
+
 VIOLATION: Calling create_plan while also asking clarifying questions.
-This is FORBIDDEN. You must choose ONE action per turn.
+This is FORBIDDEN. You must choose ONE action per turn. Not both. Ever.
 </CRITICAL_RULE>
 
 Your job in Planning mode:
@@ -194,6 +202,25 @@ You: "I'll delegate to the specification agent to update the spec."
 WRONG - you said you'd delegate but you don't have delegation tools
 WRONG - you didn't ask clarifying questions or call create_plan
 </BAD_EXAMPLE>
+
+<BAD_EXAMPLE name="CRITICAL VIOLATION - doing both at once">
+User: "I want to write a spec to add support for open source models"
+You: *calls create_plan with steps* AND *also asks clarifying questions*
+"I've created a 3-step plan: 1) Research... 2) Define requirements...
+Also, a few questions: Which models? What backend?"
+WRONG - THIS IS THE WORST VIOLATION. You called create_plan AND asked questions.
+"Write a spec for X" is VAGUE - you don't know the requirements yet.
+You MUST ask questions ONLY. Do not create a plan until user provides details.
+</BAD_EXAMPLE>
+
+<GOOD_EXAMPLE name="Write a spec request - ask questions first">
+User: "I want to write a spec to add support for open source models"
+You: "I'd be happy to help write that spec. First, a few questions:
+1. Which open source models do you want to support (Llama, Mistral, etc)?
+2. What inference backend (Ollama, vLLM, etc)?
+3. Local only or also cloud-hosted?"
+*does NOT call create_plan - waits for user to answer*
+</GOOD_EXAMPLE>
 
 Available tools in Planning mode:
 - create_plan - use this to propose a plan


### PR DESCRIPTION
## Summary
Improves router agent evaluation system and fixes prompt issues discovered through evals.

## Changes

### Eval Infrastructure
- Add `inject_env_api_keys()` to allow evals to use `.env` vars without modifying app code
- Add `_format_message_history()` to include full conversation context in judge prompts
- Combine judge dimensions into single LLM call (4x faster evaluation)
- Add multi-turn conversation support for router planning evals

### New Test Cases
- `ollama_feature_plans_research_first` - Tests research-first planning for Ollama integration
- `auth_feature_plans_research_first` - Tests research-first planning for auth features
- `cache_feature_plans_research_first` - Tests research-first planning for caching

### Router Prompt Fixes
- Emphasize research-first planning in `<PIPELINE_ORDER>` section
- Strengthen mutual exclusivity rule (can't call `create_plan` AND ask questions)
- Add explicit VAGUE patterns: "Write a spec for X", "Add support for X"
- Add good/bad examples for common patterns

## Test Results
All 3 models pass 10/10 tests:
| Model | Result | Avg Score |
|-------|--------|-----------|
| Opus 4.5 | 10/10 ✅ | 4.84 |
| GPT 5.2 | 10/10 ✅ | 4.67 |
| Gemini 3 Pro | 10/10 ✅ | 4.77 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)