### PR TITLE
feat(tui): add shell command execution with `!` prefix

### DIFF
--- a/src/shotgun/tui/commands/__init__.py
+++ b/src/shotgun/tui/commands/__init__.py
@@ -54,6 +54,14 @@ class CommandHandler:
 **Commands:**
 • `/help` - Show this help message
 
+**Shell Commands:**
+• `!<command>` - Execute shell commands directly (e.g., `!ls`, `!git status`)
+  - Commands run in your current working directory
+  - Output is displayed in the chat (not sent to AI)
+  - Commands are NOT added to conversation history
+  - Leading whitespace is allowed: `  !echo hi` works
+  - Note: `!!` is treated as `!` (no history expansion in this version)
+
 **Keyboard Shortcuts:**
 
 * `Enter` - Send message

--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -846,6 +846,72 @@ class ChatScreen(Screen[None]):
         )
         self.agent_manager.add_hint_message(hint)
 
+    async def execute_shell_command(self, command: str) -> None:
+        """Execute a shell command and display output.
+
+        This implements the `!`-to-shell behavior for interactive mode.
+        Commands are executed in the current working directory with
+        full shell features (pipes, redirection, etc.).
+
+        Args:
+            command: The shell command to execute (after stripping the leading `!`)
+
+        Note:
+            - Commands are executed with shell=True for full shell features
+            - Output is streamed to the TUI via hint messages
+            - Errors are displayed but do not crash the application
+            - Commands are NOT added to conversation history
+        """
+        # Handle empty command (just `!` with nothing after it)
+        if not command or command.isspace():
+            self.mount_hint("⚠️ Empty shell command. Usage: `!<command>`")
+            return
+
+        # Show what command is being executed
+        # Use code block for better visibility
+        self.mount_hint(f"**Running:** `{command}`")
+
+        try:
+            # Execute with shell=True to support pipes, redirection, etc.
+            # Run in current working directory
+            process = await asyncio.create_subprocess_shell(
+                command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=Path.cwd(),
+            )
+
+            # Wait for command to complete and capture output
+            stdout_bytes, stderr_bytes = await process.communicate()
+            stdout = stdout_bytes.decode("utf-8", errors="replace")
+            stderr = stderr_bytes.decode("utf-8", errors="replace")
+            return_code = process.returncode or 0
+
+            # Build output message
+            output_parts = []
+
+            if stdout:
+                # Show stdout in a code block for proper formatting
+                output_parts.append(f"```\n{stdout.rstrip()}\n```")
+
+            if stderr:
+                # Show stderr with a warning indicator
+                output_parts.append(f"**stderr:**\n```\n{stderr.rstrip()}\n```")
+
+            if return_code != 0:
+                # Show non-zero exit code as error
+                output_parts.append(f"**Exit code:** {return_code}")
+
+            # Display output (or success message if no output)
+            if output_parts:
+                self.mount_hint("\n\n".join(output_parts))
+            elif return_code == 0:
+                self.mount_hint("✓ Command completed successfully (no output)")
+
+        except Exception as e:
+            # Show error message
+            self.mount_hint(f"❌ **Shell command failed:**\n```\n{str(e)}\n```")
+
     @on(PartialResponseMessage)
     def handle_partial_response(self, event: PartialResponseMessage) -> None:
         # Filter event.messages to exclude ModelRequest with only ToolReturnPart
@@ -1125,10 +1191,41 @@ class ChatScreen(Screen[None]):
 
     @on(PromptInput.Submitted)
     async def handle_submit(self, message: PromptInput.Submitted) -> None:
+        """Handle user input submission from the prompt.
+
+        This is the main interactive loop entrypoint for shotgun-cli TUI.
+        Input classification:
+        1. Lines starting with `!` (after trimming whitespace) are shell commands
+        2. Lines starting with `/` are internal commands
+        3. All other lines are sent to the LLM
+
+        Shell command behavior (`!`-to-shell):
+        - Lines like `!ls` or `  !git status` execute as shell commands
+        - Shell commands are NOT sent to LLM
+        - Shell commands are NOT added to conversation history
+        - Implementation: v1 limitation - no history expansion (!!, !$, etc.)
+        """
         text = message.text.strip()
 
         # If empty text, just clear input and return
         if not text:
