### PR TITLE
fix(tui): improve button visibility on codebase index prompt screen

### DIFF
--- a/src/shotgun/tui/screens/chat/codebase_index_prompt_screen.py
+++ b/src/shotgun/tui/screens/chat/codebase_index_prompt_screen.py
@@ -11,8 +11,10 @@ from textual.events import Resize
 from textual.screen import ModalScreen
 from textual.widgets import Button, Label, Markdown, Static
 
-from shotgun.tui.layout import COMPACT_HEIGHT_THRESHOLD
 from shotgun.utils.file_system_utils import get_shotgun_home
+
+# Use a higher threshold than the global default since this dialog has more content
+INDEX_PROMPT_COMPACT_THRESHOLD = 45
 
 
 def _is_home_directory() -> bool:
@@ -46,7 +48,7 @@ class CodebaseIndexPromptScreen(ModalScreen[bool]):
             max-width: 90;
             height: auto;
             max-height: 85%;
-            border: wide $primary;
+            border: none;
             padding: 1 2;
             layout: vertical;
             background: $surface;
@@ -200,12 +202,14 @@ We take your privacy seriously. You can read our full [privacy policy](https://a
         if _is_home_directory():
             _track_event("home_directory_warning_shown")
         # Apply compact layout if starting in a short terminal
-        self._apply_compact_layout(self.app.size.height < COMPACT_HEIGHT_THRESHOLD)
+        self._apply_compact_layout(
+            self.app.size.height < INDEX_PROMPT_COMPACT_THRESHOLD
+        )
 
     @on(Resize)
     def handle_resize(self, event: Resize) -> None:
         """Adjust layout based on terminal height."""
-        self._apply_compact_layout(event.size.height < COMPACT_HEIGHT_THRESHOLD)
+        self._apply_compact_layout(event.size.height < INDEX_PROMPT_COMPACT_THRESHOLD)
 
     def _apply_compact_layout(self, compact: bool) -> None:
         """Apply or remove compact layout classes for short terminals."""


### PR DESCRIPTION
## Summary
- Remove border from dialog to save ~4 lines of vertical space
- Raise compact mode threshold to 45 lines (from global 35) so compact mode kicks in earlier for this content-heavy dialog

This ensures buttons remain visible on smaller terminal windows.

## Test plan
- [ ] Resize terminal to various heights and verify buttons are visible
- [ ] Verify compact mode kicks in at appropriate height

🤖 Generated with [Claude Code](https://claude.com/claude-code)