### PR TITLE
fix(file_management): handle binary files in .shotgun directory

### DIFF
--- a/evals/datasets/router_agent/file_request_cases.py
+++ b/evals/datasets/router_agent/file_request_cases.py
@@ -140,10 +140,50 @@ PDF_NO_RESEARCH_FILE_READ = ShotgunTestCase(
 )
 
 
+# Test: Router should use file_requests for multiple PDFs in .shotgun directory
+# This captures the bug where Router tries to read .shotgun/user_stories/*.pdf files
+# using read_file (text tool) instead of file_requests (binary files)
+SHOTGUN_MULTIPLE_PDFS_FILE_REQUEST = ShotgunTestCase(
+    name="shotgun_multiple_pdfs_file_request",
+    inputs=TestCaseInput(
+        prompt="take a look at the user stories in .shotgun/user_stories/ - there are two PDFs there",
+        agent_type=AgentType.ROUTER,
+        context=TestCaseContext(
+            has_codebase_indexed=False,
+            router_mode="drafting",
+        ),
+    ),
+    expected=ExpectedAgentOutput(
+        max_clarifying_questions=0,
+        disallowed_delegations=["research", "specification", "plan", "tasks", "export"],
+        # Should NOT use read_file on PDF files (will fail with UTF-8 error)
+        # Router should use file_requests instead
+        disallowed_tools=["read_file"],
+        response_not_contains=[
+            "can't read",
+            "cannot read",
+            "binary file",  # Should not expose internal error to user
+            "UTF-8",
+            "codec",
+            "decode",
+        ],
+        # LLM Judge evaluation criteria:
+        expected_response=(
+            "The Router should immediately use file_requests to load the PDF files. "
+            "The response should indicate it will check/load the files and the file_requests "
+            "field should contain paths to both PDF files (e.g., '.shotgun/user_stories/story1.pdf'). "
+            "The Router should NOT ask clarifying questions, should NOT claim inability to access files, "
+            "and should NOT use the read_file tool which only works for text files."
+        ),
+    ),
+)
+
+
 # Export all test cases
 FILE_REQUEST_CASES: list[ShotgunTestCase] = [
     PDF_FILE_REQUEST_NO_QUESTIONS,
     IMAGE_FILE_REQUEST_NO_QUESTIONS,
     PDF_DIRECT_ACCESS_NO_EXCUSES,
     PDF_NO_RESEARCH_FILE_READ,
+    SHOTGUN_MULTIPLE_PDFS_FILE_REQUEST,
 ]

--- a/src/shotgun/agents/conversation/history/token_counting/base.py
+++ b/src/shotgun/agents/conversation/history/token_counting/base.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 
-from pydantic_ai.messages import ModelMessage
+from pydantic_ai.messages import BinaryContent, ModelMessage
 
 
 class TokenCounter(ABC):
@@ -41,33 +41,75 @@ class TokenCounter(ABC):
         """
 
 
+def _extract_text_from_content(content: object) -> str | None:
+    """Extract text from a content object, skipping BinaryContent.
+
+    Args:
+        content: A content object (str, BinaryContent, list, etc.)
+
+    Returns:
+        Extracted text or None if content is binary/empty
+    """
+    if isinstance(content, BinaryContent):
+        return None
+    if isinstance(content, str):
+        return content.strip() if content.strip() else None
+    if isinstance(content, list):
+        # Content can be a list like ['text', BinaryContent(...), 'more text']
+        text_items = []
+        for item in content:
+            extracted = _extract_text_from_content(item)
+            if extracted:
+                text_items.append(extracted)
+        return "\n".join(text_items) if text_items else None
+    # For other types, convert to string but skip if it looks like binary
+    text = str(content)
+    # Skip if it's a BinaryContent repr (contains raw bytes)
+    if "BinaryContent(data=b" in text:
+        return None
+    return text.strip() if text.strip() else None
+
+
 def extract_text_from_messages(messages: list[ModelMessage]) -> str:
     """Extract all text content from messages for token counting.
+
+    Note: BinaryContent (PDFs, images) is skipped because:
+    1. str(BinaryContent) includes raw bytes which tokenize terribly
+    2. Claude uses fixed token costs for images/PDFs based on dimensions/pages,
+       not raw data size
+    3. Including binary data in text token counting causes massive overestimates
+       (e.g., 127KB of PDFs -> 267K tokens instead of ~few thousand)
 
     Args:
         messages: List of PydanticAI messages
 
     Returns:
