### PR TITLE
feat(codebase): add WorkDistributor for parallel file parsing (Stage 2)

### DIFF
--- a/src/shotgun/codebase/core/metrics_types.py
+++ b/src/shotgun/codebase/core/metrics_types.py
@@ -1,10 +1,12 @@
 """Type definitions for indexing metrics collection.
 
 These models define the data structures for tracking performance metrics
-during codebase indexing operations.
+during codebase indexing operations, as well as work distribution types
+for parallel file parsing.
 """
 
 from enum import StrEnum
+from pathlib import Path
 
 from pydantic import BaseModel, Field
 
@@ -93,4 +95,78 @@ class IndexingMetrics(BaseModel):
     peak_memory_mb: float = Field(..., description="Peak memory usage")
     parallelism_efficiency: float | None = Field(
         None, description="Efficiency factor (0.0-1.0) of parallelization"
+    )
+
+
+# =============================================================================
+# Work Distribution Types
+# =============================================================================
+
+
+class FileInfo(BaseModel):
+    """Information about a file for work distribution.
+
+    Used by WorkDistributor to calculate balanced work assignments
+    based on file size.
+    """
+
+    file_path: Path = Field(..., description="Absolute path to file")
+    relative_path: Path = Field(..., description="Path relative to repo root")
+    language: str = Field(..., description="Programming language")
+    module_qn: str = Field(..., description="Qualified name for the module")
+    container_qn: str | None = Field(
+        None, description="Parent package/folder qualified name"
+    )
+    file_size_bytes: int = Field(..., description="File size in bytes for balancing")
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+class FileParseTask(BaseModel):
+    """A task representing a file to be parsed by a worker.
+
+    This is the serializable unit of work sent to worker processes.
+    """
+
+    file_path: Path = Field(..., description="Absolute path to file")
+    relative_path: Path = Field(..., description="Path relative to repo root")
+    language: str = Field(..., description="Programming language")
+    module_qn: str = Field(..., description="Qualified name for the module")
+    container_qn: str | None = Field(
+        None, description="Parent package/folder qualified name"
+    )
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+class WorkBatch(BaseModel):
+    """A batch of file parse tasks for distribution to a worker.
+
+    Batches group multiple tasks together to reduce queue overhead
+    when distributing work across processes.
+    """
+
+    batch_id: int = Field(..., description="Unique batch identifier")
+    tasks: list[FileParseTask] = Field(..., description="Tasks in this batch")
+    estimated_duration_seconds: float | None = Field(
+        None, description="Estimated processing time"
+    )
+
+
+class DistributionStats(BaseModel):
+    """Statistics about work distribution across workers.
+
+    Provides insight into how files are balanced across workers
+    for debugging and verification.
+    """
+
+    total_files: int = Field(..., description="Total number of files")
+    total_bytes: int = Field(..., description="Total size in bytes")
+    worker_count: int = Field(..., description="Number of workers")
+    batch_size: int = Field(..., description="Files per batch")
+    files_per_worker: list[int] = Field(
+        ..., description="Number of files assigned to each worker"
+    )
+    bytes_per_worker: list[int] = Field(
+        ..., description="Total bytes assigned to each worker"
     )

--- a/src/shotgun/codebase/core/work_distributor.py
+++ b/src/shotgun/codebase/core/work_distributor.py
@@ -8,10 +8,13 @@ from __future__ import annotations
 
 import multiprocessing
 import os
-from pathlib import Path
 
-from pydantic import BaseModel, Field
-
+from shotgun.codebase.core.metrics_types import (
+    DistributionStats,
+    FileInfo,
+    FileParseTask,
+    WorkBatch,
+)
 from shotgun.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -19,55 +22,17 @@ logger = get_logger(__name__)
 # Default values
 DEFAULT_BATCH_SIZE = 20
 
