### PR TITLE
fix(agents): remove unsupported Claude Sonnet 4 model

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -105,9 +105,9 @@ shotgun config --provider gemini --api-key "your-key"
 
 #### Update Model Selection
 ```bash
-shotgun config --model "claude-sonnet-4"
-shotgun config --model "gpt-4"
-shotgun config --model "gemini-2.0-flash-exp"
+shotgun config --model "claude-sonnet-4-5"
+shotgun config --model "gpt-5.1"
+shotgun config --model "gemini-2.5-pro"
 ```
 
 ### Codebase Graph Management

--- a/src/shotgun/agents/config/models.py
+++ b/src/shotgun/agents/config/models.py
@@ -28,7 +28,6 @@ class ModelName(StrEnum):
     GPT_5_1 = "gpt-5.1"
     GPT_5_2 = "gpt-5.2"
     CLAUDE_OPUS_4_5 = "claude-opus-4-5"
-    CLAUDE_SONNET_4 = "claude-sonnet-4"
     CLAUDE_SONNET_4_5 = "claude-sonnet-4-5"
     CLAUDE_HAIKU_4_5 = "claude-haiku-4-5"
     GEMINI_2_5_PRO = "gemini-2.5-pro"
@@ -156,14 +155,6 @@ MODEL_SPECS: dict[ModelName, ModelSpec] = {
         max_output_tokens=64_000,
         litellm_proxy_model_name="anthropic/claude-opus-4-5",
         short_name="Opus 4.5",
-    ),
-    ModelName.CLAUDE_SONNET_4: ModelSpec(
-        name=ModelName.CLAUDE_SONNET_4,
-        provider=ProviderType.ANTHROPIC,
-        max_input_tokens=200_000,
-        max_output_tokens=64_000,
-        litellm_proxy_model_name="anthropic/claude-sonnet-4",
-        short_name="Sonnet 4",
     ),
     ModelName.GEMINI_2_5_FLASH_LITE: ModelSpec(
         name=ModelName.GEMINI_2_5_FLASH_LITE,

--- a/src/shotgun/tui/screens/model_picker.py
+++ b/src/shotgun/tui/screens/model_picker.py
@@ -328,7 +328,6 @@ class ModelPickerScreen(Screen[ModelConfigUpdated | None]):
             ModelName.GPT_5_1: "GPT-5.1 (OpenAI)",
             ModelName.GPT_5_2: "GPT-5.2 (OpenAI)",
             ModelName.CLAUDE_OPUS_4_5: "Claude Opus 4.5 (Anthropic)",
-            ModelName.CLAUDE_SONNET_4: "Claude Sonnet 4 (Anthropic)",
             ModelName.CLAUDE_SONNET_4_5: "Claude Sonnet 4.5 (Anthropic)",
             ModelName.CLAUDE_HAIKU_4_5: "Claude Haiku 4.5 (Anthropic)",
             ModelName.GEMINI_2_5_PRO: "Gemini 2.5 Pro (Google)",


### PR DESCRIPTION
## Summary
- Remove Claude Sonnet 4 from the `ModelName` enum and `MODEL_SPECS` dictionary
- Remove Sonnet 4 from the model picker display names
- Update CLI documentation examples with current model names (gpt-5.1, claude-sonnet-4-5, gemini-2.5-pro)

## Test plan
- [x] Verify mypy passes
- [x] Verify ruff passes
- [x] Verify pytest smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)