### PR TITLE
fix(ci): pass changelog via env var to avoid shell backtick interpretation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -459,10 +459,11 @@ jobs:
       - name: Send Slack notification
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SHOTGUN_ALPHA_WEBHOOK }}
+          # Pass changelog via env var to avoid shell interpretation of backticks in commit messages
+          CHANGELOG_RAW: ${{ steps.changelog.outputs.changelog }}
         run: |
           VERSION="${{ needs.build-and-package.outputs.version }}"
           IS_DEV="${{ needs.build-and-package.outputs.is_dev }}"
-          CHANGELOG_RAW="${{ steps.changelog.outputs.changelog }}"
 
           # Properly escape changelog for JSON using printf and jq
           # This ensures all special characters are properly escaped


### PR DESCRIPTION
## Summary
- Fix Slack notification failure caused by backticks in commit messages being interpreted as shell command substitution
- Move changelog from direct shell interpolation to environment variable

## Root Cause
The commit message `feat(tui): add shell command execution with `!` prefix (#266)` contains backticks. When injected via `${{ steps.changelog.outputs.changelog }}` directly into the bash script, bash interprets the backticks as command substitution and tries to execute `!` as a command, failing the step.

## Test plan
- [ ] Verify the next deployment's Slack notification succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)