-
-class FileInfo(BaseModel):
-    """Information about a file for work distribution.
-
-    Used by WorkDistributor to calculate balanced work assignments
-    based on file size.
-    """
-
-    file_path: Path = Field(..., description="Absolute path to file")
-    relative_path: Path = Field(..., description="Path relative to repo root")
-    language: str = Field(..., description="Programming language")
-    module_qn: str = Field(..., description="Qualified name for the module")
-    container_qn: str | None = Field(
-        None, description="Parent package/folder qualified name"
-    )
-    file_size_bytes: int = Field(..., description="File size in bytes for balancing")
-
-    model_config = {"arbitrary_types_allowed": True}
-
-
-class FileParseTask(BaseModel):
-    """A task representing a file to be parsed by a worker.
-
-    This is the serializable unit of work sent to worker processes.
-    """
-
-    file_path: Path = Field(..., description="Absolute path to file")
-    relative_path: Path = Field(..., description="Path relative to repo root")
-    language: str = Field(..., description="Programming language")
-    module_qn: str = Field(..., description="Qualified name for the module")
-    container_qn: str | None = Field(
-        None, description="Parent package/folder qualified name"
-    )
-
-    model_config = {"arbitrary_types_allowed": True}
-
-
-class WorkBatch(BaseModel):
-    """A batch of file parse tasks for distribution to a worker.
-
-    Batches group multiple tasks together to reduce queue overhead
-    when distributing work across processes.
-    """
-
-    batch_id: int = Field(..., description="Unique batch identifier")
-    tasks: list[FileParseTask] = Field(..., description="Tasks in this batch")
-    estimated_duration_seconds: float | None = Field(
-        None, description="Estimated processing time"
-    )
+# Re-export types for convenience
+__all__ = [
+    "DEFAULT_BATCH_SIZE",
+    "DistributionStats",
+    "FileInfo",
+    "FileParseTask",
+    "WorkBatch",
+    "WorkDistributor",
+    "get_batch_size",
+    "get_worker_count",
+]
 
 
 def get_worker_count() -> int:
@@ -164,6 +129,41 @@ class WorkDistributor:
             f"batch size {self.batch_size}"
         )
 
+    def _distribute_files(
+        self, files: list[FileInfo]
+    ) -> list[tuple[int, list[FileInfo]]]:
+        """Distribute files across workers using size-balanced bin-packing.
+
+        Args:
+            files: List of files to distribute.
+
+        Returns:
+            List of (total_bytes, file_list) tuples, one per worker.
+        """
+        # Sort files by size descending (largest first)
+        sorted_files = sorted(files, key=lambda f: f.file_size_bytes, reverse=True)
+
+        # Initialize worker buckets with total work tracking
+        # Each bucket is (total_bytes, list_of_files)
+        worker_buckets: list[tuple[int, list[FileInfo]]] = [
+            (0, []) for _ in range(self.worker_count)
+        ]
+
+        # Assign each file to worker with least total work (bin-packing)
+        for file_info in sorted_files:
+            # Find worker with minimum total work
+            min_idx = min(
+                range(len(worker_buckets)), key=lambda i: worker_buckets[i][0]
+            )
+            total_work, files_list = worker_buckets[min_idx]
+            files_list.append(file_info)
+            worker_buckets[min_idx] = (
+                total_work + file_info.file_size_bytes,
+                files_list,
+            )
+
+        return worker_buckets
+
     def create_batches(self, files: list[FileInfo]) -> list[WorkBatch]:
         """Partition files into balanced batches for parallel processing.
 
@@ -187,27 +187,8 @@ class WorkDistributor:
             f"Distributing {len(files)} files across {self.worker_count} workers"
         )
 
-        # Sort files by size descending (largest first)
-        sorted_files = sorted(files, key=lambda f: f.file_size_bytes, reverse=True)
-
-        # Initialize worker buckets with total work tracking
-        # Each bucket is (total_bytes, list_of_files)
-        worker_buckets: list[tuple[int, list[FileInfo]]] = [
-            (0, []) for _ in range(self.worker_count)
-        ]
-
-        # Assign each file to worker with least total work (bin-packing)
-        for file_info in sorted_files:
-            # Find worker with minimum total work
-            min_idx = min(
-                range(len(worker_buckets)), key=lambda i: worker_buckets[i][0]
-            )
-            total_work, files_list = worker_buckets[min_idx]
-            files_list.append(file_info)
-            worker_buckets[min_idx] = (
-                total_work + file_info.file_size_bytes,
-                files_list,
-            )
+        # Distribute files across workers
+        worker_buckets = self._distribute_files(files)
 
         # Log distribution statistics
         for worker_id, (total_bytes, worker_files) in enumerate(worker_buckets):
@@ -255,7 +236,7 @@ class WorkDistributor:
             container_qn=file_info.container_qn,
         )
 
-    def get_distribution_stats(self, files: list[FileInfo]) -> dict[str, object]:
+    def get_distribution_stats(self, files: list[FileInfo]) -> DistributionStats:
         """Get statistics about how files would be distributed.
 
         Useful for debugging and verification without creating actual batches.
