### PR TITLE
docs(readme): remove outdated alpha upgrade warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,6 @@ When you launch Shotgun, it will guide you through:
 
 _**💡 Pro tip:** Run Shotgun in your IDE's terminal for the best experience._
 
-> [!WARNING]
-> **Upgrading from alpha?** Uninstall the old version first:
-> ```bash
-> npm uninstall -g @proofs-io/shotgun @proofs-io/shotgun-server
-> ```
-
 ---
 
 # 🎥 Demo


### PR DESCRIPTION
## Summary
- Remove the npm uninstall warning for the old alpha version from README
- The alpha version distributed via npm is no longer relevant as Shotgun has been on uv/uvx for some time

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)