### PR TITLE
fix(agents): improve immediate cancellation of agent execution on ESC

### DIFF
--- a/src/shotgun/agents/agent_manager.py
+++ b/src/shotgun/agents/agent_manager.py
@@ -46,6 +46,7 @@ from pydantic_ai.messages import (
 from textual.message import Message
 from textual.widget import Widget
 
+from shotgun.agents.cancellation import CancellableStreamIterator
 from shotgun.agents.common import add_system_prompt_message, add_system_status_message
 from shotgun.agents.config.models import (
     KeyProvider,
@@ -1101,6 +1102,11 @@ class AgentManager(Widget):
             )
         else:
             partial_parts = []
+
+        # Wrap stream with cancellable iterator for responsive ESC handling
+        deps = _ctx.deps
+        if deps.cancellation_event:
+            stream = CancellableStreamIterator(stream, deps.cancellation_event)
 
         async for event in stream:
             try:

--- a/src/shotgun/agents/cancellation.py
+++ b/src/shotgun/agents/cancellation.py
@@ -1,0 +1,103 @@
+"""Cancellation utilities for agent execution.
+
+This module provides utilities for responsive cancellation of agent operations,
+particularly for handling ESC key presses during LLM streaming.
+"""
+
+import asyncio
+from collections.abc import AsyncIterable, AsyncIterator
+from typing import TypeVar
+
+from shotgun.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+T = TypeVar("T")
+
+CANCELLATION_CHECK_INTERVAL = 0.5  # Check every 500ms
+CANCELLATION_MESSAGE = "Operation cancelled by user"
+
+
+class CancellableStreamIterator(AsyncIterator[T]):
+    """Wraps an async iterable to check for cancellation periodically.
+
+    This allows ESC cancellation to be responsive even when the underlying
+    stream (LLM chunks) is slow to produce events. Instead of blocking
+    indefinitely on the next chunk, we timeout periodically and check
+    if cancellation was requested.
+
+    Example:
+        ```python
+        cancellation_event = asyncio.Event()
+
+        async def process_stream(stream):
+            wrapped = CancellableStreamIterator(stream, cancellation_event)
+            async for event in wrapped:
+                process(event)
+
+        # In another task, set the event to cancel:
+        cancellation_event.set()
+        ```
+    """
+
+    def __init__(
+        self,
+        stream: AsyncIterable[T],
+        cancellation_event: asyncio.Event | None = None,
+        check_interval: float = CANCELLATION_CHECK_INTERVAL,
+    ) -> None:
+        """Initialize the cancellable stream iterator.
+
+        Args:
+            stream: The underlying async iterable to wrap
+            cancellation_event: Event that signals cancellation when set
+            check_interval: How often to check for cancellation (seconds)
+        """
+        self._stream = stream
+        self._iterator: AsyncIterator[T] | None = None
+        self._cancellation_event = cancellation_event
+        self._check_interval = check_interval
+        self._pending_task: asyncio.Task[T] | None = None
+
+    def __aiter__(self) -> AsyncIterator[T]:
+        return self
+
+    async def __anext__(self) -> T:
+        if self._iterator is None:
+            self._iterator = self._stream.__aiter__()
+
+        # Create a task for the next item if we don't have one pending
+        if self._pending_task is None:
+            # Capture iterator reference for the coroutine
+            iterator = self._iterator
+
+            async def get_next() -> T:
+                return await iterator.__anext__()
+
+            self._pending_task = asyncio.create_task(get_next())
+
+        while True:
+            # Check if cancellation was requested
+            if self._cancellation_event and self._cancellation_event.is_set():
+                logger.debug("Cancellation detected in stream iterator")
+                # Cancel the pending task and raise
+                self._pending_task.cancel()
+                self._pending_task = None
+                raise asyncio.CancelledError(CANCELLATION_MESSAGE)
+
+            # Wait for the task with a short timeout
+            # Using asyncio.wait instead of wait_for to avoid cancelling the task on timeout
+            done, _ = await asyncio.wait(
+                [self._pending_task],
+                timeout=self._check_interval,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            if done:
+                # Task completed - get result and clear pending task
+                task = done.pop()
+                self._pending_task = None
+                # Re-raise StopAsyncIteration or return the result
+                return task.result()
+
+            # Task not done yet, loop and check cancellation again

--- a/src/shotgun/agents/models.py
+++ b/src/shotgun/agents/models.py
@@ -1,7 +1,7 @@
 """Pydantic models for agent dependencies and configuration."""
 
 import os
-from asyncio import Future, Queue
+from asyncio import Event, Future, Queue
 from collections.abc import Callable
 from datetime import datetime
 from enum import StrEnum
@@ -371,6 +371,11 @@ class AgentDeps(AgentRuntimeOptions):
     sub_agent_context: SubAgentContext | None = Field(
         default=None,
         description="Context when agent is delegated to by router",
+    )
+
+    cancellation_event: Event | None = Field(
+        default=None,
+        description="Event set when the operation should be cancelled",
     )
 
 

--- a/src/shotgun/agents/router/tools/delegation_tools.py
+++ b/src/shotgun/agents/router/tools/delegation_tools.py
@@ -255,6 +255,9 @@ async def _run_sub_agent(
     # Set up SubAgentContext so sub-agent knows it's being orchestrated
     sub_agent_deps.sub_agent_context = _build_sub_agent_context(deps)
 
+    # Propagate cancellation event for responsive ESC handling in sub-agents
+    sub_agent_deps.cancellation_event = deps.cancellation_event
+
     # Clear sub-agent's file tracker for fresh tracking
     sub_agent_deps.file_tracker.clear()
 

--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -1861,6 +1861,9 @@ class ChatScreen(Screen[None]):
         self.processing_state.start_processing("Processing...")
         self.processing_state.bind_worker(get_current_worker())
 
+        # Pass cancellation event to deps for responsive ESC handling
+        self.deps.cancellation_event = self.processing_state.cancellation_event
+
         # Start context indicator animation immediately
         self.widget_coordinator.set_context_streaming(True)
 

--- a/src/shotgun/tui/state/processing_state.py
+++ b/src/shotgun/tui/state/processing_state.py
@@ -7,6 +7,7 @@ This module provides centralized management of processing state including:
 - Providing clean cancellation API
 """
 
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 from shotgun.logging_config import get_logger
@@ -61,6 +62,7 @@ class ProcessingStateManager:
         self._spinner_widget: Spinner | None = None
         self._default_spinner_text = "Processing..."
         self._telemetry_context = telemetry_context or {}
+        self._cancellation_event: asyncio.Event | None = None
 
     @property
     def is_working(self) -> bool:
@@ -70,6 +72,15 @@ class ProcessingStateManager:
             True if processing, False if idle
         """
         return self._working
+
+    @property
+    def cancellation_event(self) -> asyncio.Event | None:
+        """Get the current cancellation event for agent deps.
+
+        Returns:
+            The cancellation event for the current operation, or None if not processing
+        """
+        return self._cancellation_event
 
     def bind_spinner(self, spinner: "Spinner") -> None:
         """Bind a spinner widget for state coordination.
@@ -95,6 +106,9 @@ class ProcessingStateManager:
         self._working = True
         text = spinner_text or self._default_spinner_text
 
+        # Create a new cancellation event for this operation
+        self._cancellation_event = asyncio.Event()
+
         # Update screen's reactive working state
         if hasattr(self.screen, "working"):
             self.screen.working = True
@@ -113,6 +127,7 @@ class ProcessingStateManager:
 
         self._working = False
         self._current_worker = None
+        self._cancellation_event = None
 
         # Update screen's reactive working state
         if hasattr(self.screen, "working"):
@@ -151,6 +166,10 @@ class ProcessingStateManager:
             return False
 
         try:
+            # Set the cancellation event first for immediate effect on streaming
+            if self._cancellation_event:
+                self._cancellation_event.set()
+
             self._current_worker.cancel()
             logger.info("Operation cancelled successfully")
 

--- a/test/unit/agents/router/test_delegation.py
+++ b/test/unit/agents/router/test_delegation.py
@@ -60,6 +60,7 @@ def mock_router_deps():
     deps.tasks = []
     deps.parent_stream_handler = None  # For streaming support
     deps.pending_approval = None  # No pending approval by default
+    deps.cancellation_event = None  # For ESC cancellation support
     return deps
 
 

--- a/test/unit/agents/test_cancellation.py
+++ b/test/unit/agents/test_cancellation.py
@@ -1,0 +1,156 @@
+"""Tests for the cancellation utilities module."""
+
+import asyncio
+
+import pytest
+
+from shotgun.agents.cancellation import (
+    CANCELLATION_CHECK_INTERVAL,
+    CANCELLATION_MESSAGE,
+    CancellableStreamIterator,
+)
+
+
+async def async_generator(items: list[int], delay: float = 0):
+    """Helper async generator for testing."""
+    for item in items:
+        if delay > 0:
+            await asyncio.sleep(delay)
+        yield item
+
+
+@pytest.mark.asyncio
+async def test_cancellable_stream_iterator_yields_items_normally():
+    """Test that the iterator yields all items when not cancelled."""
+    items = [1, 2, 3, 4, 5]
+    stream = async_generator(items)
+    iterator = CancellableStreamIterator(stream)
+
+    result = [item async for item in iterator]
+
+    assert result == items
+
+
+@pytest.mark.asyncio
+async def test_cancellable_stream_iterator_raises_on_cancellation():
+    """Test that the iterator raises CancelledError when event is set."""
+    items = [1, 2, 3, 4, 5]
+    cancellation_event = asyncio.Event()
+
+    async def slow_generator():
+        for item in items:
+            await asyncio.sleep(0.1)
+            yield item
+
+    iterator = CancellableStreamIterator(
+        slow_generator(),
+        cancellation_event=cancellation_event,
+        check_interval=0.05,  # Short interval for fast test
+    )
+
+    result = []
+    with pytest.raises(asyncio.CancelledError, match=CANCELLATION_MESSAGE):
+        async for item in iterator:
+            result.append(item)
+            if len(result) == 2:
+                # Cancel after receiving 2 items
+                cancellation_event.set()
+
+    # Should have received some items before cancellation
+    assert len(result) >= 2
+
+
+@pytest.mark.asyncio
+async def test_cancellable_stream_iterator_checks_cancellation_during_slow_stream():
+    """Test that cancellation is detected even when stream is slow."""
+    cancellation_event = asyncio.Event()
+
+    async def very_slow_generator():
+        for i in range(3):
+            await asyncio.sleep(10)  # Very slow - 10 seconds per item
+            yield i
+
+    iterator = CancellableStreamIterator(
+        very_slow_generator(),
+        cancellation_event=cancellation_event,
+        check_interval=0.05,  # Check every 50ms
+    )
+
+    async def cancel_after_delay():
+        await asyncio.sleep(0.1)
+        cancellation_event.set()
+
+    # Start the cancellation task
+    cancel_task = asyncio.create_task(cancel_after_delay())
+
+    start_time = asyncio.get_event_loop().time()
+    with pytest.raises(asyncio.CancelledError):
+        async for _ in iterator:
+            pass  # Should never get here
+
+    elapsed = asyncio.get_event_loop().time() - start_time
+
+    # Should have cancelled quickly (< 1 second), not waited 10 seconds for first item
+    assert elapsed < 1.0
+
+    await cancel_task
+
+
+@pytest.mark.asyncio
+async def test_cancellable_stream_iterator_without_event():
+    """Test that the iterator works normally without a cancellation event."""
+    items = [10, 20, 30]
+    stream = async_generator(items)
+    iterator = CancellableStreamIterator(stream, cancellation_event=None)
+
+    result = [item async for item in iterator]
+
+    assert result == items
+
+
+@pytest.mark.asyncio
+async def test_cancellable_stream_iterator_handles_stop_iteration():
+    """Test that StopAsyncIteration is properly propagated."""
+    items = [1, 2]
+    stream = async_generator(items)
+    iterator = CancellableStreamIterator(stream)
+
+    result = []
+    async for item in iterator:
+        result.append(item)
+
+    assert result == items
+
+
+@pytest.mark.asyncio
+async def test_cancellable_stream_iterator_custom_check_interval():
+    """Test that custom check interval is respected."""
+    custom_interval = 0.1
+    items = [1]
+    stream = async_generator(items)
+    iterator = CancellableStreamIterator(stream, check_interval=custom_interval)
+
+    assert iterator._check_interval == custom_interval
+
+    result = [item async for item in iterator]
+    assert result == items
+
+
+@pytest.mark.asyncio
+async def test_cancellable_stream_iterator_pre_cancelled():
+    """Test immediate cancellation when event is already set."""
+    cancellation_event = asyncio.Event()
+    cancellation_event.set()  # Set before iteration starts
+
+    items = [1, 2, 3]
+    stream = async_generator(items)
+    iterator = CancellableStreamIterator(stream, cancellation_event=cancellation_event)
+
+    with pytest.raises(asyncio.CancelledError):
+        async for _ in iterator:
+            pass
+
+
+def test_default_cancellation_check_interval():
+    """Test that default check interval is 0.5 seconds."""
+    assert CANCELLATION_CHECK_INTERVAL == 0.5


### PR DESCRIPTION
## Summary

- Implement `CancellableStreamIterator` to enable responsive ESC cancellation during LLM streaming
- Previously, `asyncio.CancelledError` only raised at await points, causing delays when waiting for slow LLM chunks
- Now cancellation is checked every 500ms, ensuring ESC responds within ~1 second even during slow API calls

## Changes

- Add `cancellation_event` field to `AgentDeps` for signaling cancellation
- Create `CancellableStreamIterator` class that wraps the pydantic_ai event stream
- Wire cancellation event through `ProcessingStateManager` lifecycle
- Propagate cancellation event to sub-agents during router delegation

## Test plan

- [x] Unit tests for `CancellableStreamIterator` (8 tests)
- [x] Verify existing delegation tests pass with new cancellation_event field
- [x] mypy type checking passes
- [x] ruff linting passes
- [ ] Manual test: Start TUI, submit prompt, press ESC during execution - should cancel within ~1 second

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)