-        Combined text content from all messages
+        Combined text content from all messages (excluding binary content)
     """
     text_parts = []
 
     for message in messages:
         if hasattr(message, "parts"):
             for part in message.parts:
-                if hasattr(part, "content") and isinstance(part.content, str):
-                    # Only add non-empty content
-                    if part.content.strip():
-                        text_parts.append(part.content)
+                # Skip BinaryContent directly
+                if isinstance(part, BinaryContent):
+                    continue
+
+                # Check if part has content attribute (UserPromptPart, etc.)
+                if hasattr(part, "content"):
+                    extracted = _extract_text_from_content(part.content)
+                    if extracted:
+                        text_parts.append(extracted)
                 else:
-                    # Handle non-text parts (tool calls, etc.)
+                    # Handle other parts (tool calls, etc.) - but check for binary
                     part_str = str(part)
-                    if part_str.strip():
+                    # Skip if it contains BinaryContent repr
+                    if "BinaryContent(data=b" not in part_str and part_str.strip():
                         text_parts.append(part_str)
         else:
             # Handle messages without parts
             msg_str = str(message)
-            if msg_str.strip():
+            if "BinaryContent(data=b" not in msg_str and msg_str.strip():
                 text_parts.append(msg_str)
 
     # If no valid text parts found, return a minimal placeholder

--- a/src/shotgun/agents/tools/file_management.py
+++ b/src/shotgun/agents/tools/file_management.py
@@ -163,19 +163,33 @@ def _validate_shotgun_path(filename: str) -> Path:
     return full_path
 
 
+# Binary file extensions that should be loaded via file_requests
+BINARY_EXTENSIONS = {".pdf", ".png", ".jpg", ".jpeg", ".gif", ".webp"}
+
+
 @register_tool(
     category=ToolCategory.ARTIFACT_MANAGEMENT,
     display_text="Reading file",
     key_arg="filename",
 )
 async def read_file(ctx: RunContext[AgentDeps], filename: str) -> str:
-    """Read a file from the .shotgun directory.
+    """Read a TEXT file from the .shotgun directory.
+
+    IMPORTANT: This tool is for TEXT files only (.md, .txt, .json, etc.).
+
+    For BINARY files (PDFs, images), DO NOT use this tool. Instead:
+    - Use file_requests in your response to load binary files
+    - Example: {"response": "Let me check that.", "file_requests": ["/path/to/file.pdf"]}
+
+    Binary file extensions that require file_requests instead:
+    - .pdf, .png, .jpg, .jpeg, .gif, .webp
 
     Args:
         filename: Relative path to file within .shotgun directory
 
     Returns:
-        File contents as string
+        File contents as string. For binary files, returns instructions
+        with the absolute path to use in file_requests.
 
     Raises:
         ValueError: If path is outside .shotgun directory
@@ -188,6 +202,22 @@ async def read_file(ctx: RunContext[AgentDeps], filename: str) -> str:
 
         if not await aiofiles.os.path.exists(file_path):
             raise FileNotFoundError(f"File not found: {filename}")
+
+        # Check if it's a binary file type (PDF, image)
+        suffix = file_path.suffix.lower()
+        if suffix in BINARY_EXTENSIONS:
+            # Return info for the agent to use file_requests
+            logger.debug(
+                "📎 Binary file detected (%s), returning path for file_requests: %s",
+                suffix,
+                file_path,
+            )
+            return (
+                f"This is a binary file ({suffix}) that cannot be read as text. "
+                f"To view its contents, include the absolute path in your "
+                f"`file_requests` response field:\n\n"
+                f"Absolute path: {file_path}"
+            )
 
         async with aiofiles.open(file_path, encoding="utf-8") as f:
             content = await f.read()

--- a/src/shotgun/prompts/agents/router.j2
+++ b/src/shotgun/prompts/agents/router.j2
@@ -610,6 +610,30 @@ This gives you context about:
 Don't ask the user to repeat information that's already in these files.
 
 You cannot write or modify files directly. To modify any file, delegate to the appropriate sub-agent based on the file ownership in the SUB_AGENT_DELEGATION section.
+
+<BINARY_FILES_IN_SHOTGUN_DIRECTORY priority="CRITICAL">
+The read_file tool is for TEXT files ONLY (.md, .txt, .json, etc.).
+
+NEVER use read_file for binary files, even if they are in .shotgun/:
+- .pdf files → Use file_requests
+- .png, .jpg, .jpeg, .gif, .webp files → Use file_requests
+
+If a user mentions PDFs or images in .shotgun/ (e.g., ".shotgun/user_stories/story.pdf"):
+1. Use file_requests with the full path: ".shotgun/user_stories/story.pdf"
+2. DO NOT call read_file("user_stories/story.pdf") - it will fail
+
+<BAD_EXAMPLE name="Using read_file for PDFs in .shotgun">
+User: "look at the PDFs in .shotgun/user_stories/"
+You: *calls read_file("user_stories/story1.pdf")*
+WRONG - read_file cannot read binary files. It will fail with a UTF-8 decode error.
+</BAD_EXAMPLE>
+
+<GOOD_EXAMPLE name="Using file_requests for PDFs in .shotgun">
+User: "look at the PDFs in .shotgun/user_stories/"
+You: {"response": "Let me check those user stories.", "file_requests": [".shotgun/user_stories/story1.pdf", ".shotgun/user_stories/story2.pdf"]}
+CORRECT - Binary files anywhere (including .shotgun/) use file_requests.
+</GOOD_EXAMPLE>
+</BINARY_FILES_IN_SHOTGUN_DIRECTORY>
 </FILE_ACCESS>
 
 <FILE_REQUESTS>

--- a/test/unit/test_file_management.py
+++ b/test/unit/test_file_management.py
@@ -184,6 +184,84 @@ class TestReadFile:
             assert "Access denied" in result
 
     @pytest.mark.asyncio
+    async def test_read_pdf_returns_file_request_instruction(self):
+        """Test that reading a PDF returns instructions to use file_requests."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch(
+                "shotgun.agents.tools.file_management.get_shotgun_base_path"
+            ) as mock_base:
+                shotgun_dir = Path(temp_dir) / ".shotgun"
+                shotgun_dir.mkdir()
+                mock_base.return_value = shotgun_dir
+
+                # Create test PDF file (just binary content for testing)
+                test_file = shotgun_dir / "document.pdf"
+                test_file.write_bytes(b"%PDF-1.4 fake pdf content")
+
+                # Create mock context
+                mock_ctx = MagicMock()
+                mock_ctx.deps = MagicMock()
+
+                result = await read_file(mock_ctx, "document.pdf")
+
+                assert "binary file" in result
+                assert "file_requests" in result
+                assert str(test_file) in result
+
+    @pytest.mark.asyncio
+    async def test_read_image_returns_file_request_instruction(self):
+        """Test that reading an image returns instructions to use file_requests."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch(
+                "shotgun.agents.tools.file_management.get_shotgun_base_path"
+            ) as mock_base:
+                shotgun_dir = Path(temp_dir) / ".shotgun"
+                shotgun_dir.mkdir()
+                mock_base.return_value = shotgun_dir
+
+                # Create test image file (just binary content for testing)
+                test_file = shotgun_dir / "image.png"
+                test_file.write_bytes(b"\x89PNG\r\n\x1a\n fake png content")
+
+                # Create mock context
+                mock_ctx = MagicMock()
+                mock_ctx.deps = MagicMock()
+
+                result = await read_file(mock_ctx, "image.png")
+
+                assert "binary file" in result
+                assert ".png" in result
+                assert "file_requests" in result
+                assert str(test_file) in result
+
+    @pytest.mark.asyncio
+    async def test_read_all_supported_binary_extensions(self):
+        """Test that all supported binary extensions are handled."""
+        from shotgun.agents.tools.file_management import BINARY_EXTENSIONS
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch(
+                "shotgun.agents.tools.file_management.get_shotgun_base_path"
+            ) as mock_base:
+                shotgun_dir = Path(temp_dir) / ".shotgun"
+                shotgun_dir.mkdir()
+                mock_base.return_value = shotgun_dir
+
+                # Create mock context
+                mock_ctx = MagicMock()
+                mock_ctx.deps = MagicMock()
+
+                for ext in BINARY_EXTENSIONS:
+                    # Create test file
+                    test_file = shotgun_dir / f"test{ext}"
+                    test_file.write_bytes(b"binary content")
+
+                    result = await read_file(mock_ctx, f"test{ext}")
+
+                    assert "binary file" in result, f"Failed for extension {ext}"
+                    assert "file_requests" in result, f"Failed for extension {ext}"
+
+    @pytest.mark.asyncio
     async def test_permission_error_handling(self):
         """Test handling of permission errors."""
         from unittest.mock import AsyncMock


### PR DESCRIPTION
## Summary
- Fix `read_file` tool to detect binary files (PDF, PNG, JPG, etc.) and return instructions with absolute path for `file_requests`
- Add XML guidance to Router prompt for handling binary files in `.shotgun/` directory
- Add eval case and unit tests for multiple PDFs in `.shotgun` directory

## Test plan
- [x] Unit tests pass for binary file detection (`test_read_pdf_returns_file_request_instruction`, `test_read_image_returns_file_request_instruction`, `test_read_all_supported_binary_extensions`)
- [x] mypy passes
- [x] ruff passes
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)