+            self.widget_coordinator.update_prompt_input(clear=True)
+            self.value = ""
+            return
+
+        # Stage 1: Classify input - check if line starts with `!` (shell command)
+        # Trim leading whitespace and check first character
+        trimmed = message.text.lstrip()
+        if trimmed.startswith("!"):
+            # This is a shell command - extract the command by removing exactly one `!`
+            # Note: `!!ls` becomes `!ls` in v1 (no special history expansion)
+            shell_command = trimmed[1:]  # Remove the leading `!`
+
+            # Execute shell command (do NOT forward to LLM or add to history)
+            await self.execute_shell_command(shell_command)
+
+            # Clear input and return (do not proceed to LLM handling)
+            # This ensures shell commands are never added to conversation history
             self.widget_coordinator.update_prompt_input(clear=True)
             self.value = ""
             return

--- a/test/unit/tui/conftest.py
+++ b/test/unit/tui/conftest.py
@@ -69,6 +69,8 @@ def mock_agent_manager(mock_agent_deps):
     manager._current_agent_type = AgentType.RESEARCH  # Used by ChatScreen.__init__
     manager.switch_agent = Mock()
     manager.run_agent = AsyncMock(return_value="Test response")
+    manager.ui_message_history = []  # For shell command tests
+    manager.add_hint_message = Mock()  # For hint display in shell commands
     return manager
 
 

--- a/test/unit/tui/test_chat_screen.py
+++ b/test/unit/tui/test_chat_screen.py
@@ -321,3 +321,267 @@ class TestQAModeToggle:
         # Q&A mode should NOT be active
         assert screen.qa_mode is False
         assert screen.qa_questions == []
