### PR TITLE
fix(agents): update plan creation display text to 'Creating a Drafting plan'

### DIFF
--- a/src/shotgun/agents/router/tools/plan_tools.py
+++ b/src/shotgun/agents/router/tools/plan_tools.py
@@ -45,7 +45,7 @@ def _notify_plan_changed(deps: RouterDeps) -> None:
 
 @register_tool(
     category=ToolCategory.PLANNING,
-    display_text="Creating execution plan",
+    display_text="Creating a Drafting plan",
     key_arg="input",
 )
 async def create_plan(
@@ -63,7 +63,7 @@ async def create_plan(
     Returns:
         ToolResult indicating success or failure
     """
-    logger.debug("Creating execution plan with goal: %s", input.goal)
+    logger.debug("Creating a Drafting plan with goal: %s", input.goal)
 
     # Convert step inputs to ExecutionStep objects
     steps = [


### PR DESCRIPTION
## Summary
- Updates the display text shown during plan creation from "Creating execution plan" to "Creating a Drafting plan"
- Updates the corresponding debug log message for consistency

## Test plan
- [x] Verified mypy passes
- [x] Verified ruff passes
- [x] Verified smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)