### PR TITLE
fix(tui): reset execution state after ESC cancellation

### DIFF
--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -71,6 +71,7 @@ from shotgun.codebase.core.manager import (
 from shotgun.codebase.models import IndexProgress, ProgressPhase
 from shotgun.exceptions import (
     SHOTGUN_CONTACT_EMAIL,
+    AgentCancelledException,
     ErrorNotPickedUpBySentry,
     ShotgunAccountException,
 )
@@ -1881,6 +1882,12 @@ class ChatScreen(Screen[None]):
             else:
                 # Fallback if message format is unexpected
                 self.mount_hint(e.to_markdown())
+        except AgentCancelledException as e:
+            # Reset execution state on cancellation so user can switch modes
+            if isinstance(self.deps, RouterDeps):
+                self.deps.is_executing = False
+                self.deps.active_sub_agent = None
+            self.mount_hint(e.to_markdown())
         except ErrorNotPickedUpBySentry as e:
             # All other user-actionable errors - display with markdown
             self.mount_hint(e.to_markdown())


### PR DESCRIPTION
## Summary
- Reset `is_executing` and `active_sub_agent` when agent operation is cancelled via ESC
- Allows users to switch back to Planning mode with Shift+Tab after cancelling plan execution

## Root Cause
When ESC was pressed during plan execution, the worker was cancelled and `AgentCancelledException` was raised, but `is_executing` and `active_sub_agent` were not reset. This blocked mode toggle at `chat_screen.py:577-588`.

## Fix
Added explicit handling for `AgentCancelledException` that resets these execution state variables before showing the cancellation message.

Fixes #310

## Test plan
- [x] Start the TUI and enter planning mode
- [x] Submit a task that creates a plan
- [x] Approve the plan to start execution
- [x] Press ESC during plan execution
- [x] Verify Shift+Tab now switches back to Planning mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)