+
+
+class TestShellCommandHandling:
+    """Tests for `!`-to-shell command handling in interactive mode."""
+
+    @pytest.mark.asyncio
+    async def test_normal_prompt_sent_to_llm_not_shell(
+        self,
+        mock_agent_manager,
+        mock_conversation_manager,
+        mock_conversation_service,
+        mock_widget_coordinator,
+        mock_processing_state,
+        mock_command_handler,
+        mock_placeholder_hints,
+        mock_codebase_sdk,
+        mock_agent_deps,
+    ):
+        """Test that normal prompts without `!` are sent to LLM, not shell."""
+        from shotgun.tui.components.prompt_input import PromptInput
+        from shotgun.tui.screens.chat import ChatScreen
+
+        screen = ChatScreen(
+            agent_manager=mock_agent_manager,
+            conversation_manager=mock_conversation_manager,
+            conversation_service=mock_conversation_service,
+            widget_coordinator=mock_widget_coordinator,
+            processing_state=mock_processing_state,
+            command_handler=mock_command_handler,
+            placeholder_hints=mock_placeholder_hints,
+            codebase_sdk=mock_codebase_sdk,
+            deps=mock_agent_deps,
+        )
+
+        # Mock the command handler to return False (not a slash command)
+        mock_command_handler.is_command.return_value = False
+
+        # Create a mock execute_shell_command to verify it's NOT called
+        screen.execute_shell_command = AsyncMock()
+
+        # Mock run_agent to prevent full execution
+        screen.run_agent = Mock()
+
+        # Simulate user entering a normal prompt
+        event = PromptInput.Submitted(text="What is Python?")
+        await screen.handle_submit(event)
+
+        # Shell command should NOT be executed
+        screen.execute_shell_command.assert_not_called()
+
+        # Prompt should be added to UI message history (LLM path)
+        assert len(mock_agent_manager.ui_message_history) > 0
+
+    @pytest.mark.asyncio
+    async def test_shell_command_with_leading_bang(
+        self,
+        mock_agent_manager,
+        mock_conversation_manager,
+        mock_conversation_service,
+        mock_widget_coordinator,
+        mock_processing_state,
+        mock_command_handler,
+        mock_placeholder_hints,
+        mock_codebase_sdk,
+        mock_agent_deps,
+    ):
+        """Test that `!ls` is executed as shell command."""
+        from shotgun.tui.components.prompt_input import PromptInput
+        from shotgun.tui.screens.chat import ChatScreen
+
+        screen = ChatScreen(
+            agent_manager=mock_agent_manager,
+            conversation_manager=mock_conversation_manager,
+            conversation_service=mock_conversation_service,
+            widget_coordinator=mock_widget_coordinator,
+            processing_state=mock_processing_state,
+            command_handler=mock_command_handler,
+            placeholder_hints=mock_placeholder_hints,
+            codebase_sdk=mock_codebase_sdk,
+            deps=mock_agent_deps,
+        )
+
+        # Mock execute_shell_command
+        screen.execute_shell_command = AsyncMock()
+
+        # Simulate user entering `!ls`
+        event = PromptInput.Submitted(text="!ls")
+        await screen.handle_submit(event)
+
+        # Shell command should be executed with "ls" (bang removed)
+        screen.execute_shell_command.assert_called_once_with("ls")
+
+        # Should NOT be added to LLM message history
+        assert len(mock_agent_manager.ui_message_history) == 0
+
+    @pytest.mark.asyncio
+    async def test_shell_command_with_leading_whitespace(
+        self,
+        mock_agent_manager,
+        mock_conversation_manager,
+        mock_conversation_service,
+        mock_widget_coordinator,
+        mock_processing_state,
+        mock_command_handler,
+        mock_placeholder_hints,
+        mock_codebase_sdk,
+        mock_agent_deps,
+    ):
+        """Test that `   !echo hi` is treated as shell command."""
+        from shotgun.tui.components.prompt_input import PromptInput
+        from shotgun.tui.screens.chat import ChatScreen
+
+        screen = ChatScreen(
+            agent_manager=mock_agent_manager,
+            conversation_manager=mock_conversation_manager,
+            conversation_service=mock_conversation_service,
+            widget_coordinator=mock_widget_coordinator,
+            processing_state=mock_processing_state,
+            command_handler=mock_command_handler,
+            placeholder_hints=mock_placeholder_hints,
+            codebase_sdk=mock_codebase_sdk,
+            deps=mock_agent_deps,
+        )
+
+        # Mock execute_shell_command
+        screen.execute_shell_command = AsyncMock()
+
+        # Simulate user entering `   !echo hi` (with leading spaces)
+        event = PromptInput.Submitted(text="   !echo hi")
+        await screen.handle_submit(event)
+
+        # Shell command should be executed with "echo hi"
+        screen.execute_shell_command.assert_called_once_with("echo hi")
+
+        # Should NOT be added to LLM message history
+        assert len(mock_agent_manager.ui_message_history) == 0
+
+    @pytest.mark.asyncio
+    async def test_empty_bang_shows_warning(
+        self,
+        mock_agent_manager,
+        mock_conversation_manager,
+        mock_conversation_service,
+        mock_widget_coordinator,
+        mock_processing_state,
+        mock_command_handler,
+        mock_placeholder_hints,
+        mock_codebase_sdk,
+        mock_agent_deps,
+    ):
+        """Test that `!` alone shows a warning message."""
+        from shotgun.tui.components.prompt_input import PromptInput
+        from shotgun.tui.screens.chat import ChatScreen
+
+        screen = ChatScreen(
+            agent_manager=mock_agent_manager,
+            conversation_manager=mock_conversation_manager,
+            conversation_service=mock_conversation_service,
+            widget_coordinator=mock_widget_coordinator,
+            processing_state=mock_processing_state,
+            command_handler=mock_command_handler,
+            placeholder_hints=mock_placeholder_hints,
+            codebase_sdk=mock_codebase_sdk,
+            deps=mock_agent_deps,
+        )
+
+        # Simulate user entering just `!`
+        event = PromptInput.Submitted(text="!")
+        await screen.handle_submit(event)
+
+        # Should show warning hint about empty command
+        mock_agent_manager.add_hint_message.assert_called()
+        call_args = mock_agent_manager.add_hint_message.call_args[0][0]
+        assert "Empty shell command" in call_args.message
+
+    @pytest.mark.asyncio
+    async def test_double_bang_treated_as_single_bang_command(
+        self,
+        mock_agent_manager,
+        mock_conversation_manager,
+        mock_conversation_service,
+        mock_widget_coordinator,
+        mock_processing_state,
+        mock_command_handler,
+        mock_placeholder_hints,
+        mock_codebase_sdk,
+        mock_agent_deps,
+    ):
+        """Test that `!!ls` is treated as shell command `!ls` (no history expansion in v1)."""
+        from shotgun.tui.components.prompt_input import PromptInput
+        from shotgun.tui.screens.chat import ChatScreen
+
+        screen = ChatScreen(
+            agent_manager=mock_agent_manager,
+            conversation_manager=mock_conversation_manager,
+            conversation_service=mock_conversation_service,
+            widget_coordinator=mock_widget_coordinator,
+            processing_state=mock_processing_state,
+            command_handler=mock_command_handler,
+            placeholder_hints=mock_placeholder_hints,
+            codebase_sdk=mock_codebase_sdk,
+            deps=mock_agent_deps,
+        )
+
+        # Mock execute_shell_command
+        screen.execute_shell_command = AsyncMock()
+
+        # Simulate user entering `!!ls`
+        event = PromptInput.Submitted(text="!!ls")
+        await screen.handle_submit(event)
+
+        # Shell command should be executed with "!ls" (only first `!` removed)
+        screen.execute_shell_command.assert_called_once_with("!ls")
+
+        # Should NOT be added to LLM message history
+        assert len(mock_agent_manager.ui_message_history) == 0
+
+    @pytest.mark.asyncio
+    async def test_bang_in_middle_sent_to_llm(
+        self,
+        mock_agent_manager,
+        mock_conversation_manager,
+        mock_conversation_service,
+        mock_widget_coordinator,
+        mock_processing_state,
+        mock_command_handler,
+        mock_placeholder_hints,
+        mock_codebase_sdk,
+        mock_agent_deps,
+    ):
+        """Test that `echo !` (bang not at start) is sent to LLM, not shell."""
+        from shotgun.tui.components.prompt_input import PromptInput
+        from shotgun.tui.screens.chat import ChatScreen
+
+        screen = ChatScreen(
+            agent_manager=mock_agent_manager,
+            conversation_manager=mock_conversation_manager,
+            conversation_service=mock_conversation_service,
+            widget_coordinator=mock_widget_coordinator,
+            processing_state=mock_processing_state,
+            command_handler=mock_command_handler,
+            placeholder_hints=mock_placeholder_hints,
+            codebase_sdk=mock_codebase_sdk,
+            deps=mock_agent_deps,
+        )
+
+        # Mock the command handler to return False (not a slash command)
+        mock_command_handler.is_command.return_value = False
+
+        # Mock execute_shell_command to verify it's NOT called
+        screen.execute_shell_command = AsyncMock()
+
+        # Mock run_agent to prevent full execution
+        screen.run_agent = Mock()
+
+        # Simulate user entering `echo !`
+        event = PromptInput.Submitted(text="echo !")
+        await screen.handle_submit(event)
+
+        # Shell command should NOT be executed
+        screen.execute_shell_command.assert_not_called()
+
+        # Prompt should be added to UI message history (LLM path)
+        assert len(mock_agent_manager.ui_message_history) > 0


### PR DESCRIPTION
Implements shell command execution in TUI interactive mode. Users can now run shell commands directly from the chat interface by prefixing them with `!`.

**Features:**
- Execute shell commands via `!<command>` (e.g., `!ls`, `!git status`)
- Commands run in current working directory with full shell features
- Output displayed in chat via hint messages
- Commands NOT added to conversation history
- Error handling for failed shell executions

**Edge Cases:**
- Empty `!` shows usage warning
- Leading whitespace allowed: `  !echo hi` works
- `!!ls` treated as `!ls` (no history expansion in v1)
- Mid-line `!` like `echo !` sent to LLM (not shell)

**Tests:**
- Comprehensive unit tests for input routing
- Edge case coverage (empty, `!!`, mid-line `!`)
- Mock-based testing for shell executor

**Documentation:**
- Updated `/help` command with shell command docs
- Added inline comments explaining v1 limitations


🤖 Generated with [Claude Code](https://claude.com/claude-code)