### PR TITLE
feat(tui): add delete option to database locked dialog

### DIFF
--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -120,6 +120,7 @@ from shotgun.tui.screens.confirmation_dialog import ConfirmationDialog
 from shotgun.tui.screens.database_locked_dialog import DatabaseLockedDialog
 from shotgun.tui.screens.database_timeout_dialog import DatabaseTimeoutDialog
 from shotgun.tui.screens.kuzu_error_dialog import KuzuErrorDialog
+from shotgun.tui.screens.models import LockedDialogAction
 from shotgun.tui.screens.shared_specs import (
     CreateSpecDialog,
     ShareSpecsAction,
@@ -341,12 +342,12 @@ class ChatScreen(Screen[None]):
             # Show single locked dialog
             locked_action = await self.app.push_screen_wait(DatabaseLockedDialog())
 
-            if locked_action == "quit":
+            if locked_action == LockedDialogAction.QUIT:
                 # User cancelled - exit the app gracefully
                 await self.app.action_quit()
                 return False
 
-            if locked_action == "delete":
+            if locked_action == LockedDialogAction.DELETE:
                 # User confirmed deletion of locked databases
                 for issue in locked_issues:
                     deleted = await manager.delete_database(issue.graph_id)
@@ -365,7 +366,7 @@ class ChatScreen(Screen[None]):
                 # Continue with startup after deletion
                 return True
 
-            # locked_action == "retry" - re-detect to see if locks are cleared
+            # locked_action == LockedDialogAction.RETRY - re-detect to see if locks are cleared
             new_issues = await manager.detect_database_issues(timeout_seconds=10.0)
             still_locked = [
                 i for i in new_issues if i.error_type == KuzuErrorType.LOCKED

--- a/src/shotgun/tui/screens/database_locked_dialog.py
+++ b/src/shotgun/tui/screens/database_locked_dialog.py
@@ -1,7 +1,6 @@
 """Dialog shown when the database is locked by another process."""
 
 import webbrowser
-from typing import Literal
 
 import pyperclip  # type: ignore[import-untyped]
 from textual import on
@@ -15,12 +14,13 @@ from shotgun.exceptions import SHOTGUN_CONTACT_EMAIL
 from shotgun.posthog_telemetry import track_event
 from shotgun.tui.layout import COMPACT_HEIGHT_THRESHOLD
 from shotgun.tui.screens.confirmation_dialog import ConfirmationDialog
+from shotgun.tui.screens.models import LockedDialogAction
 
 # Discord invite link for support
 DISCORD_LINK = "https://discord.gg/5RmY6J2N7s"
 
 
-class DatabaseLockedDialog(ModalScreen[Literal["retry", "delete", "quit"]]):
+class DatabaseLockedDialog(ModalScreen[LockedDialogAction]):
     """Dialog shown when the database is locked by another process.
 
     This modal informs the user that the database is locked, which could mean
@@ -28,9 +28,9 @@ class DatabaseLockedDialog(ModalScreen[Literal["retry", "delete", "quit"]]):
     without releasing the lock.
 
     Returns:
-        "retry" if user wants to retry after closing other instances
-        "delete" if user wants to delete the locked database
-        "quit" if user wants to quit the application
+        LockedDialogAction.RETRY if user wants to retry after closing other instances
+        LockedDialogAction.DELETE if user wants to delete the locked database
+        LockedDialogAction.QUIT if user wants to quit the application
     """
 
     DEFAULT_CSS = """
@@ -172,13 +172,13 @@ class DatabaseLockedDialog(ModalScreen[Literal["retry", "delete", "quit"]]):
     def handle_cancel(self, event: Button.Pressed) -> None:
         """Handle cancel button press."""
         event.stop()
-        self.dismiss("quit")
+        self.dismiss(LockedDialogAction.QUIT)
 
     @on(Button.Pressed, "#retry")
     def handle_retry(self, event: Button.Pressed) -> None:
         """Handle retry button press."""
         event.stop()
-        self.dismiss("retry")
+        self.dismiss(LockedDialogAction.RETRY)
 
     @on(Button.Pressed, "#delete")
     async def handle_delete(self, event: Button.Pressed) -> None:
@@ -201,7 +201,7 @@ class DatabaseLockedDialog(ModalScreen[Literal["retry", "delete", "quit"]]):
         )
         if confirmed:
             track_event("database_locked_dialog_delete", {})
-            self.dismiss("delete")
+            self.dismiss(LockedDialogAction.DELETE)
 
     @on(Button.Pressed, "#copy-email")
     def handle_copy_email(self, event: Button.Pressed) -> None:

--- a/src/shotgun/tui/screens/models.py
+++ b/src/shotgun/tui/screens/models.py
@@ -1,0 +1,11 @@
+"""Models and enums for TUI screens."""
+
+from enum import StrEnum
+
+
+class LockedDialogAction(StrEnum):
+    """Actions available in the database locked dialog."""
+
+    RETRY = "retry"
+    DELETE = "delete"
+    QUIT = "quit"

--- a/test/unit/tui/screens/test_database_locked_dialog.py
+++ b/test/unit/tui/screens/test_database_locked_dialog.py
@@ -1,20 +1,18 @@
 """Tests for DatabaseLockedDialog delete functionality."""
 
+from typing import get_args, get_origin
 from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 import pytest
+from textual.screen import ModalScreen
 
 from shotgun.codebase.core.errors import DatabaseIssue, KuzuErrorType
 from shotgun.tui.screens.database_locked_dialog import DatabaseLockedDialog
+from shotgun.tui.screens.models import LockedDialogAction
 
 
 def test_dialog_class_type():
-    """Test that DatabaseLockedDialog returns the correct Literal type."""
-    # The dialog class should be a ModalScreen with Literal return type
-    from typing import Literal, get_args, get_origin
-
-    from textual.screen import ModalScreen
-
+    """Test that DatabaseLockedDialog returns the correct LockedDialogAction type."""
     assert issubclass(DatabaseLockedDialog, ModalScreen)
 
     # Check the generic type annotation
@@ -22,13 +20,13 @@ def test_dialog_class_type():
     origin = get_origin(type_hint)
     args = get_args(type_hint)
 
-    # Should be ModalScreen[Literal["retry", "delete", "quit"]]
+    # Should be ModalScreen[LockedDialogAction]
     assert origin is ModalScreen
-    assert args == (Literal["retry", "delete", "quit"],)
+    assert args == (LockedDialogAction,)
 
 
-@pytest.mark.asyncio
-async def test_handle_pending_database_issues_delete_action(
+@pytest.fixture
+def locked_db_test_context(
     mock_agent_manager,
     mock_conversation_manager,
     mock_conversation_service,
@@ -40,7 +38,11 @@ async def test_handle_pending_database_issues_delete_action(
     mock_agent_deps,
     temp_storage_dir,
 ):
-    """Test that delete action from locked dialog deletes the database."""
+    """Create common test context for database locked dialog tests.
+
+    Returns a dict with screen, mock_app, temp_storage_dir, and mock_agent_manager.
+    """
+    # Import ChatScreen inside fixture to avoid import ordering issues
     from shotgun.tui.screens.chat import ChatScreen
 
     screen = ChatScreen(
@@ -55,8 +57,27 @@ async def test_handle_pending_database_issues_delete_action(
         deps=mock_agent_deps,
     )
 
-    # Create a mock app with pending database issues
     mock_app = Mock()
+    mock_app.action_quit = AsyncMock()
+    mock_app.size = Mock(height=50)
+
+    return {
+        "screen": screen,
+        "mock_app": mock_app,
+        "temp_storage_dir": temp_storage_dir,
+        "mock_agent_manager": mock_agent_manager,
+    }
+
+
+@pytest.mark.asyncio
+async def test_handle_pending_database_issues_delete_action(locked_db_test_context):
+    """Test that delete action from locked dialog deletes the database."""
+    ctx = locked_db_test_context
+    screen = ctx["screen"]
+    mock_app = ctx["mock_app"]
+    temp_storage_dir = ctx["temp_storage_dir"]
+    mock_agent_manager = ctx["mock_agent_manager"]
+
     locked_issue = DatabaseIssue(
         graph_id="test-graph-123",
         graph_path=temp_storage_dir / "test.kuzu",
@@ -64,73 +85,40 @@ async def test_handle_pending_database_issues_delete_action(
         message="Could not set lock",
     )
     mock_app.pending_db_issues = [locked_issue]
+    mock_app.push_screen_wait = AsyncMock(return_value=LockedDialogAction.DELETE)
 
-    # Mock push_screen_wait to return "delete"
-    mock_app.push_screen_wait = AsyncMock(return_value="delete")
-    mock_app.action_quit = AsyncMock()
-    mock_app.size = Mock(height=50)
-
-    # Mock the CodebaseGraphManager at its source module
-    with patch("shotgun.codebase.core.manager.CodebaseGraphManager") as mock_manager_cls:
+    with patch(
+        "shotgun.codebase.core.manager.CodebaseGraphManager"
+    ) as mock_manager_cls:
         mock_manager_instance = Mock()
         mock_manager_instance.delete_database = AsyncMock(return_value=True)
         mock_manager_cls.return_value = mock_manager_instance
 
-        # Mock the app property on screen
         with patch.object(
             type(screen), "app", new_callable=PropertyMock
         ) as mock_app_prop:
             mock_app_prop.return_value = mock_app
 
-            # Call the handler
             result = await screen._handle_pending_database_issues()
 
-            # Should return True (continue with startup)
             assert result is True
-
-            # Should have called delete_database
             mock_manager_instance.delete_database.assert_called_once_with(
                 "test-graph-123"
             )
-
-            # Should have added hint message about deletion
             mock_agent_manager.add_hint_message.assert_called()
-            # Verify hint message mentions deletion and re-indexing
             call_args = mock_agent_manager.add_hint_message.call_args[0][0]
             assert "Deleted" in call_args.message
             assert "/index" in call_args.message
 
 
 @pytest.mark.asyncio
-async def test_handle_pending_database_issues_quit_action(
-    mock_agent_manager,
-    mock_conversation_manager,
-    mock_conversation_service,
-    mock_widget_coordinator,
-    mock_processing_state,
-    mock_command_handler,
-    mock_placeholder_hints,
-    mock_codebase_sdk,
-    mock_agent_deps,
-    temp_storage_dir,
-):
+async def test_handle_pending_database_issues_quit_action(locked_db_test_context):
     """Test that quit action from locked dialog exits the app."""
-    from shotgun.tui.screens.chat import ChatScreen
+    ctx = locked_db_test_context
+    screen = ctx["screen"]
+    mock_app = ctx["mock_app"]
+    temp_storage_dir = ctx["temp_storage_dir"]
 
-    screen = ChatScreen(
-        agent_manager=mock_agent_manager,
-        conversation_manager=mock_conversation_manager,
-        conversation_service=mock_conversation_service,
-        widget_coordinator=mock_widget_coordinator,
-        processing_state=mock_processing_state,
-        command_handler=mock_command_handler,
-        placeholder_hints=mock_placeholder_hints,
-        codebase_sdk=mock_codebase_sdk,
-        deps=mock_agent_deps,
-    )
-
-    # Create a mock app with pending database issues
-    mock_app = Mock()
     locked_issue = DatabaseIssue(
         graph_id="test-graph-123",
         graph_path=temp_storage_dir / "test.kuzu",
@@ -138,63 +126,33 @@ async def test_handle_pending_database_issues_quit_action(
         message="Could not set lock",
     )
     mock_app.pending_db_issues = [locked_issue]
+    mock_app.push_screen_wait = AsyncMock(return_value=LockedDialogAction.QUIT)
 
-    # Mock push_screen_wait to return "quit"
-    mock_app.push_screen_wait = AsyncMock(return_value="quit")
-    mock_app.action_quit = AsyncMock()
-    mock_app.size = Mock(height=50)
-
-    # Mock the CodebaseGraphManager at its source module
-    with patch("shotgun.codebase.core.manager.CodebaseGraphManager") as mock_manager_cls:
+    with patch(
+        "shotgun.codebase.core.manager.CodebaseGraphManager"
+    ) as mock_manager_cls:
         mock_manager_instance = Mock()
         mock_manager_cls.return_value = mock_manager_instance
 
-        # Mock the app property on screen
         with patch.object(
             type(screen), "app", new_callable=PropertyMock
         ) as mock_app_prop:
             mock_app_prop.return_value = mock_app
 
-            # Call the handler
             result = await screen._handle_pending_database_issues()
 
-            # Should return False (abort startup)
             assert result is False
-
-            # Should have called action_quit
             mock_app.action_quit.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_handle_pending_database_issues_retry_success(
-    mock_agent_manager,
-    mock_conversation_manager,
-    mock_conversation_service,
-    mock_widget_coordinator,
-    mock_processing_state,
-    mock_command_handler,
-    mock_placeholder_hints,
-    mock_codebase_sdk,
-    mock_agent_deps,
-    temp_storage_dir,
-):
+async def test_handle_pending_database_issues_retry_success(locked_db_test_context):
     """Test that retry action continues if lock is cleared."""
-    from shotgun.tui.screens.chat import ChatScreen
+    ctx = locked_db_test_context
+    screen = ctx["screen"]
+    mock_app = ctx["mock_app"]
+    temp_storage_dir = ctx["temp_storage_dir"]
 
-    screen = ChatScreen(
-        agent_manager=mock_agent_manager,
-        conversation_manager=mock_conversation_manager,
-        conversation_service=mock_conversation_service,
-        widget_coordinator=mock_widget_coordinator,
-        processing_state=mock_processing_state,
-        command_handler=mock_command_handler,
-        placeholder_hints=mock_placeholder_hints,
-        codebase_sdk=mock_codebase_sdk,
-        deps=mock_agent_deps,
-    )
-
-    # Create a mock app with pending database issues
-    mock_app = Mock()
     locked_issue = DatabaseIssue(
         graph_id="test-graph-123",
         graph_path=temp_storage_dir / "test.kuzu",
@@ -202,65 +160,35 @@ async def test_handle_pending_database_issues_retry_success(
         message="Could not set lock",
     )
     mock_app.pending_db_issues = [locked_issue]
+    mock_app.push_screen_wait = AsyncMock(return_value=LockedDialogAction.RETRY)
 
-    # Mock push_screen_wait to return "retry"
-    mock_app.push_screen_wait = AsyncMock(return_value="retry")
-    mock_app.action_quit = AsyncMock()
-    mock_app.size = Mock(height=50)
-
-    # Mock the CodebaseGraphManager at its source module
-    with patch("shotgun.codebase.core.manager.CodebaseGraphManager") as mock_manager_cls:
+    with patch(
+        "shotgun.codebase.core.manager.CodebaseGraphManager"
+    ) as mock_manager_cls:
         mock_manager_instance = Mock()
-        # Simulate lock being cleared on retry
         mock_manager_instance.detect_database_issues = AsyncMock(return_value=[])
         mock_manager_cls.return_value = mock_manager_instance
 
-        # Mock the app property on screen
         with patch.object(
             type(screen), "app", new_callable=PropertyMock
         ) as mock_app_prop:
             mock_app_prop.return_value = mock_app
 
-            # Call the handler
             result = await screen._handle_pending_database_issues()
 
-            # Should return True (continue with startup)
             assert result is True
-
-            # Should have called detect_database_issues to check if lock cleared
             mock_manager_instance.detect_database_issues.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_handle_pending_database_issues_retry_still_locked(
-    mock_agent_manager,
-    mock_conversation_manager,
-    mock_conversation_service,
-    mock_widget_coordinator,
-    mock_processing_state,
-    mock_command_handler,
-    mock_placeholder_hints,
-    mock_codebase_sdk,
-    mock_agent_deps,
-    temp_storage_dir,
-):
+async def test_handle_pending_database_issues_retry_still_locked(locked_db_test_context):
     """Test that retry action quits if lock persists."""
-    from shotgun.tui.screens.chat import ChatScreen
+    ctx = locked_db_test_context
+    screen = ctx["screen"]
+    mock_app = ctx["mock_app"]
+    temp_storage_dir = ctx["temp_storage_dir"]
+    mock_agent_manager = ctx["mock_agent_manager"]
 
-    screen = ChatScreen(
-        agent_manager=mock_agent_manager,
-        conversation_manager=mock_conversation_manager,
-        conversation_service=mock_conversation_service,
-        widget_coordinator=mock_widget_coordinator,
-        processing_state=mock_processing_state,
-        command_handler=mock_command_handler,
-        placeholder_hints=mock_placeholder_hints,
-        codebase_sdk=mock_codebase_sdk,
-        deps=mock_agent_deps,
-    )
-
-    # Create a mock app with pending database issues
-    mock_app = Mock()
     locked_issue = DatabaseIssue(
         graph_id="test-graph-123",
         graph_path=temp_storage_dir / "test.kuzu",
@@ -268,37 +196,26 @@ async def test_handle_pending_database_issues_retry_still_locked(
         message="Could not set lock",
     )
     mock_app.pending_db_issues = [locked_issue]
+    mock_app.push_screen_wait = AsyncMock(return_value=LockedDialogAction.RETRY)
 
-    # Mock push_screen_wait to return "retry"
-    mock_app.push_screen_wait = AsyncMock(return_value="retry")
-    mock_app.action_quit = AsyncMock()
-    mock_app.size = Mock(height=50)
-
-    # Mock the CodebaseGraphManager at its source module
-    with patch("shotgun.codebase.core.manager.CodebaseGraphManager") as mock_manager_cls:
+    with patch(
+        "shotgun.codebase.core.manager.CodebaseGraphManager"
+    ) as mock_manager_cls:
         mock_manager_instance = Mock()
-        # Simulate lock still present on retry
         mock_manager_instance.detect_database_issues = AsyncMock(
             return_value=[locked_issue]
         )
         mock_manager_cls.return_value = mock_manager_instance
 
-        # Mock the app property on screen
         with patch.object(
             type(screen), "app", new_callable=PropertyMock
         ) as mock_app_prop:
             mock_app_prop.return_value = mock_app
 
-            # Call the handler
             result = await screen._handle_pending_database_issues()
 
-            # Should return False (abort startup)
             assert result is False
-
-            # Should have called action_quit since still locked
             mock_app.action_quit.assert_called_once()
-
-            # Should have added hint message about still being locked
             mock_agent_manager.add_hint_message.assert_called()
             call_args = mock_agent_manager.add_hint_message.call_args[0][0]
             assert "still locked" in call_args.message
@@ -306,34 +223,14 @@ async def test_handle_pending_database_issues_retry_still_locked(
 
 @pytest.mark.asyncio
 async def test_handle_pending_database_issues_delete_multiple_locked(
-    mock_agent_manager,
-    mock_conversation_manager,
-    mock_conversation_service,
-    mock_widget_coordinator,
-    mock_processing_state,
-    mock_command_handler,
-    mock_placeholder_hints,
-    mock_codebase_sdk,
-    mock_agent_deps,
-    temp_storage_dir,
+    locked_db_test_context,
 ):
     """Test that delete action deletes all locked databases."""
-    from shotgun.tui.screens.chat import ChatScreen
+    ctx = locked_db_test_context
+    screen = ctx["screen"]
+    mock_app = ctx["mock_app"]
+    temp_storage_dir = ctx["temp_storage_dir"]
 
-    screen = ChatScreen(
-        agent_manager=mock_agent_manager,
-        conversation_manager=mock_conversation_manager,
-        conversation_service=mock_conversation_service,
-        widget_coordinator=mock_widget_coordinator,
-        processing_state=mock_processing_state,
-        command_handler=mock_command_handler,
-        placeholder_hints=mock_placeholder_hints,
-        codebase_sdk=mock_codebase_sdk,
-        deps=mock_agent_deps,
-    )
-
-    # Create a mock app with multiple locked database issues
-    mock_app = Mock()
     locked_issue1 = DatabaseIssue(
         graph_id="test-graph-111",
         graph_path=temp_storage_dir / "test1.kuzu",
@@ -347,31 +244,23 @@ async def test_handle_pending_database_issues_delete_multiple_locked(
         message="Could not set lock",
     )
     mock_app.pending_db_issues = [locked_issue1, locked_issue2]
+    mock_app.push_screen_wait = AsyncMock(return_value=LockedDialogAction.DELETE)
 
-    # Mock push_screen_wait to return "delete"
-    mock_app.push_screen_wait = AsyncMock(return_value="delete")
-    mock_app.action_quit = AsyncMock()
-    mock_app.size = Mock(height=50)
-
-    # Mock the CodebaseGraphManager at its source module
-    with patch("shotgun.codebase.core.manager.CodebaseGraphManager") as mock_manager_cls:
+    with patch(
+        "shotgun.codebase.core.manager.CodebaseGraphManager"
+    ) as mock_manager_cls:
         mock_manager_instance = Mock()
         mock_manager_instance.delete_database = AsyncMock(return_value=True)
         mock_manager_cls.return_value = mock_manager_instance
 
-        # Mock the app property on screen
         with patch.object(
             type(screen), "app", new_callable=PropertyMock
         ) as mock_app_prop:
             mock_app_prop.return_value = mock_app
 
-            # Call the handler
             result = await screen._handle_pending_database_issues()
 
-            # Should return True (continue with startup)
             assert result is True
-
-            # Should have called delete_database for both
             assert mock_manager_instance.delete_database.call_count == 2
             mock_manager_instance.delete_database.assert_any_call("test-graph-111")
             mock_manager_instance.delete_database.assert_any_call("test-graph-222")


### PR DESCRIPTION
## Summary
- Add "Delete Index" option to the database locked dialog for handling stale locks from unsafe shutdowns
- Update dialog message to explain that we cannot determine if another instance is running or if there's a stale lock
- Add two-step confirmation before deleting to prevent accidental data loss
- Add unit tests for the new delete, quit, and retry functionality

## Background
When shotgun crashes or shuts down unsafely while holding a database lock, the lock becomes "stale". Users are stuck because there's no other instance to close, and "Retry" doesn't help. This PR adds a "Delete Index" option that allows users to delete the locked database and re-index.

## Test plan
- [x] Unit tests pass for delete, quit, retry, and retry-still-locked scenarios
- [x] Smoke tests pass
- [x] Mypy type checking passes
- [x] Ruff linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)