### PR TITLE
feat(agents): add sub-agent cost optimization with cheaper model substitution

### DIFF
--- a/src/shotgun/agents/common.py
+++ b/src/shotgun/agents/common.py
@@ -130,6 +130,7 @@ async def create_base_agent(
     additional_tools: list[Any] | None = None,
     provider: ProviderType | None = None,
     agent_mode: AgentType | None = None,
+    for_sub_agent: bool = False,
 ) -> tuple[ShotgunAgent, AgentDeps]:
     """Create a base agent with common configuration.
 
@@ -140,6 +141,7 @@ async def create_base_agent(
         additional_tools: Optional list of additional tools
         provider: Optional provider override. If None, uses configured default
         agent_mode: The mode of the agent (research, plan, tasks, specify, export)
+        for_sub_agent: If True, use cheaper model for cost optimization
 
     Returns:
         Tuple of (Configured Pydantic AI agent, Agent dependencies)
@@ -148,7 +150,7 @@ async def create_base_agent(
 
     # Get configured model or fall back to first available provider
     try:
-        model_config = await get_provider_model(provider)
+        model_config = await get_provider_model(provider, for_sub_agent=for_sub_agent)
         provider_name = model_config.provider
         logger.debug(
             "🤖 Creating agent with configured %s model: %s",

--- a/src/shotgun/agents/config/models.py
+++ b/src/shotgun/agents/config/models.py
@@ -165,6 +165,23 @@ MODEL_SPECS: dict[ModelName, ModelSpec] = {
     ),
 }
 
+# Sub-agent model mappings for cost optimization
+# Maps expensive models to cheaper alternatives from the same provider
+SUB_AGENT_MODEL_MAPPINGS: dict[ModelName, ModelName] = {
+    # Anthropic: premium models use Haiku for sub-agents
+    ModelName.CLAUDE_OPUS_4_5: ModelName.CLAUDE_HAIKU_4_5,
+    ModelName.CLAUDE_SONNET_4_5: ModelName.CLAUDE_HAIKU_4_5,
+    # Gemini: Pro uses Flash for sub-agents
+    ModelName.GEMINI_3_PRO_PREVIEW: ModelName.GEMINI_3_FLASH_PREVIEW,
+    # OpenAI: 5.2 uses 5.1 for sub-agents
+    ModelName.GPT_5_2: ModelName.GPT_5_1,
+}
+
+
+def get_sub_agent_model(main_model: ModelName) -> ModelName:
+    """Get the cheaper model for sub-agents, or same model if no cheaper alternative."""
+    return SUB_AGENT_MODEL_MAPPINGS.get(main_model, main_model)
+
 
 class OpenAIConfig(BaseModel):
     """Configuration for OpenAI provider."""

--- a/src/shotgun/agents/config/provider.py
+++ b/src/shotgun/agents/config/provider.py
@@ -24,6 +24,7 @@ from .models import (
     ModelName,
     ProviderType,
     ShotgunConfig,
+    get_sub_agent_model,
 )
 from .streaming_test import check_streaming_capability
 
@@ -175,6 +176,7 @@ def get_or_create_model(
 
 async def get_provider_model(
     provider_or_model: ProviderType | ModelName | None = None,
+    for_sub_agent: bool = False,
 ) -> ModelConfig:
     """Get a fully configured ModelConfig with API key and Model instance.
 