@@ -264,39 +245,26 @@ class WorkDistributor:
             files: List of files to analyze.
 
         Returns:
-            Dictionary with distribution statistics.
+            DistributionStats with distribution information.
         """
         if not files:
-            return {
-                "total_files": 0,
-                "total_bytes": 0,
-                "worker_count": self.worker_count,
-                "batch_size": self.batch_size,
-                "files_per_worker": [],
-                "bytes_per_worker": [],
-            }
-
-        # Simulate distribution
-        sorted_files = sorted(files, key=lambda f: f.file_size_bytes, reverse=True)
-        worker_buckets: list[tuple[int, int]] = [
-            (0, 0) for _ in range(self.worker_count)
-        ]
-
-        for file_info in sorted_files:
-            min_idx = min(
-                range(len(worker_buckets)), key=lambda i: worker_buckets[i][0]
-            )
-            total_bytes, file_count = worker_buckets[min_idx]
-            worker_buckets[min_idx] = (
-                total_bytes + file_info.file_size_bytes,
-                file_count + 1,
+            return DistributionStats(
+                total_files=0,
+                total_bytes=0,
+                worker_count=self.worker_count,
+                batch_size=self.batch_size,
+                files_per_worker=[0] * self.worker_count,
+                bytes_per_worker=[0] * self.worker_count,
             )
 
-        return {
-            "total_files": len(files),
-            "total_bytes": sum(f.file_size_bytes for f in files),
-            "worker_count": self.worker_count,
-            "batch_size": self.batch_size,
-            "files_per_worker": [count for _, count in worker_buckets],
-            "bytes_per_worker": [bytes_ for bytes_, _ in worker_buckets],
-        }
+        # Use shared distribution logic
+        worker_buckets = self._distribute_files(files)
+
+        return DistributionStats(
+            total_files=len(files),
+            total_bytes=sum(f.file_size_bytes for f in files),
+            worker_count=self.worker_count,
+            batch_size=self.batch_size,
+            files_per_worker=[len(file_list) for _, file_list in worker_buckets],
+            bytes_per_worker=[total_bytes for total_bytes, _ in worker_buckets],
+        )

--- a/test/unit/codebase/test_work_distributor.py
+++ b/test/unit/codebase/test_work_distributor.py
@@ -7,6 +7,7 @@ import pytest
 
 from shotgun.codebase.core.work_distributor import (
     DEFAULT_BATCH_SIZE,
+    DistributionStats,
     FileInfo,
     FileParseTask,
     WorkBatch,
@@ -232,16 +233,14 @@ def test_create_batches_balanced_distribution(sample_files: list[FileInfo]) -> N
     stats = distributor.get_distribution_stats(sample_files)
 
     # Check that files are distributed across workers
-    files_per_worker = stats["files_per_worker"]
-    assert all(isinstance(count, int) for count in files_per_worker)
+    assert all(isinstance(count, int) for count in stats.files_per_worker)
 
     # Bytes should be somewhat balanced (not all in one worker)
-    bytes_per_worker = stats["bytes_per_worker"]
-    assert max(bytes_per_worker) <= sum(bytes_per_worker)  # No single worker has all
+    assert max(stats.bytes_per_worker) <= sum(stats.bytes_per_worker)
 
     # Verify batch distribution matches stats
     total_tasks_in_batches = sum(len(batch.tasks) for batch in batches)
-    assert total_tasks_in_batches == stats["total_files"]
+    assert total_tasks_in_batches == stats.total_files
 
 
 def test_create_batches_large_files_not_bottlenecked(
@@ -252,12 +251,11 @@ def test_create_batches_large_files_not_bottlenecked(
     distributor = WorkDistributor(worker_count=4, batch_size=20)
 
     stats = distributor.get_distribution_stats(sample_files)
-    bytes_per_worker = stats["bytes_per_worker"]
 
     # The two largest files (100KB, 50KB) should go to different workers
     # so max worker should have at most ~100KB + some small files
-    max_bytes = max(bytes_per_worker)
-    total_bytes = sum(bytes_per_worker)
+    max_bytes = max(stats.bytes_per_worker)
+    total_bytes = sum(stats.bytes_per_worker)
 
     # No single worker should have more than 60% of total work
     assert max_bytes <= total_bytes * 0.6
@@ -285,8 +283,7 @@ def test_create_batches_same_size_files() -> None:
 
     # Distribution should be even (3 files per worker)
     stats = distributor.get_distribution_stats(files)
-    files_per_worker = stats["files_per_worker"]
-    assert files_per_worker == [3, 3, 3, 3]
+    assert stats.files_per_worker == [3, 3, 3, 3]
 
 
 def test_create_batches_batch_size_respected(large_file_set: list[FileInfo]) -> None:
@@ -346,10 +343,12 @@ def test_get_distribution_stats_empty() -> None:
     distributor = WorkDistributor(worker_count=4, batch_size=10)
     stats = distributor.get_distribution_stats([])
 
-    assert stats["total_files"] == 0
-    assert stats["total_bytes"] == 0
-    assert stats["worker_count"] == 4
-    assert stats["batch_size"] == 10
+    assert stats.total_files == 0
+    assert stats.total_bytes == 0
+    assert stats.worker_count == 4
+    assert stats.batch_size == 10
+    assert stats.files_per_worker == [0, 0, 0, 0]
+    assert stats.bytes_per_worker == [0, 0, 0, 0]
 
 
 def test_get_distribution_stats_populated(sample_files: list[FileInfo]) -> None:
@@ -357,12 +356,20 @@ def test_get_distribution_stats_populated(sample_files: list[FileInfo]) -> None:
     distributor = WorkDistributor(worker_count=4, batch_size=10)
     stats = distributor.get_distribution_stats(sample_files)
 
-    assert stats["total_files"] == len(sample_files)
-    assert stats["total_bytes"] == sum(f.file_size_bytes for f in sample_files)
-    assert stats["worker_count"] == 4
-    assert stats["batch_size"] == 10
-    assert len(stats["files_per_worker"]) == 4
-    assert len(stats["bytes_per_worker"]) == 4
+    assert stats.total_files == len(sample_files)
+    assert stats.total_bytes == sum(f.file_size_bytes for f in sample_files)
+    assert stats.worker_count == 4
+    assert stats.batch_size == 10
+    assert len(stats.files_per_worker) == 4
+    assert len(stats.bytes_per_worker) == 4
+
+
+def test_get_distribution_stats_returns_pydantic_model() -> None:
+    """Test that get_distribution_stats returns a DistributionStats model."""
+    distributor = WorkDistributor(worker_count=2, batch_size=5)
+    stats = distributor.get_distribution_stats([])
+
+    assert isinstance(stats, DistributionStats)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Add `WorkDistributor` class with size-balanced bin-packing algorithm for distributing file parsing across workers
- Add `get_worker_count()` with adaptive CPU detection (cpu_count - 2 for 4+ cores)
- Add `get_batch_size()` with configurable batch size (default: 20)
- Support environment variable overrides: `SHOTGUN_INDEX_WORKERS`, `SHOTGUN_INDEX_BATCH_SIZE`

This is Stage 2 of the parallel indexing feature. The WorkDistributor will be integrated with `SimpleGraphBuilder` in Stage 4.

## Test plan
- [x] All 30 unit tests pass
- [x] Code coverage: 99.17%
- [x] mypy type checking passes
- [x] ruff linting passes
- [x] Edge cases tested: empty list, single file, same-size files, large file distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)