### PR TITLE
fix(prompts): add file_requests rules to Router prompt

### DIFF
--- a/src/shotgun/prompts/agents/router.j2
+++ b/src/shotgun/prompts/agents/router.j2
@@ -44,6 +44,7 @@ DON'T ask when:
 - Task is simple and clear ("What files are in .shotgun?")
 - User already provided sufficient detail
 - It's a follow-up to previous clarification
+- User asks about a specific file path (e.g. "what is in tmp/file.pdf") - use file_requests instead
 
 Question guidelines:
 - Maximum 2-4 questions (don't overwhelm)
@@ -526,6 +527,46 @@ Don't ask the user to repeat information that's already in these files.
 
 You cannot write or modify files directly. To modify any file, delegate to the appropriate sub-agent based on the file ownership in the SUB_AGENT_DELEGATION section.
 </FILE_ACCESS>
+
+<FILE_REQUESTS>
+Use file_requests to read binary files. Supported types: .pdf, .png, .jpg, .jpeg, .gif, .webp
+
+The files will be loaded and shown to you in the next message.
+
+<RULE name="File paths bypass clarifying questions">
+When the user provides a specific file path, do not ask clarifying questions.
+Load the file immediately using file_requests.
+
+A specific file path looks like: tmp/example.pdf, docs/report.pdf, designs/mockup.png
+
+When you see a path like this, your response must include file_requests with that path.
+Do not ask if the file exists. Do not ask what they want to do with it.
+Load it first. Ask questions later if needed.
+</RULE>
+
+<BAD_EXAMPLE name="Asking questions instead of loading file">
+User: What is in tmp/example_pdf.pdf
+Assistant: Before I look at that file, I have a few questions. Is this file in your workspace? What specifically are you looking for?
+
+This is wrong. The user gave a specific path. Load it immediately.
+</BAD_EXAMPLE>
+
+<BAD_EXAMPLE name="Asking about existence">
+User: What is in docs/report.pdf
+Assistant: Is this file in your project directory?
+
+This is wrong. Do not ask if a file exists. Just load it.
+</BAD_EXAMPLE>
+
+<GOOD_EXAMPLE name="Correct behavior">
+User: What is in tmp/example_pdf.pdf
+Assistant response: {"response": "Let me check that PDF.", "file_requests": ["tmp/example_pdf.pdf"], "clarifying_questions": null}
+
+This is correct. File path was specific. No questions asked. File loaded immediately.
+</GOOD_EXAMPLE>
+
+Do not use file_requests for text files like .md, .txt, or .py. Use read_file for those.
+</FILE_REQUESTS>
 
 <RESPONSE_FORMAT>
 Always respond with a clear, concise summary of what you did or what you need.


### PR DESCRIPTION
## Summary
- Add explicit rules for handling specific file paths in the Router prompt
- Router should use file_requests immediately for paths like "tmp/example.pdf" instead of asking clarifying questions
- Add FILE_REQUESTS section with rules, bad examples, and good examples

## Changes
- Add exception to "Ask Before Complex Work" rule for specific file paths
- Add FILE_REQUESTS section explaining when and how to use file_requests

## Test Results (eval: pdf_file_request_no_questions)
| Model | Pass Rate |
|-------|-----------|
| GPT 5.2 | 6/6 (100%) |
| Claude Sonnet 4.5 | 5/6 (83%) |
| Gemini 3 Pro | 6/6 (100%) |

## Test plan
- [x] Run file_requests eval with multiple models
- [ ] Manual test: ask Router "what is in tmp/example.pdf" and verify it uses file_requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)