### PR TITLE
fix(tui): allow SHIFT+TAB to escape Q&A mode when stuck

### DIFF
--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -409,10 +409,11 @@ class ChatScreen(Screen[None]):
         """Toggle between Planning and Drafting modes for Router."""
         from shotgun.agents.router.models import RouterDeps, RouterMode
 
-        # Prevent mode switching during Q&A
+        # If in Q&A mode, exit it first (SHIFT+TAB escapes Q&A mode)
         if self.qa_mode:
+            self._exit_qa_mode()
             self.agent_manager.add_hint_message(
-                HintMessage(message="⚠️ Cannot switch modes while answering questions")
+                HintMessage(message="Exited Q&A mode via Shift+Tab")
             )
             return
 
@@ -937,6 +938,11 @@ class ChatScreen(Screen[None]):
         """
         # Clear any streaming partial response (removes final_result JSON)
         self._clear_partial_response()
+
+        # Safety check: don't enter Q&A mode if questions array is empty
+        if not event.questions:
+            logger.warning("ClarifyingQuestionsMessage received with empty questions")
+            return
 
         # Enter Q&A mode
         self.qa_mode = True

--- a/test/unit/tui/test_chat_screen.py
+++ b/test/unit/tui/test_chat_screen.py
@@ -177,3 +177,147 @@ def test_codebase_sdk_mocked(chat_screen, mock_codebase_sdk):
     mock_codebase_sdk.list_codebases_for_directory.return_value = AsyncMock(
         return_value=Mock(graphs=[])
     )
+
+
+class TestQAModeToggle:
+    """Tests for Q&A mode toggle behavior - SHIFT+TAB exits Q&A mode."""
+
+    def test_shift_tab_exits_qa_mode_when_questions_empty(
+        self,
+        mock_agent_manager,
+        mock_conversation_manager,
+        mock_conversation_service,
+        mock_widget_coordinator,
+        mock_processing_state,
+        mock_command_handler,
+        mock_placeholder_hints,
+        mock_codebase_sdk,
+        mock_agent_deps,
+    ):
+        """Test that SHIFT+TAB exits Q&A mode when qa_questions is empty."""
+        from shotgun.agents.router.models import RouterDeps, RouterMode
+        from shotgun.tui.screens.chat import ChatScreen
+
+        router_deps = RouterDeps(
+            interactive_mode=True,
+            is_tui_context=True,
+            llm_model=mock_agent_deps.llm_model,
+            codebase_service=mock_agent_deps.codebase_service,
+            system_prompt_fn=mock_agent_deps.system_prompt_fn,
+            router_mode=RouterMode.PLANNING,
+        )
+
+        screen = ChatScreen(
+            agent_manager=mock_agent_manager,
+            conversation_manager=mock_conversation_manager,
+            conversation_service=mock_conversation_service,
+            widget_coordinator=mock_widget_coordinator,
+            processing_state=mock_processing_state,
+            command_handler=mock_command_handler,
+            placeholder_hints=mock_placeholder_hints,
+            codebase_sdk=mock_codebase_sdk,
+            deps=router_deps,
+        )
+
+        # Simulate stuck Q&A mode: qa_mode=True but qa_questions is empty
+        screen.qa_mode = True
+        screen.qa_questions = []
+
+        # Press SHIFT+TAB (action_toggle_mode)
+        screen.action_toggle_mode()
+
+        # Q&A mode should be exited
+        assert screen.qa_mode is False
+        # Mode should NOT have changed (just exits Q&A, doesn't toggle)
+        assert router_deps.router_mode == RouterMode.PLANNING
+        # Hint should have been shown
+        mock_agent_manager.add_hint_message.assert_called()
+
+    def test_shift_tab_exits_qa_mode_when_questions_exist(
+        self,
+        mock_agent_manager,
+        mock_conversation_manager,
+        mock_conversation_service,
+        mock_widget_coordinator,
+        mock_processing_state,
+        mock_command_handler,
+        mock_placeholder_hints,
+        mock_codebase_sdk,
+        mock_agent_deps,
+    ):
+        """Test that SHIFT+TAB exits Q&A mode even when questions exist."""
+        from shotgun.agents.router.models import RouterDeps, RouterMode
+        from shotgun.tui.screens.chat import ChatScreen
+
+        router_deps = RouterDeps(
+            interactive_mode=True,
+            is_tui_context=True,
+            llm_model=mock_agent_deps.llm_model,
+            codebase_service=mock_agent_deps.codebase_service,
+            system_prompt_fn=mock_agent_deps.system_prompt_fn,
+            router_mode=RouterMode.PLANNING,
+        )
+
+        screen = ChatScreen(
+            agent_manager=mock_agent_manager,
+            conversation_manager=mock_conversation_manager,
+            conversation_service=mock_conversation_service,
+            widget_coordinator=mock_widget_coordinator,
+            processing_state=mock_processing_state,
+            command_handler=mock_command_handler,
+            placeholder_hints=mock_placeholder_hints,
+            codebase_sdk=mock_codebase_sdk,
+            deps=router_deps,
+        )
+
+        # Active Q&A mode with questions
+        screen.qa_mode = True
+        screen.qa_questions = ["Question 1?", "Question 2?"]
+
+        # Press SHIFT+TAB (action_toggle_mode)
+        screen.action_toggle_mode()
+
+        # Q&A mode should be exited
+        assert screen.qa_mode is False
+        # Mode should NOT have changed (just exits Q&A, doesn't toggle)
+        assert router_deps.router_mode == RouterMode.PLANNING
+        # Hint should have been shown
+        mock_agent_manager.add_hint_message.assert_called()
+
+    def test_handle_clarifying_questions_skips_empty_questions(
+        self,
+        mock_agent_manager,
+        mock_conversation_manager,
+        mock_conversation_service,
+        mock_widget_coordinator,
+        mock_processing_state,
+        mock_command_handler,
+        mock_placeholder_hints,
+        mock_codebase_sdk,
+        mock_agent_deps,
+    ):
+        """Test that handle_clarifying_questions doesn't enter Q&A mode with empty questions."""
+        from shotgun.agents.agent_manager import ClarifyingQuestionsMessage
+        from shotgun.tui.screens.chat import ChatScreen
+
+        screen = ChatScreen(
+            agent_manager=mock_agent_manager,
+            conversation_manager=mock_conversation_manager,
+            conversation_service=mock_conversation_service,
+            widget_coordinator=mock_widget_coordinator,
+            processing_state=mock_processing_state,
+            command_handler=mock_command_handler,
+            placeholder_hints=mock_placeholder_hints,
+            codebase_sdk=mock_codebase_sdk,
+            deps=mock_agent_deps,
+        )
+
+        # Create event with empty questions
+        event = ClarifyingQuestionsMessage(questions=[], response_text="Test response")
+
+        # Handle the event
+        screen.handle_clarifying_questions(event)
+
+        # Q&A mode should NOT be active
+        assert screen.qa_mode is False
+        assert screen.qa_questions == []


### PR DESCRIPTION
## Summary

- Users could get stuck in Q&A mode with no way to exit if `qa_mode` was True but `qa_questions` was empty
- SHIFT+TAB now exits Q&A mode first (showing a hint message) instead of blocking mode toggle
- Added safety check to not enter Q&A mode if clarifying questions array is empty

## Test plan

- [x] Run `pytest test/unit/tui/test_chat_screen.py::TestQAModeToggle -v`
- [ ] Manual test: Start Q&A mode with agent, press SHIFT+TAB - should exit Q&A mode and show hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)