### PR TITLE
feat(web_search): enable all web search tools for Shotgun Account users

### DIFF
--- a/src/shotgun/agents/tools/web_search/__init__.py
+++ b/src/shotgun/agents/tools/web_search/__init__.py
@@ -1,17 +1,15 @@
 """Web search tools for Pydantic AI agents.
 
 Provides web search capabilities for multiple LLM providers:
-- OpenAI: Uses Responses API with web_search tool (BYOK only)
-- Anthropic: Uses Messages API with web_search_20250305 tool (BYOK only)
-- Gemini: Uses grounding with Google Search via Pydantic AI (Shotgun Account and BYOK)
+- OpenAI: Uses Responses API with web_search tool
+- Anthropic: Uses Messages API with web_search_20250305 tool
+- Gemini: Uses grounding with Google Search via Pydantic AI
 
-Shotgun Account: Only Gemini web search is available
-BYOK: All tools work with direct provider API keys
+All web search tools are available for both Shotgun Account and BYOK users.
 """
 
 from collections.abc import Awaitable, Callable
 
-from shotgun.agents.config import get_config_manager
 from shotgun.agents.config.models import ProviderType
 from shotgun.logging_config import get_logger
 
@@ -30,55 +28,26 @@ async def get_available_web_search_tools() -> list[WebSearchTool]:
     """Get list of available web search tools based on configured API keys.
 
     Works with both Shotgun Account (via LiteLLM proxy) and BYOK (individual provider keys).
-
-    Available tools:
-    - Gemini: Available for both Shotgun Account and BYOK
-    - Anthropic: BYOK only (uses Messages API with web search)
-    - OpenAI: BYOK only (uses Responses API not compatible with LiteLLM proxy)
+    All web search tools are available for Shotgun Account users.
 
     Returns:
         List of web search tool functions that have API keys configured
     """
     tools: list[WebSearchTool] = []
 
-    # Check if using Shotgun Account
-    config_manager = get_config_manager()
-    config = await config_manager.load()
+    logger.debug("🔍 Checking available web search tools")
 
-    if config.shotgun.has_valid_account:
-        logger.debug("🔑 Shotgun Account - only Gemini web search available")
+    if await is_provider_available(ProviderType.OPENAI):
+        logger.debug("✅ OpenAI web search tool available")
+        tools.append(openai_web_search_tool)
 
-        # Gemini: Only search tool available for Shotgun Account
-        if await is_provider_available(ProviderType.GOOGLE):
-            logger.debug("✅ Gemini web search tool available")
-            tools.append(gemini_web_search_tool)
+    if await is_provider_available(ProviderType.ANTHROPIC):
+        logger.debug("✅ Anthropic web search tool available")
+        tools.append(anthropic_web_search_tool)
 
-        # Anthropic: Not available for Shotgun Account (Gemini-only for Shotgun)
-        if await is_provider_available(ProviderType.ANTHROPIC):
-            logger.debug(
-                "⚠️  Anthropic web search requires BYOK (Shotgun Account uses Gemini only)"
-            )
-
-        # OpenAI: Not available for Shotgun Account (Responses API incompatible with proxy)
-        if await is_provider_available(ProviderType.OPENAI):
-            logger.debug(
-                "⚠️  OpenAI web search requires BYOK (Responses API not supported via proxy)"
-            )
-    else:
-        # BYOK mode: Load all available tools based on individual provider keys
-        logger.debug("🔑 BYOK mode - checking all provider web search tools")
-
-        if await is_provider_available(ProviderType.OPENAI):
-            logger.debug("✅ OpenAI web search tool available")
-            tools.append(openai_web_search_tool)
-
-        if await is_provider_available(ProviderType.ANTHROPIC):
-            logger.debug("✅ Anthropic web search tool available")
-            tools.append(anthropic_web_search_tool)
-
-        if await is_provider_available(ProviderType.GOOGLE):
-            logger.debug("✅ Gemini web search tool available")
-            tools.append(gemini_web_search_tool)
+    if await is_provider_available(ProviderType.GOOGLE):
+        logger.debug("✅ Gemini web search tool available")
+        tools.append(gemini_web_search_tool)
 
     if not tools:
         logger.warning("⚠️ No web search tools available - no API keys configured")