@@ -183,6 +185,7 @@ async def get_provider_model(
             - If ModelName: returns that specific model with appropriate API key
             - If ProviderType: returns default model for that provider (backward compatible)
             - If None: uses default provider with its default model
+        for_sub_agent: If True, substitute cheaper model for cost optimization.
 
     Returns:
         ModelConfig with API key configured and lazy Model instance
@@ -201,6 +204,18 @@ async def get_provider_model(
         if isinstance(provider_or_model, ModelName):
             # Specific model requested - honor it (e.g., web search tools)
             model_name = provider_or_model
+        elif isinstance(provider_or_model, ProviderType):
+            # Specific provider requested - use default model for that provider
+            # This is important for web search tools that need specific provider APIs
+            provider_defaults = {
+                ProviderType.OPENAI: ModelName.GPT_5_2,
+                ProviderType.ANTHROPIC: ModelName.CLAUDE_SONNET_4_5,
+                ProviderType.GOOGLE: ModelName.GEMINI_3_FLASH_PREVIEW,
+            }
+            model_name = provider_defaults.get(
+                provider_or_model,
+                config.selected_model or get_default_model_for_provider(config),
+            )
         else:
             # No specific model requested - use selected or default
             model_name = config.selected_model or get_default_model_for_provider(config)
@@ -208,6 +223,17 @@ async def get_provider_model(
         # Gracefully fall back if the selected model doesn't exist (backwards compatibility)
         if model_name not in MODEL_SPECS:
             model_name = get_default_model_for_provider(config)
+
+        # Apply sub-agent model mapping for cost optimization
+        if for_sub_agent:
+            original_model = model_name
+            model_name = get_sub_agent_model(model_name)
+            if model_name != original_model:
+                logger.debug(
+                    "Sub-agent model substitution: %s -> %s",
+                    original_model.value,
+                    model_name.value,
+                )
 
         spec = MODEL_SPECS[model_name]
 
@@ -270,6 +296,18 @@ async def get_provider_model(
         # Gracefully fall back if model doesn't exist
         if model_name not in MODEL_SPECS:
             model_name = ModelName.GPT_5_2
+
+        # Apply sub-agent model mapping for cost optimization
+        if for_sub_agent:
+            original_model = model_name
+            model_name = get_sub_agent_model(model_name)
+            if model_name != original_model:
+                logger.debug(
+                    "Sub-agent model substitution: %s -> %s",
+                    original_model.value,
+                    model_name.value,
+                )
+
         spec = MODEL_SPECS[model_name]
 
         # Check and test streaming capability for GPT-5 family models
@@ -321,6 +359,18 @@ async def get_provider_model(
         # Gracefully fall back if model doesn't exist
         if model_name not in MODEL_SPECS:
             model_name = ModelName.CLAUDE_SONNET_4_5
+
+        # Apply sub-agent model mapping for cost optimization
+        if for_sub_agent:
+            original_model = model_name
+            model_name = get_sub_agent_model(model_name)
+            if model_name != original_model:
+                logger.debug(
+                    "Sub-agent model substitution: %s -> %s",
+                    original_model.value,
+                    model_name.value,
+                )
+
         spec = MODEL_SPECS[model_name]
 
         # Create fully configured ModelConfig
@@ -347,6 +397,18 @@ async def get_provider_model(
         # Gracefully fall back if model doesn't exist
         if model_name not in MODEL_SPECS:
             model_name = ModelName.GEMINI_3_PRO_PREVIEW
+
+        # Apply sub-agent model mapping for cost optimization
+        if for_sub_agent:
+            original_model = model_name
+            model_name = get_sub_agent_model(model_name)
+            if model_name != original_model:
+                logger.debug(
+                    "Sub-agent model substitution: %s -> %s",
+                    original_model.value,
+                    model_name.value,
+                )
+
         spec = MODEL_SPECS[model_name]
 
         # Create fully configured ModelConfig

--- a/src/shotgun/agents/export.py
+++ b/src/shotgun/agents/export.py
@@ -23,13 +23,16 @@ logger = get_logger(__name__)
 
 
 async def create_export_agent(
-    agent_runtime_options: AgentRuntimeOptions, provider: ProviderType | None = None
+    agent_runtime_options: AgentRuntimeOptions,
+    provider: ProviderType | None = None,
+    for_sub_agent: bool = False,
 ) -> tuple[ShotgunAgent, AgentDeps]:
     """Create an export agent with file management capabilities.
 
     Args:
         agent_runtime_options: Agent runtime options for the agent
         provider: Optional provider override. If None, uses configured default
+        for_sub_agent: If True, use cheaper model for cost optimization
 
     Returns:
         Tuple of (Configured Pydantic AI agent for export management, Agent dependencies)
@@ -43,6 +46,7 @@ async def create_export_agent(
         agent_runtime_options,
         provider=provider,
         agent_mode=AgentType.EXPORT,
+        for_sub_agent=for_sub_agent,
     )
     return agent, deps
 

--- a/src/shotgun/agents/plan.py
+++ b/src/shotgun/agents/plan.py
@@ -23,13 +23,16 @@ logger = get_logger(__name__)
 
 
 async def create_plan_agent(
-    agent_runtime_options: AgentRuntimeOptions, provider: ProviderType | None = None
+    agent_runtime_options: AgentRuntimeOptions,
+    provider: ProviderType | None = None,
+    for_sub_agent: bool = False,
 ) -> tuple[ShotgunAgent, AgentDeps]:
     """Create a plan agent with artifact management capabilities.
 
     Args:
         agent_runtime_options: Agent runtime options for the agent
         provider: Optional provider override. If None, uses configured default
+        for_sub_agent: If True, use cheaper model for cost optimization
 
     Returns:
         Tuple of (Configured Pydantic AI agent for planning tasks, Agent dependencies)
@@ -45,6 +48,7 @@ async def create_plan_agent(
         additional_tools=None,
         provider=provider,
         agent_mode=AgentType.PLAN,
+        for_sub_agent=for_sub_agent,
     )
     return agent, deps
 

--- a/src/shotgun/agents/research.py
+++ b/src/shotgun/agents/research.py
@@ -26,13 +26,16 @@ logger = get_logger(__name__)
 
 
 async def create_research_agent(
-    agent_runtime_options: AgentRuntimeOptions, provider: ProviderType | None = None
+    agent_runtime_options: AgentRuntimeOptions,
+    provider: ProviderType | None = None,
+    for_sub_agent: bool = False,
 ) -> tuple[ShotgunAgent, AgentDeps]:
     """Create a research agent with web search and artifact management capabilities.
 
     Args:
         agent_runtime_options: Agent runtime options for the agent
         provider: Optional provider override. If None, uses configured default
+        for_sub_agent: If True, use cheaper model for cost optimization
 
     Returns:
         Tuple of (Configured Pydantic AI agent for research tasks, Agent dependencies)
@@ -59,6 +62,7 @@ async def create_research_agent(
         additional_tools=web_search_tools,
         provider=provider,
         agent_mode=AgentType.RESEARCH,
+        for_sub_agent=for_sub_agent,
     )
     return agent, deps
 

--- a/src/shotgun/agents/router/tools/delegation_tools.py
+++ b/src/shotgun/agents/router/tools/delegation_tools.py
@@ -82,9 +82,8 @@ async def prepare_delegation_tool(
 
 
 # Type aliases for factory functions
-CreateAgentFn = Callable[
-    [AgentRuntimeOptions], Awaitable[tuple[ShotgunAgent, AgentDeps]]
-]
+# Note: Create functions accept AgentRuntimeOptions and optional for_sub_agent kwarg
+CreateAgentFn = Callable[..., Awaitable[tuple[ShotgunAgent, AgentDeps]]]
 RunAgentFn = Callable[..., Awaitable[Any]]
 
 # Maximum retries for transient errors
@@ -177,7 +176,7 @@ async def _get_or_create_sub_agent(
     runtime_options = _create_agent_runtime_options(deps)
 
     logger.debug("Creating new %s agent for delegation", agent_type.value)
-    agent, agent_deps = await create_fn(runtime_options)
+    agent, agent_deps = await create_fn(runtime_options, for_sub_agent=True)
 
     # Cache for reuse
     cache_entry: SubAgentCacheEntry = (agent, agent_deps)

--- a/src/shotgun/agents/specify.py
+++ b/src/shotgun/agents/specify.py
@@ -23,13 +23,16 @@ logger = get_logger(__name__)
 
 
 async def create_specify_agent(
-    agent_runtime_options: AgentRuntimeOptions, provider: ProviderType | None = None
+    agent_runtime_options: AgentRuntimeOptions,
+    provider: ProviderType | None = None,
+    for_sub_agent: bool = False,
 ) -> tuple[ShotgunAgent, AgentDeps]:
     """Create a specify agent with artifact management capabilities.
 
     Args:
         agent_runtime_options: Agent runtime options for the agent
         provider: Optional provider override. If None, uses configured default
+        for_sub_agent: If True, use cheaper model for cost optimization
 
     Returns:
         Tuple of (Configured Pydantic AI agent for specification tasks, Agent dependencies)
@@ -45,6 +48,7 @@ async def create_specify_agent(
         additional_tools=None,
         provider=provider,
         agent_mode=AgentType.SPECIFY,
+        for_sub_agent=for_sub_agent,
     )
     return agent, deps
 

--- a/src/shotgun/agents/tasks.py
+++ b/src/shotgun/agents/tasks.py
@@ -23,13 +23,16 @@ logger = get_logger(__name__)
 
 
 async def create_tasks_agent(
-    agent_runtime_options: AgentRuntimeOptions, provider: ProviderType | None = None
+    agent_runtime_options: AgentRuntimeOptions,
+    provider: ProviderType | None = None,
+    for_sub_agent: bool = False,
 ) -> tuple[ShotgunAgent, AgentDeps]:
     """Create a tasks agent with file management capabilities.
 
     Args:
         agent_runtime_options: Agent runtime options for the agent
         provider: Optional provider override. If None, uses configured default
+        for_sub_agent: If True, use cheaper model for cost optimization
 
     Returns:
         Tuple of (Configured Pydantic AI agent for task management, Agent dependencies)
@@ -43,6 +46,7 @@ async def create_tasks_agent(
         agent_runtime_options,
         provider=provider,
         agent_mode=AgentType.TASKS,
+        for_sub_agent=for_sub_agent,
     )
     return agent, deps
 

--- a/src/shotgun/agents/tools/web_search/__init__.py
+++ b/src/shotgun/agents/tools/web_search/__init__.py
@@ -5,12 +5,13 @@ Provides web search capabilities for multiple LLM providers:
 - Anthropic: Uses Messages API with web_search_20250305 tool
 - Gemini: Uses grounding with Google Search via Pydantic AI
 
-All web search tools are available for both Shotgun Account and BYOK users.
+Web search uses the provider matching the user's selected model for consistency.
 """
 
 from collections.abc import Awaitable, Callable
 
-from shotgun.agents.config.models import ProviderType
+from shotgun.agents.config.manager import get_config_manager
+from shotgun.agents.config.models import MODEL_SPECS, ProviderType
 from shotgun.logging_config import get_logger
 
 from .anthropic import anthropic_web_search_tool
@@ -23,38 +24,55 @@ logger = get_logger(__name__)
 # Type alias for web search tools (all now async)
 WebSearchTool = Callable[[str], Awaitable[str]]
 
+# Map providers to their web search tools
+_PROVIDER_WEB_SEARCH_TOOLS: dict[ProviderType, WebSearchTool] = {
+    ProviderType.OPENAI: openai_web_search_tool,
+    ProviderType.ANTHROPIC: anthropic_web_search_tool,
+    ProviderType.GOOGLE: gemini_web_search_tool,
+}
+
 
 async def get_available_web_search_tools() -> list[WebSearchTool]:
-    """Get list of available web search tools based on configured API keys.
+    """Get web search tool matching the user's selected provider.
 
-    Works with both Shotgun Account (via LiteLLM proxy) and BYOK (individual provider keys).
-    All web search tools are available for Shotgun Account users.
+    Prefers the web search tool from the same provider as the user's selected model.
+    Falls back to other available providers if the preferred one isn't available.
 
     Returns:
-        List of web search tool functions that have API keys configured
+        List containing the preferred web search tool, or empty if none available
     """
-    tools: list[WebSearchTool] = []
-
     logger.debug("🔍 Checking available web search tools")
 
-    if await is_provider_available(ProviderType.OPENAI):
-        logger.debug("✅ OpenAI web search tool available")
-        tools.append(openai_web_search_tool)
+    # Get user's selected model to determine preferred provider
+    config_manager = get_config_manager()
+    config = await config_manager.load(force_reload=False)
 
-    if await is_provider_available(ProviderType.ANTHROPIC):
-        logger.debug("✅ Anthropic web search tool available")
-        tools.append(anthropic_web_search_tool)
+    preferred_provider: ProviderType | None = None
+    if config.selected_model and config.selected_model in MODEL_SPECS:
+        preferred_provider = MODEL_SPECS[config.selected_model].provider
+        logger.debug(
+            "User selected model %s, preferring %s web search",
+            config.selected_model.value,
+            preferred_provider.value,
+        )
 
-    if await is_provider_available(ProviderType.GOOGLE):
-        logger.debug("✅ Gemini web search tool available")
-        tools.append(gemini_web_search_tool)
+    # Try preferred provider first
+    if preferred_provider and await is_provider_available(preferred_provider):
+        tool = _PROVIDER_WEB_SEARCH_TOOLS[preferred_provider]
+        logger.info(
+            "🔍 Using %s web search (matches selected model)", preferred_provider.value
+        )
+        return [tool]
 
-    if not tools:
-        logger.warning("⚠️ No web search tools available - no API keys configured")
-    else:
-        logger.info("🔍 %d web search tool(s) available", len(tools))
+    # Fall back to any available provider
+    for provider in ProviderType:
+        if await is_provider_available(provider):
+            tool = _PROVIDER_WEB_SEARCH_TOOLS[provider]
+            logger.info("🔍 Using %s web search (fallback)", provider.value)
+            return [tool]
 
-    return tools
+    logger.warning("⚠️ No web search tools available - no API keys configured")
+    return []
 
 
 __all__ = [

--- a/src/shotgun/agents/tools/web_search/anthropic.py
+++ b/src/shotgun/agents/tools/web_search/anthropic.py
@@ -6,7 +6,7 @@ from pydantic_ai.settings import ModelSettings
 
 from shotgun.agents.config import get_provider_model
 from shotgun.agents.config.constants import MEDIUM_TEXT_8K_TOKENS
-from shotgun.agents.config.models import ProviderType
+from shotgun.agents.config.models import ModelName
 from shotgun.agents.llm import shotgun_model_request
 from shotgun.agents.tools.registry import ToolCategory, register_tool
 from shotgun.logging_config import get_logger
@@ -45,8 +45,9 @@ async def anthropic_web_search_tool(query: str) -> str:
     logger.debug("📡 Executing Anthropic web search with prompt: %s", query)
 
     # Get model configuration (supports both Shotgun and BYOK)
+    # Use Haiku (cheapest Anthropic model) for web search
     try:
-        model_config = await get_provider_model(ProviderType.ANTHROPIC)
+        model_config = await get_provider_model(ModelName.CLAUDE_HAIKU_4_5)
     except ValueError as e:
         error_msg = f"Anthropic API key not configured: {str(e)}"
         logger.error("❌ %s", error_msg)
@@ -141,7 +142,7 @@ async def main() -> None:
     # Check if API key is available
     try:
         if callable(get_provider_model):
-            model_config = await get_provider_model(ProviderType.ANTHROPIC)
+            model_config = await get_provider_model(ModelName.CLAUDE_HAIKU_4_5)
             if not model_config.api_key:
                 raise ValueError("No API key configured")
     except (ValueError, Exception):

--- a/src/shotgun/agents/tools/web_search/openai.py
+++ b/src/shotgun/agents/tools/web_search/openai.py
@@ -74,14 +74,19 @@ async def openai_web_search_tool(query: str) -> str:
         if model_config.is_shotgun_account:
             logger.debug("🔑 Using Shotgun Account proxy for OpenAI web search")
             client = AsyncOpenAI(api_key=api_key, base_url=LITELLM_PROXY_OPENAI_BASE)
+            # Use gpt-5.2 for web search on Shotgun Account
+            # The proxy requires openai/ prefix for LiteLLM routing
+            web_search_model = "openai/gpt-5.2"
         else:
             client = AsyncOpenAI(api_key=api_key)
+            # BYOK users can use gpt-5-mini directly
+            web_search_model = "gpt-5-mini"
 
         # Wrap API call with timeout to prevent indefinite hangs
         try:
             response = await asyncio.wait_for(
                 client.responses.create(
-                    model="gpt-5-mini",
+                    model=web_search_model,
                     input=[
                         {
                             "role": "user",

--- a/test/unit/agents/config/test_sub_agent_models.py
+++ b/test/unit/agents/config/test_sub_agent_models.py
@@ -1,0 +1,92 @@
+"""Tests for sub-agent model mapping."""
+
+from shotgun.agents.config.models import (
+    MODEL_SPECS,
+    SUB_AGENT_MODEL_MAPPINGS,
+    ModelName,
+    get_sub_agent_model,
+)
+
+
+def test_anthropic_opus_maps_to_haiku():
+    """Claude Opus 4.5 should map to Claude Haiku 4.5 for sub-agents."""
+    assert get_sub_agent_model(ModelName.CLAUDE_OPUS_4_5) == ModelName.CLAUDE_HAIKU_4_5
+
+
+def test_anthropic_sonnet_maps_to_haiku():
+    """Claude Sonnet 4.5 should map to Claude Haiku 4.5 for sub-agents."""
+    assert (
+        get_sub_agent_model(ModelName.CLAUDE_SONNET_4_5) == ModelName.CLAUDE_HAIKU_4_5
+    )
+
+
+def test_anthropic_haiku_returns_self():
+    """Claude Haiku 4.5 should return itself (already cheapest)."""
+    assert get_sub_agent_model(ModelName.CLAUDE_HAIKU_4_5) == ModelName.CLAUDE_HAIKU_4_5
+
+
+def test_gemini_pro_maps_to_flash():
+    """Gemini 3 Pro should map to Gemini 3 Flash for sub-agents."""
+    assert (
+        get_sub_agent_model(ModelName.GEMINI_3_PRO_PREVIEW)
+        == ModelName.GEMINI_3_FLASH_PREVIEW
+    )
+
+
+def test_gemini_flash_returns_self():
+    """Gemini 3 Flash should return itself (already cheapest)."""
+    assert (
+        get_sub_agent_model(ModelName.GEMINI_3_FLASH_PREVIEW)
+        == ModelName.GEMINI_3_FLASH_PREVIEW
+    )
+
+
+def test_gemini_flash_lite_returns_self():
+    """Gemini 2.5 Flash Lite should return itself (already cheapest)."""
+    assert (
+        get_sub_agent_model(ModelName.GEMINI_2_5_FLASH_LITE)
+        == ModelName.GEMINI_2_5_FLASH_LITE
+    )
+
+
+def test_openai_gpt51_returns_self():
+    """GPT-5.1 should return itself (already cheapest)."""
+    assert get_sub_agent_model(ModelName.GPT_5_1) == ModelName.GPT_5_1
+
+
+def test_openai_gpt52_maps_to_gpt51():
+    """GPT-5.2 should map to GPT-5.1 for sub-agents."""
+    assert get_sub_agent_model(ModelName.GPT_5_2) == ModelName.GPT_5_1
+
+
+def test_all_mappings_preserve_provider():
+    """Ensure sub-agent models are from the same provider."""
+    for main_model, sub_model in SUB_AGENT_MODEL_MAPPINGS.items():
+        main_spec = MODEL_SPECS[main_model]
+        sub_spec = MODEL_SPECS[sub_model]
+        assert main_spec.provider == sub_spec.provider, (
+            f"Model {main_model.value} maps to {sub_model.value} "
+            f"but providers differ: {main_spec.provider} vs {sub_spec.provider}"
+        )
+
+
+def test_all_mapped_models_exist_in_specs():
+    """Ensure all models in the mapping exist in MODEL_SPECS."""
+    for main_model, sub_model in SUB_AGENT_MODEL_MAPPINGS.items():
+        assert main_model in MODEL_SPECS, (
+            f"Main model {main_model.value} not in MODEL_SPECS"
+        )
+        assert sub_model in MODEL_SPECS, (
+            f"Sub model {sub_model.value} not in MODEL_SPECS"
+        )
+
+
+def test_unmapped_models_return_self():
+    """Ensure models not in the mapping return themselves."""
+    # Get all models that are NOT in the mapping keys
+    unmapped_models = [m for m in ModelName if m not in SUB_AGENT_MODEL_MAPPINGS]
+
+    for model in unmapped_models:
+        assert get_sub_agent_model(model) == model, (
+            f"Unmapped model {model.value} should return itself"
+        )

--- a/test/unit/tui/test_copy_paste.py
+++ b/test/unit/tui/test_copy_paste.py
@@ -54,9 +54,7 @@ class TestChatHistoryOnClickLogic:
         source = inspect.getsource(ChatHistory.on_click)
 
         # Verify the method checks for selected text
-        assert "get_selected_text" in source, (
-            "on_click should check for selected text"
-        )
+        assert "get_selected_text" in source, "on_click should check for selected text"
         # Verify it only handles left clicks
         assert "button" in source, "on_click should check button type"
 
@@ -100,7 +98,9 @@ class TestCopyPasteIntegration:
         copy_called = False
         quit_pending = False
 
-        async def mock_smart_quit(screen_get_selected_text, copy_to_clipboard, start_quit_pending):
+        async def mock_smart_quit(
+            screen_get_selected_text, copy_to_clipboard, start_quit_pending
+        ):
             """Simulates the smart_quit logic with selection."""
             nonlocal copy_called, quit_pending
 
@@ -201,9 +201,9 @@ class TestQuitConfirmation:
 
         assert hasattr(ShotgunApp, "quit_pending")
         # It should be a property
-        assert isinstance(
-            ShotgunApp.quit_pending, property
-        ), "quit_pending should be a property"
+        assert isinstance(ShotgunApp.quit_pending, property), (
+            "quit_pending should be a property"
+        )
 
     def test_app_has_reset_quit_pending_method(self):
         """Verify ShotgunApp has the _reset_quit_pending method."""
@@ -231,4 +231,6 @@ class TestQuitConfirmation:
                 break
 
         assert escape_binding is not None, "escape binding should exist"
-        assert escape_binding.action == "cancel_quit", "escape should trigger cancel_quit"
+        assert escape_binding.action == "cancel_quit", (
+            "escape should trigger cancel_quit"
+        )


### PR DESCRIPTION
## Summary
- Add sub-agent cost optimization that automatically substitutes expensive models with cheaper alternatives from the same provider for delegated sub-agents
- Web search now uses the tool matching the user's selected provider

## Sub-Agent Model Mappings

| User-Selected Model | Sub-Agent Model |
|---------------------|-----------------|
| Claude Opus 4.5     | Claude Haiku 4.5 |
| Claude Sonnet 4.5   | Claude Haiku 4.5 |
| Gemini 3 Pro        | Gemini 3 Flash |
| GPT-5.2             | GPT-5.1 |
| Others              | No change |

## Web Search Changes
- Web search now prefers the tool matching the user's selected provider
- Falls back to any available provider if preferred one unavailable

## Test plan
- [x] Unit tests for model mappings
- [x] Ruff linting passes
- [x] Mypy type checking passes
- [x] Smoke tests pass

Generated with [Claude Code](https://claude.com/claude-code)