### PR TITLE
fix(agents): disable parallel tool calls for Router agent

### DIFF
--- a/src/shotgun/agents/common.py
+++ b/src/shotgun/agents/common.py
@@ -15,6 +15,7 @@ from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
 )
+from pydantic_ai.settings import ModelSettings
 
 from shotgun.agents.config import ProviderType, get_provider_model
 from shotgun.agents.models import (
@@ -537,6 +538,7 @@ async def run_agent(
     message_history: list[ModelMessage] | None = None,
     usage_limits: UsageLimits | None = None,
     event_stream_handler: EventStreamHandler | None = None,
+    model_settings: ModelSettings | None = None,
 ) -> AgentRunResult[AgentResponse]:
     """Run an agent with optional streaming support.
 
@@ -548,6 +550,8 @@ async def run_agent(
         usage_limits: Optional usage limits for the run.
         event_stream_handler: Optional callback for streaming events.
             When provided, enables real-time streaming of agent responses.
+        model_settings: Optional model settings for the run.
+            Can be used to configure model behavior like parallel_tool_calls.
 
     Returns:
         The agent run result.
@@ -565,6 +569,7 @@ async def run_agent(
         usage_limits=usage_limits,
         message_history=message_history,
         event_stream_handler=event_stream_handler,
+        model_settings=model_settings,
     )
 
     # Log file operations summary if any files were modified

--- a/src/shotgun/agents/router/router.py
+++ b/src/shotgun/agents/router/router.py
@@ -10,6 +10,7 @@ from functools import partial
 from pydantic_ai import Agent, Tool
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.messages import ModelMessage
+from pydantic_ai.settings import ModelSettings
 
 from shotgun.agents.common import (
     add_system_status_message,
@@ -169,12 +170,20 @@ async def run_router_agent(
     try:
         usage_limits = create_usage_limits()
 
+        # Disable parallel tool calls for the Router agent.
+        # This prevents models like GPT-5.2 from calling multiple delegation tools
+        # simultaneously, which would run multiple sub-agents in parallel and
+        # cause race conditions with shared state (active_sub_agent, file_tracker).
+        # Sub-agents must run sequentially to maintain proper state management.
+        router_model_settings: ModelSettings = {"parallel_tool_calls": False}
+
         result = await run_agent(
             agent=agent,  # type: ignore[arg-type]
             prompt=prompt,
             deps=deps,
             message_history=message_history,
             usage_limits=usage_limits,
+            model_settings=router_model_settings,
         )
 
         logger.debug("Router agent completed successfully")


### PR DESCRIPTION
## Summary
- Prevents models like GPT-5.2 from calling multiple delegation tools simultaneously
- Adds `model_settings` parameter to `run_agent()` for configuring model behavior
- Router agent now passes `parallel_tool_calls=False` to ensure sub-agents run sequentially

## Problem
When GPT 5.2 (and potentially other models) act as the Router agent, they make parallel tool calls that delegate to sub-agents all at the same time. This causes:
- Race conditions with shared state (`active_sub_agent`, `file_tracker`)
- UI display issues (only one active sub-agent can be shown at a time)
- Potential context confusion between sub-agents

## Solution
Pass `model_settings={"parallel_tool_calls": False}` to the Router agent's run function. This setting is supported by OpenAI models and Pydantic AI.

## Test plan
- [x] All 126 Router unit tests pass
- [x] All common.py unit tests pass
- [x] Mypy type checking passes
- [x] Ruff linting passes
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)