### PR TITLE
fix(config): persist selected model across TUI restarts

### DIFF
--- a/src/shotgun/agents/config/provider.py
+++ b/src/shotgun/agents/config/provider.py
@@ -48,7 +48,7 @@ def get_default_model_for_provider(config: ShotgunConfig) -> ModelName:
     """
     # Priority 1: Shotgun Account
     if _get_api_key(config.shotgun.api_key):
-        return ModelName.CLAUDE_SONNET_4_5
+        return ModelName.CLAUDE_OPUS_4_5
 
     # Priority 2: Individual provider keys
     if _get_api_key(config.anthropic.api_key):
@@ -269,20 +269,34 @@ async def get_provider_model(
                 if isinstance(provider_or_model, ProviderType)
                 else ProviderType(provider_or_model)
             )
+            requested_model = None  # Will use provider's default model
         else:
-            # No provider specified - find first available provider with a key
-            provider_enum = None
-            for provider in ProviderType:
-                if _has_provider_key(config, provider):
-                    provider_enum = provider
-                    break
+            # No provider specified - check if user has a selected model
+            if config.selected_model and config.selected_model in MODEL_SPECS:
+                selected_spec = MODEL_SPECS[config.selected_model]
+                # Only use selected model if its provider has a configured key
+                if _has_provider_key(config, selected_spec.provider):
+                    provider_enum = selected_spec.provider
+                    requested_model = config.selected_model
+                else:
+                    # Selected model's provider has no key - fall back to finding available provider
+                    provider_enum = None
+                    requested_model = None
+            else:
+                provider_enum = None
+                requested_model = None
+
+            # If no selected model or its provider unavailable, find first available provider
+            if provider_enum is None:
+                for provider in ProviderType:
+                    if _has_provider_key(config, provider):
+                        provider_enum = provider
+                        break
 
             if provider_enum is None:
                 raise ValueError(
                     "No provider keys configured. Set via environment variables or config."
                 )
-
-        requested_model = None  # Will use provider's default model
 
     if provider_enum == ProviderType.OPENAI:
         api_key = _get_api_key(config.openai.api_key, "OPENAI_API_KEY")

--- a/test/unit/test_config_manager.py
+++ b/test/unit/test_config_manager.py
@@ -419,6 +419,61 @@ async def test_get_provider_model_none_finds_first_available(mock_get_config_man
 
 @patch("shotgun.agents.config.provider.get_config_manager")
 @pytest.mark.asyncio
+async def test_get_provider_model_respects_selected_model(mock_get_config_manager):
+    """Test get_provider_model respects selected_model when provider has key."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        config_path = Path(temp_dir) / "config.json"
+        manager = ConfigManager(config_path=config_path)
+
+        import uuid
+
+        # User has selected Opus but also has OpenAI key (which would be first provider)
+        config = ShotgunConfig(
+            openai=OpenAIConfig(api_key=SecretStr("openai-key")),
+            anthropic=AnthropicConfig(api_key=SecretStr("anthropic-key")),
+            selected_model=ModelName.CLAUDE_OPUS_4_5,
+            shotgun_instance_id=str(uuid.uuid4()),
+        )
+        manager._config = config
+        mock_get_config_manager.return_value = manager
+
+        model = await get_provider_model(None)
+
+        # Should respect selected_model (Opus) not fall back to first provider (OpenAI)
+        assert isinstance(model, ModelConfig)
+        assert model.name == ModelName.CLAUDE_OPUS_4_5
+
+
+@patch("shotgun.agents.config.provider.get_config_manager")
+@pytest.mark.asyncio
+async def test_get_provider_model_falls_back_when_selected_model_provider_has_no_key(
+    mock_get_config_manager,
+):
+    """Test get_provider_model falls back when selected model's provider has no key."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        config_path = Path(temp_dir) / "config.json"
+        manager = ConfigManager(config_path=config_path)
+
+        import uuid
+
+        # User has selected Opus but only has OpenAI key (Anthropic has no key)
+        config = ShotgunConfig(
+            openai=OpenAIConfig(api_key=SecretStr("openai-key")),
+            selected_model=ModelName.CLAUDE_OPUS_4_5,
+            shotgun_instance_id=str(uuid.uuid4()),
+        )
+        manager._config = config
+        mock_get_config_manager.return_value = manager
+
+        model = await get_provider_model(None)
+
+        # Should fall back to OpenAI since Anthropic has no key
+        assert isinstance(model, ModelConfig)
+        assert model.name == ModelName.GPT_5_2
+
+
+@patch("shotgun.agents.config.provider.get_config_manager")
+@pytest.mark.asyncio
 async def test_get_provider_model_unsupported_provider(mock_get_config_manager):
     """Test get_provider_model with unsupported provider."""
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

- Fixed model selection not persisting across TUI restarts for BYOK users
- Changed default model for Shotgun Account users from Sonnet 4.5 to Opus 4.5
- Added unit tests for the new behavior

## Problem

When a user selected a model (e.g., Opus 4.5) and closed/reopened the TUI, it would revert to GPT-5.2 instead of remembering the selection. This was because `get_provider_model()` ignored `config.selected_model` in BYOK mode, instead always defaulting to the first available provider's default model.

## Solution

Modified `get_provider_model()` to:
1. Check `config.selected_model` when no specific provider/model is requested
2. Honor the selected model if its provider has a configured API key
3. Fall back to finding the first available provider only if the selected model's provider has no key

## Test plan

- [x] Unit tests pass for new behavior (`test_get_provider_model_respects_selected_model`, `test_get_provider_model_falls_back_when_selected_model_provider_has_no_key`)
- [x] All existing config tests pass (74 tests)
- [x] Smoke tests pass
- [x] Manually tested with Playwright:
  - Started TUI, verified Opus 4.5 was shown (from config)
  - Changed to Sonnet 4.5, restarted TUI
  - Verified Sonnet 4.5 persisted across restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)