### PR TITLE
fix(conversation): replace BinaryContent with FileReference placeholders

### DIFF
--- a/src/shotgun/agents/conversation/__init__.py
+++ b/src/shotgun/agents/conversation/__init__.py
@@ -1,17 +1,20 @@
 """Conversation module for managing conversation history and persistence."""
 
 from .filters import (
+    filter_binary_content,
     filter_incomplete_messages,
     filter_orphaned_tool_responses,
     is_tool_call_complete,
 )
 from .manager import ConversationManager
-from .models import ConversationHistory, ConversationState
+from .models import ConversationHistory, ConversationState, FileReference
 
 __all__ = [
     "ConversationHistory",
     "ConversationManager",
     "ConversationState",
+    "FileReference",
+    "filter_binary_content",
     "filter_incomplete_messages",
     "filter_orphaned_tool_responses",
     "is_tool_call_complete",

--- a/src/shotgun/agents/conversation/filters.py
+++ b/src/shotgun/agents/conversation/filters.py
@@ -1,8 +1,13 @@
 """Filter functions for conversation message validation."""
 
+from __future__ import annotations
+
 import json
 import logging
+import re
+from typing import TYPE_CHECKING, Any
 
+from pydantic_ai import BinaryContent
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
@@ -10,7 +15,13 @@ from pydantic_ai.messages import (
     ModelResponse,
     ToolCallPart,
     ToolReturnPart,
+    UserPromptPart,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from pydantic_ai.messages import UserContent
 
 logger = logging.getLogger(__name__)
 
@@ -158,6 +169,146 @@ def filter_orphaned_tool_responses(messages: list[ModelMessage]) -> list[ModelMe
                 "orphaned_count": orphaned_count,
                 "total_messages": len(messages),
                 "orphaned_tool_names": orphaned_tool_names,
+            },
+        )
+
+    return filtered
+
+
+# Pattern to extract file path from the marker string preceding BinaryContent
+# Format: "\n\n--- File: {path} ---"
+_FILE_MARKER_PATTERN = re.compile(r"^[\n\s]*---\s*File:\s*(.+?)\s*---$")
+
+
+def _extract_file_path(text: str) -> str | None:
+    """Extract file path from a file marker string.
+
+    Args:
+        text: String potentially containing a file marker
+
+    Returns:
+        The file path if found, None otherwise
+    """
+    match = _FILE_MARKER_PATTERN.match(text.strip())
+    return match.group(1) if match else None
+
+
+def _create_file_reference(
+    binary: BinaryContent, file_path: str | None
+) -> dict[str, Any]:
+    """Create a FileReference dict from BinaryContent.
+
+    Args:
+        binary: The BinaryContent to create a reference for
+        file_path: The file path if known, None for unknown
+
+    Returns:
+        A dict representation of FileReference
+    """
+    return {
+        "kind": "file_reference",
+        "file_path": file_path or "<unknown>",
+        "media_type": binary.media_type,
+        "size_bytes": len(binary.data),
+    }
+
+
+def _filter_content_parts(content: Sequence[UserContent]) -> list[UserContent]:
+    """Replace BinaryContent with FileReference in content parts.
+
+    Args:
+        content: Sequence of content parts (strings, BinaryContent, etc.)
+
+    Returns:
+        New list with BinaryContent replaced by FileReference dicts
+    """
+    result: list[UserContent] = []
+    last_file_path: str | None = None
+
+    for item in content:
+        if isinstance(item, str):
+            # Check if this is a file marker and extract the path
+            extracted_path = _extract_file_path(item)
+            if extracted_path:
+                last_file_path = extracted_path
+            result.append(item)
+        elif isinstance(item, BinaryContent):
+            # Replace BinaryContent with FileReference
+            file_ref = _create_file_reference(item, last_file_path)
+            result.append(file_ref)  # type: ignore[arg-type]
+            last_file_path = None  # Reset after use
+        else:
+            # Keep other content types as-is
+            result.append(item)
+
+    return result
+
+
+def filter_binary_content(messages: list[ModelMessage]) -> list[ModelMessage]:
+    """Replace BinaryContent with FileReference placeholders in messages.
+
+    This ensures conversation history can be serialized to JSON without
+    UTF-8 encoding issues from binary data. The FileReference preserves
+    metadata about the file that was loaded.
+
+    Args:
+        messages: List of messages to filter
+
+    Returns:
+        List of messages with BinaryContent replaced by FileReference
+    """
+    filtered: list[ModelMessage] = []
+    replaced_count = 0
+
+    for message in messages:
+        if not isinstance(message, ModelRequest):
+            filtered.append(message)
+            continue
+
+        # Check if any parts contain BinaryContent
+        has_binary = False
+        for part in message.parts:
+            if isinstance(part, UserPromptPart):
+                # Content can be a string or sequence
+                if isinstance(part.content, (list, tuple)):
+                    for item in part.content:
+                        if isinstance(item, BinaryContent):
+                            has_binary = True
+                            break
+            if has_binary:
+                break
+
+        if not has_binary:
+            filtered.append(message)
+            continue
+
+        # Filter parts, replacing BinaryContent with FileReference
+        filtered_parts: list[ModelRequestPart] = []
+        for part in message.parts:
+            if isinstance(part, UserPromptPart) and isinstance(
+                part.content, (list, tuple)
+            ):
+                # Filter the content parts
+                new_content = _filter_content_parts(part.content)
+                # Count how many were replaced
+                for item in new_content:
+                    if isinstance(item, dict) and item.get("kind") == "file_reference":
+                        replaced_count += 1
+                # Create new UserPromptPart with filtered content
+                filtered_parts.append(
+                    UserPromptPart(content=new_content, timestamp=part.timestamp)
+                )
+            else:
+                filtered_parts.append(part)
+
+        filtered.append(ModelRequest(parts=filtered_parts))
+
+    if replaced_count > 0:
+        logger.info(
+            "Replaced binary content with file references",
+            extra={
+                "replaced_count": replaced_count,
+                "total_messages": len(messages),
             },
         )
 

--- a/src/shotgun/agents/conversation/models.py
+++ b/src/shotgun/agents/conversation/models.py
@@ -1,7 +1,7 @@
 """Models for persisting TUI conversation history."""
 
 from datetime import datetime
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic_ai.messages import (
@@ -15,12 +15,29 @@ from pydantic_core import to_jsonable_python
 from shotgun.tui.screens.chat_screen.hint_message import HintMessage
 
 from .filters import (
+    filter_binary_content,
     filter_incomplete_messages,
     filter_orphaned_tool_responses,
     is_tool_call_complete,
 )
 
 SerializedMessage = dict[str, Any]
+
+
+class FileReference(BaseModel):
+    """Placeholder for binary content that was loaded from a file.
+
+    When binary content (like PDFs, images) is loaded via file_requests,
+    we store this reference instead of the actual binary data to:
+    - Keep conversation.json lightweight
+    - Avoid UTF-8 encoding issues with binary data
+    - Allow the AI to request the file again if needed
+    """
+
+    kind: Literal["file_reference"] = "file_reference"
+    file_path: str
+    media_type: str
+    size_bytes: int
 
 
 class ConversationState(BaseModel):
@@ -54,8 +71,10 @@ class ConversationHistory(BaseModel):
         Args:
             messages: List of ModelMessage objects to serialize and store
         """
+        # Replace BinaryContent with FileReference to avoid serialization issues
+        filtered_messages = filter_binary_content(messages)
         # Filter out messages with incomplete tool calls to prevent corruption
-        filtered_messages = filter_incomplete_messages(messages)
+        filtered_messages = filter_incomplete_messages(filtered_messages)
         # Filter out orphaned tool responses (tool responses without tool calls)
         filtered_messages = filter_orphaned_tool_responses(filtered_messages)
 
@@ -66,17 +85,33 @@ class ConversationHistory(BaseModel):
 
     def set_ui_messages(self, messages: list[ModelMessage | HintMessage]) -> None:
         """Set ui_history from a list of UI messages."""
+        # First pass: apply binary content filter to ModelMessages only
+        # This preserves message count and order (just modifies content)
+        binary_filtered: list[ModelMessage | HintMessage] = []
+        model_messages_for_filter: list[ModelMessage] = []
+        model_indices: list[int] = []
 
-        # Filter out ModelMessages with incomplete tool calls (keep all HintMessages)
-        # We need to maintain message order, so we'll check each message individually
-        filtered_messages: list[ModelMessage | HintMessage] = []
-
-        for msg in messages:
+        for i, msg in enumerate(messages):
             if isinstance(msg, HintMessage):
-                # Always keep hint messages
+                binary_filtered.append(msg)
+            else:
+                model_messages_for_filter.append(msg)
+                model_indices.append(i)
+                binary_filtered.append(msg)  # Placeholder, will be replaced
+
+        # Apply binary content filter
+        if model_messages_for_filter:
+            filtered_models = filter_binary_content(model_messages_for_filter)
+            # Replace the placeholders with filtered versions
+            for idx, filtered_msg in zip(model_indices, filtered_models, strict=True):
+                binary_filtered[idx] = filtered_msg
+
+        # Second pass: filter out ModelMessages with incomplete tool calls
+        filtered_messages: list[ModelMessage | HintMessage] = []
+        for msg in binary_filtered:
+            if isinstance(msg, HintMessage):
                 filtered_messages.append(msg)
             elif isinstance(msg, ModelResponse):
-                # Check if this ModelResponse has incomplete tool calls
                 has_incomplete = False
                 for part in msg.parts:
                     if isinstance(part, ToolCallPart) and not is_tool_call_complete(
@@ -84,11 +119,9 @@ class ConversationHistory(BaseModel):
                     ):
                         has_incomplete = True
                         break
-
                 if not has_incomplete:
                     filtered_messages.append(msg)
             else:
-                # Keep all other ModelMessage types (ModelRequest, etc.)
                 filtered_messages.append(msg)
 
         def _serialize_message(

--- a/test/unit/agents/conversation/__init__.py
+++ b/test/unit/agents/conversation/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for conversation module."""

--- a/test/unit/agents/conversation/test_filters.py
+++ b/test/unit/agents/conversation/test_filters.py
@@ -1,0 +1,245 @@
+"""Tests for conversation filter functions."""
+
+from datetime import datetime, timezone
+
+from pydantic_ai import BinaryContent
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    UserPromptPart,
+)
+
+from shotgun.agents.conversation.filters import (
+    _create_file_reference,
+    _extract_file_path,
+    _filter_content_parts,
+    filter_binary_content,
+)
+
+
+def test_extract_file_path_valid():
+    """Test extracting file path from a valid marker string."""
+    result = _extract_file_path("\n\n--- File: /path/to/file.pdf ---")
+    assert result == "/path/to/file.pdf"
+
+
+def test_extract_file_path_with_spaces():
+    """Test extracting file path with spaces in the path."""
+    result = _extract_file_path("\n\n--- File: /path/to/my file.pdf ---")
+    assert result == "/path/to/my file.pdf"
+
+
+def test_extract_file_path_no_leading_newlines():
+    """Test extracting file path without leading newlines."""
+    result = _extract_file_path("--- File: /path/to/file.pdf ---")
+    assert result == "/path/to/file.pdf"
+
+
+def test_extract_file_path_invalid():
+    """Test that invalid strings return None."""
+    assert _extract_file_path("Hello world") is None
+    assert _extract_file_path("File: /path/to/file.pdf") is None
+    assert _extract_file_path("--- File ---") is None
+
+
+def test_create_file_reference():
+    """Test creating a file reference dict from BinaryContent."""
+    binary = BinaryContent(data=b"test data", media_type="application/pdf")
+    result = _create_file_reference(binary, "/path/to/file.pdf")
+
+    assert result["kind"] == "file_reference"
+    assert result["file_path"] == "/path/to/file.pdf"
+    assert result["media_type"] == "application/pdf"
+    assert result["size_bytes"] == 9
+
+
+def test_create_file_reference_unknown_path():
+    """Test creating a file reference with unknown path."""
+    binary = BinaryContent(data=b"test", media_type="image/png")
+    result = _create_file_reference(binary, None)
+
+    assert result["file_path"] == "<unknown>"
+
+
+def test_filter_content_parts_single_file():
+    """Test filtering content parts with a single file."""
+    binary = BinaryContent(data=b"PDF content", media_type="application/pdf")
+    content = [
+        "Please analyze this file:",
+        "\n\n--- File: /docs/report.pdf ---",
+        binary,
+    ]
+
+    result = _filter_content_parts(content)
+
+    assert len(result) == 3
+    assert result[0] == "Please analyze this file:"
+    assert result[1] == "\n\n--- File: /docs/report.pdf ---"
+    assert isinstance(result[2], dict)
+    assert result[2]["kind"] == "file_reference"
+    assert result[2]["file_path"] == "/docs/report.pdf"
+    assert result[2]["media_type"] == "application/pdf"
+    assert result[2]["size_bytes"] == 11
+
+
+def test_filter_content_parts_multiple_files():
+    """Test filtering content parts with multiple files."""
+    pdf = BinaryContent(data=b"PDF", media_type="application/pdf")
+    image = BinaryContent(data=b"IMAGE DATA", media_type="image/png")
+    content = [
+        "Here are the files:",
+        "\n\n--- File: /docs/report.pdf ---",
+        pdf,
+        "\n\n--- File: /images/chart.png ---",
+        image,
+    ]
+
+    result = _filter_content_parts(content)
+
+    assert len(result) == 5
+    assert result[2]["file_path"] == "/docs/report.pdf"
+    assert result[4]["file_path"] == "/images/chart.png"
+
+
+def test_filter_content_parts_no_binary():
+    """Test filtering content parts with no binary content."""
+    content = ["Hello", "World"]
+    result = _filter_content_parts(content)
+    assert result == ["Hello", "World"]
+
+
+def test_filter_content_parts_binary_without_marker():
+    """Test filtering binary content without a preceding file marker."""
+    binary = BinaryContent(data=b"data", media_type="image/jpeg")
+    content = ["Some text", binary]
+
+    result = _filter_content_parts(content)
+
+    assert len(result) == 2
+    assert result[1]["file_path"] == "<unknown>"
+
+
+def test_filter_binary_content_empty_list():
+    """Test filtering an empty message list."""
+    result = filter_binary_content([])
+    assert result == []
+
+
+def test_filter_binary_content_no_binary():
+    """Test filtering messages without binary content."""
+    messages = [
+        ModelRequest(parts=[UserPromptPart(content="Hello")]),
+        ModelResponse(parts=[TextPart(content="Hi there!")]),
+    ]
+
+    result = filter_binary_content(messages)
+
+    assert len(result) == 2
+    assert result[0] == messages[0]
+    assert result[1] == messages[1]
+
+
+def test_filter_binary_content_with_binary():
+    """Test filtering messages with binary content."""
+    binary = BinaryContent(data=b"PDF data here", media_type="application/pdf")
+    timestamp = datetime.now(timezone.utc)
+    messages = [
+        ModelRequest(
+            parts=[
+                UserPromptPart(
+                    content=[
+                        "Please read this file:",
+                        "\n\n--- File: /test.pdf ---",
+                        binary,
+                    ],
+                    timestamp=timestamp,
+                )
+            ]
+        ),
+        ModelResponse(parts=[TextPart(content="I've read the file.")]),
+    ]
+
+    result = filter_binary_content(messages)
+
+    assert len(result) == 2
+    # Check the first message was modified
+    request = result[0]
+    assert isinstance(request, ModelRequest)
+    user_part = request.parts[0]
+    assert isinstance(user_part, UserPromptPart)
+    assert isinstance(user_part.content, list)
+    assert len(user_part.content) == 3
+    # The binary content should be replaced with a dict
+    file_ref = user_part.content[2]
+    assert isinstance(file_ref, dict)
+    assert file_ref["kind"] == "file_reference"
+    assert file_ref["file_path"] == "/test.pdf"
+    assert file_ref["size_bytes"] == 13
+    # Timestamp should be preserved
+    assert user_part.timestamp == timestamp
+
+
+def test_filter_binary_content_preserves_model_response():
+    """Test that ModelResponse messages pass through unchanged."""
+    response = ModelResponse(parts=[TextPart(content="Response text")])
+    result = filter_binary_content([response])
+
+    assert len(result) == 1
+    assert result[0] is response
+
+
+def test_filter_binary_content_string_content_unchanged():
+    """Test that string content in UserPromptPart passes through unchanged."""
+    messages = [ModelRequest(parts=[UserPromptPart(content="Just a string")])]
+
+    result = filter_binary_content(messages)
+
+    assert len(result) == 1
+    request = result[0]
+    assert isinstance(request, ModelRequest)
+    assert request.parts[0].content == "Just a string"
+
+
+def test_filter_binary_content_multiple_requests():
+    """Test filtering multiple requests with binary content."""
+    binary1 = BinaryContent(data=b"First", media_type="application/pdf")
+    binary2 = BinaryContent(data=b"Second", media_type="image/png")
+
+    messages = [
+        ModelRequest(
+            parts=[
+                UserPromptPart(
+                    content=[
+                        "\n\n--- File: /first.pdf ---",
+                        binary1,
+                    ]
+                )
+            ]
+        ),
+        ModelResponse(parts=[TextPart(content="Got it")]),
+        ModelRequest(
+            parts=[
+                UserPromptPart(
+                    content=[
+                        "\n\n--- File: /second.png ---",
+                        binary2,
+                    ]
+                )
+            ]
+        ),
+    ]
+
+    result = filter_binary_content(messages)
+
+    assert len(result) == 3
+    # First request
+    req1 = result[0]
+    assert isinstance(req1, ModelRequest)
+    content1 = req1.parts[0].content
+    assert content1[1]["file_path"] == "/first.pdf"
+    # Third message (second request)
+    req2 = result[2]
+    assert isinstance(req2, ModelRequest)
+    content2 = req2.parts[0].content
+    assert content2[1]["file_path"] == "/second.png"


### PR DESCRIPTION
## Summary

- Fixes UTF-8 decode error when saving conversation with PDF/binary content loaded via `file_requests`
- Adds `FileReference` model as a serializable placeholder for `BinaryContent`
- Adds `filter_binary_content()` filter that replaces `BinaryContent` with `FileReference` before serialization
- Preserves file metadata (path, media_type, size_bytes) for AI context

## Problem

When a PDF file was loaded via `file_requests`, the `BinaryContent` object in `UserPromptPart.content` caused a UTF-8 decode error during `to_jsonable_python()` serialization because the fallback `str(x)` couldn't handle raw bytes.

## Solution

Replace `BinaryContent` objects with `FileReference` placeholders before serialization:

```json
{
  "kind": "file_reference",
  "file_path": "/path/to/file.pdf",
  "media_type": "application/pdf",
  "size_bytes": 12345
}
```

This keeps conversation.json lightweight, avoids encoding issues, and preserves context about what files were loaded.

## Test plan

- [x] Unit tests for `filter_binary_content()` and helpers (16 tests)
- [x] All conversation-related tests pass (47 tests)
- [x] Manual TUI verification: loaded PDF, conversation saved with `file_reference` placeholders
- [x] Verified logs show "Replaced binary content with file references"
- [x] mypy passes
- [x] ruff passes
- [x] smoke tests pass

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)