### PR TITLE
ci(deploy): parallelize test execution in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,8 @@ permissions:
   id-token: write  # Required for trusted publishing
 
 jobs:
-  run-tests:
+  # Linting and type checking (runs in parallel with tests)
+  lint-and-typecheck:
     runs-on: ubuntu-latest
 
     steps:
@@ -37,12 +38,97 @@ jobs:
       - name: Run mypy
         run: uv run mypy src/
 
-      - name: Run unit tests
+  # Test Group 1: Config, conversation, history, and agents (medium load)
+  test-group-1:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run tests - Config, History & Agents
         run: |
-          echo "Running unit tests only (integration tests skipped for faster deployment)"
-          uv run pytest test/unit/ -v
-          # Future: When tests are marked with smoke_test, use:
-          # uv run pytest test/unit/ -m smoke_test -v
+          uv run pytest \
+            test/unit/test_config*.py \
+            test/unit/test_conversation*.py \
+            test/unit/test_history*.py \
+            test/unit/agents/ \
+            -q
+
+  # Test Group 2: Codebase, LLM proxy, Web (heavy load - Kuzu database)
+  test-group-2:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run tests - Codebase, LLM Proxy & Web
+        run: |
+          uv run pytest \
+            test/unit/codebase/ \
+            test/unit/llm_proxy/ \
+            test/unit/shotgun_web/ \
+            test/unit/test_web_search.py \
+            -q
+
+  # Test Group 3: CLI, TUI, exceptions & utilities (light load)
+  test-group-3:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run tests - CLI, TUI & Utilities
+        run: |
+          uv run pytest \
+            test/unit/cli/ \
+            test/unit/tui/ \
+            test/unit/exceptions/ \
+            test/unit/test_common.py \
+            test/unit/test_file_management.py \
+            test/unit/test_file_system_utils.py \
+            test/unit/test_logging_config.py \
+            test/unit/test_marketing.py \
+            test/unit/test_posthog_telemetry.py \
+            test/unit/test_provider.py \
+            test/unit/test_sentry_filtering.py \
+            test/unit/test_settings.py \
+            test/unit/test_streaming_detection.py \
+            test/unit/test_update_checker.py \
+            test/unit/test_agent_manager_filtering.py \
+            -q
 
   build-and-package:
     runs-on: ubuntu-latest
@@ -161,7 +247,7 @@ jobs:
 
   deploy-to-pypi:
     runs-on: ubuntu-latest
-    needs: [run-tests, build-and-package]
+    needs: [lint-and-typecheck, test-group-1, test-group-2, test-group-3, build-and-package]
     # Uncomment if you have a configured environment in GitHub
     # environment:
     #   name: pypi


### PR DESCRIPTION
## Summary
- Split single `run-tests` job into 4 parallel jobs matching PR workflow structure
- Tests now run concurrently: lint-and-typecheck, test-group-1, test-group-2, test-group-3
- `build-and-package` also runs in parallel with tests
- Significantly reduces deployment pipeline time

## Test plan
- [ ] Verify workflow YAML is valid
- [ ] Check that deploy workflow triggers correctly on tag push
- [ ] Confirm all test groups complete before deploy-to-pypi runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)