--- a/src/shotgun/agents/tools/web_search/openai.py
+++ b/src/shotgun/agents/tools/web_search/openai.py
@@ -8,6 +8,7 @@ from opentelemetry import trace
 from shotgun.agents.config import get_provider_model
 from shotgun.agents.config.models import ProviderType
 from shotgun.agents.tools.registry import ToolCategory, register_tool
+from shotgun.llm_proxy import LITELLM_PROXY_OPENAI_BASE
 from shotgun.logging_config import get_logger
 from shotgun.prompts import PromptLoader
 from shotgun.utils.datetime_utils import get_datetime_context
@@ -30,7 +31,8 @@ async def openai_web_search_tool(query: str) -> str:
     """Perform a web search and return results.
 
     This tool uses OpenAI's web search capabilities to find current information
-    about the given query.
+    about the given query. Works with both Shotgun Account (via LiteLLM proxy)
+    and direct OpenAI API keys (BYOK).
 
     Args:
         query: The search query
@@ -68,7 +70,12 @@ async def openai_web_search_tool(query: str) -> str:
             utc_offset=dt_context.utc_offset,
         )
 
-        client = AsyncOpenAI(api_key=api_key)
+        # Use proxy for Shotgun Account, direct API for BYOK
+        if model_config.is_shotgun_account:
+            logger.debug("🔑 Using Shotgun Account proxy for OpenAI web search")
+            client = AsyncOpenAI(api_key=api_key, base_url=LITELLM_PROXY_OPENAI_BASE)
+        else:
+            client = AsyncOpenAI(api_key=api_key)
 
         # Wrap API call with timeout to prevent indefinite hangs
         try:

--- a/test/unit/test_web_search.py
+++ b/test/unit/test_web_search.py
@@ -21,6 +21,7 @@ class TestWebSearchTool:
 
         mock_model_config = Mock()
         mock_model_config.api_key = "test-api-key"
+        mock_model_config.is_shotgun_account = False
 
         with (
             patch(
@@ -52,6 +53,7 @@ class TestWebSearchTool:
 
         mock_model_config = Mock()
         mock_model_config.api_key = "test-api-key"
+        mock_model_config.is_shotgun_account = False
 
         with (
             patch(
@@ -81,6 +83,7 @@ class TestWebSearchTool:
 
         mock_model_config = Mock()
         mock_model_config.api_key = "test-api-key"
+        mock_model_config.is_shotgun_account = False
 
         with (
             patch(
@@ -108,6 +111,7 @@ class TestWebSearchTool:
 
         mock_model_config = Mock()
         mock_model_config.api_key = "test-api-key"
+        mock_model_config.is_shotgun_account = False
 
         with (
             patch(
@@ -132,6 +136,7 @@ class TestWebSearchTool:
         """Test handling of OpenAI client creation errors."""
         mock_model_config = Mock()
         mock_model_config.api_key = "test-api-key"
+        mock_model_config.is_shotgun_account = False
 
         with (
             patch(
@@ -161,6 +166,7 @@ class TestWebSearchTool:
 
         mock_model_config = Mock()
         mock_model_config.api_key = "test-api-key"
+        mock_model_config.is_shotgun_account = False
 
         with (
             patch(
@@ -229,6 +235,7 @@ class TestWebSearchTool:
 
         mock_model_config = Mock()
         mock_model_config.api_key = "test-api-key"
+        mock_model_config.is_shotgun_account = False
 
         with (
             patch(
@@ -263,6 +270,7 @@ class TestWebSearchTool:
 
         mock_model_config = Mock()
         mock_model_config.api_key = "test-api-key"
+        mock_model_config.is_shotgun_account = False
 
         with (
             patch(
@@ -296,6 +304,7 @@ class TestWebSearchTool:
 
         mock_model_config = Mock()
         mock_model_config.api_key = "test-api-key"
+        mock_model_config.is_shotgun_account = False
 
         test_queries = [
             "simple query",
@@ -363,6 +372,7 @@ class TestWebSearchTool:
 
         mock_model_config = Mock()
         mock_model_config.api_key = "test-api-key"
+        mock_model_config.is_shotgun_account = False
 
         with (
             patch(
@@ -405,6 +415,7 @@ class TestIntegrationScenarios:
 
         mock_model_config = Mock()
         mock_model_config.api_key = "test-api-key"
+        mock_model_config.is_shotgun_account = False
 
         with (
             patch(
@@ -464,6 +475,7 @@ class TestIntegrationScenarios:
 
         mock_model_config = Mock()
         mock_model_config.api_key = "test-api-key"
+        mock_model_config.is_shotgun_account = False
 
         for exception, expected_error_text in error_scenarios:
             mock_client = Mock()
@@ -493,6 +505,7 @@ class TestIntegrationScenarios:
         """Test that timeout errors return a user-friendly message."""
         mock_model_config = Mock()
         mock_model_config.api_key = "test-api-key"
+        mock_model_config.is_shotgun_account = False
 
         mock_client = Mock()
         mock_client.responses.create = AsyncMock(side_effect=TimeoutError("timeout"))
@@ -512,3 +525,40 @@ class TestIntegrationScenarios:
             result = await openai_web_search_tool("test query")
 
             assert "timed out" in result
+
+    @pytest.mark.asyncio
+    async def test_shotgun_account_uses_proxy(self):
+        """Test that Shotgun Account uses LiteLLM proxy endpoint."""
+        mock_response = Mock()
+        mock_response.output_text = "Search results"
+
+        mock_client = Mock()
+        mock_client.responses.create = AsyncMock(return_value=mock_response)
+
+        mock_model_config = Mock()
+        mock_model_config.api_key = "shotgun-api-key"
+        mock_model_config.is_shotgun_account = True
+
+        with (
+            patch(
+                "shotgun.agents.tools.web_search.openai.get_provider_model"
+            ) as mock_get_provider,
+            patch("shotgun.agents.tools.web_search.openai.AsyncOpenAI") as mock_openai,
+            patch("shotgun.agents.tools.web_search.openai.trace") as mock_trace,
+            patch(
+                "shotgun.agents.tools.web_search.openai.LITELLM_PROXY_OPENAI_BASE",
+                "https://proxy.example.com",
+            ),
+        ):
+            mock_get_provider.return_value = mock_model_config
+            mock_openai.return_value = mock_client
+            mock_span = Mock()
+            mock_trace.get_current_span.return_value = mock_span
+
+            result = await openai_web_search_tool("test query")
+
+            assert result == "Search results"
+            # Verify proxy URL is used for Shotgun Account
+            mock_openai.assert_called_once_with(
+                api_key="shotgun-api-key", base_url="https://proxy.example.com"
+            )


### PR DESCRIPTION
## Summary
- Enable all web search tools (OpenAI, Anthropic, Gemini) for Shotgun Account users, not just Gemini
- Update OpenAI web search tool to route through LiteLLM proxy when using Shotgun Account
- Simplify web search availability logic by removing Shotgun Account vs BYOK conditional branches

## Test plan
- [x] mypy type checking passes
- [x] ruff linting passes  
- [x] All unit tests pass (14 tests)
- [x] Smoke tests pass (7 tests)
- [x] Added new test `test_shotgun_account_uses_proxy` to verify proxy URL is used for Shotgun Account

🤖 Generated with [Claude Code](https://claude.com/claude-code)