### PR TITLE
feat(tui): add link buttons to HintMessage for getting started guide

### DIFF
--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -100,6 +100,8 @@ from shotgun.tui.screens.chat.codebase_index_prompt_screen import (
 )
 from shotgun.tui.screens.chat.codebase_index_selection import CodebaseIndexSelection
 from shotgun.tui.screens.chat.help_text import (
+    GETTING_STARTED_LINK,
+    GETTING_STARTED_LINK_TEXT,
     help_text_empty_dir,
     help_text_with_codebase,
 )
@@ -502,16 +504,28 @@ class ChatScreen(Screen[None]):
             await self.codebase_sdk.list_codebases_for_directory()
         ).graphs
         if accessible_graphs:
-            self.mount_hint(help_text_with_codebase(already_indexed=True))
+            self.mount_hint(
+                help_text_with_codebase(already_indexed=True),
+                link=GETTING_STARTED_LINK,
+                link_text=GETTING_STARTED_LINK_TEXT,
+            )
             return
 
         # Ask user if they want to index the current directory
         should_index = await self.app.push_screen_wait(CodebaseIndexPromptScreen())
         if not should_index:
-            self.mount_hint(help_text_empty_dir())
+            self.mount_hint(
+                help_text_empty_dir(),
+                link=GETTING_STARTED_LINK,
+                link_text=GETTING_STARTED_LINK_TEXT,
+            )
             return
 
-        self.mount_hint(help_text_with_codebase(already_indexed=False))
+        self.mount_hint(
+            help_text_with_codebase(already_indexed=False),
+            link=GETTING_STARTED_LINK,
+            link_text=GETTING_STARTED_LINK_TEXT,
+        )
 
         # Auto-index the current directory with its name
         cwd_name = cur_dir.name
@@ -963,8 +977,14 @@ class ChatScreen(Screen[None]):
                         yield ContextIndicator(id="context-indicator")
                         yield Static("", id="indexing-job-display")
 
-    def mount_hint(self, markdown: str) -> None:
-        hint = HintMessage(message=markdown)
+    def mount_hint(
+        self,
+        markdown: str,
+        *,
+        link: str | None = None,
+        link_text: str | None = None,
+    ) -> None:
+        hint = HintMessage(message=markdown, link=link, link_text=link_text)
         self.agent_manager.add_hint_message(hint)
 
     def _show_pull_hint(self) -> None:

--- a/src/shotgun/tui/screens/chat/help_text.py
+++ b/src/shotgun/tui/screens/chat/help_text.py
@@ -1,5 +1,9 @@
 """Helper functions for chat screen help text."""
 
+# Getting started guide link shown in welcome messages
+GETTING_STARTED_LINK = "https://app.shotgun.sh/how-to-use"
+GETTING_STARTED_LINK_TEXT = "Link to Getting started guide"
+
 
 def help_text_with_codebase(already_indexed: bool = False) -> str:
     """Generate help text for when a codebase is available.

--- a/src/shotgun/tui/screens/chat_screen/hint_message.py
+++ b/src/shotgun/tui/screens/chat_screen/hint_message.py
@@ -1,3 +1,4 @@
+import webbrowser
 from typing import Literal
 
 from pydantic import BaseModel
@@ -18,6 +19,9 @@ class HintMessage(BaseModel):
     # Optional email copy functionality
     email: str | None = None
     markdown_after: str | None = None
+    # Optional link functionality
+    link: str | None = None
+    link_text: str | None = None  # Button label, defaults to "Open link"
 
 
 class HintMessageWidget(Widget):
@@ -63,6 +67,31 @@ class HintMessageWidget(Widget):
             content-align: left middle;
         }
 
+        HintMessageWidget .link-row {
+            width: auto;
+            height: auto;
+            margin: 1 0;
+        }
+
+        HintMessageWidget .link-text {
+            width: auto;
+            margin-right: 1;
+            content-align: left middle;
+        }
+
+        HintMessageWidget .link-btn {
+            width: auto;
+            min-width: 16;
+            margin-right: 1;
+        }
+
+        HintMessageWidget #link-status {
+            height: 1;
+            width: 100%;
+            margin-top: 1;
+            content-align: left middle;
+        }
+
     """
 
     def __init__(self, message: HintMessage) -> None:
@@ -86,6 +115,18 @@ class HintMessageWidget(Widget):
             # Optional markdown after email
             if self.message.markdown_after:
                 yield Markdown(self.message.markdown_after)
+
+        # Optional link section
+        if self.message.link:
+            button_label = self.message.link_text or "Open link"
+            # Link buttons on same line
+            with Horizontal(classes="link-row"):
+                yield Static(f"{button_label}:", classes="link-text")
+                yield Button("Open in browser", id="open-link-btn", classes="link-btn")
+                yield Button("Copy link", id="copy-link-btn", classes="link-btn")
+
+            # Status feedback label for link operations
+            yield Label("", id="link-status")
 
     @on(Button.Pressed, "#copy-email-btn")
     def _copy_email(self) -> None:
@@ -113,3 +154,45 @@ class HintMessageWidget(Widget):
         except Exception as e:
             status_label.update(f"⚠️ Copy failed: {e}")
             logger.error(f"Failed to copy email to clipboard: {e}", exc_info=True)
+
+    @on(Button.Pressed, "#open-link-btn")
+    def _open_link(self) -> None:
+        """Open link in browser when button is pressed."""
+        if not self.message.link:
+            return
+
+        status_label = self.query_one("#link-status", Label)
+
+        try:
+            webbrowser.open(self.message.link)
+            status_label.update("✓ Opened in browser!")
+            logger.debug(f"Successfully opened link in browser: {self.message.link}")
+
+        except Exception as e:
+            status_label.update(f"⚠️ Failed to open browser: {e}")
+            logger.error(f"Failed to open link in browser: {e}", exc_info=True)
+
+    @on(Button.Pressed, "#copy-link-btn")
+    def _copy_link(self) -> None:
+        """Copy link to clipboard when button is pressed."""
+        if not self.message.link:
+            return
+
+        status_label = self.query_one("#link-status", Label)
+
+        try:
+            import pyperclip
+
+            pyperclip.copy(self.message.link)
+            status_label.update("✓ Copied to clipboard!")
+            logger.debug(f"Successfully copied link to clipboard: {self.message.link}")
+
+        except ImportError:
+            status_label.update(
+                f"⚠️ Clipboard unavailable. Please manually copy: {self.message.link}"
+            )
+            logger.warning("pyperclip not available for clipboard operations")
+
+        except Exception as e:
+            status_label.update(f"⚠️ Copy failed: {e}")
+            logger.error(f"Failed to copy link to clipboard: {e}", exc_info=True)

--- a/test/unit/tui/screens/chat_screen/test_hint_message.py
+++ b/test/unit/tui/screens/chat_screen/test_hint_message.py
@@ -1,0 +1,95 @@
+"""Unit tests for HintMessage model and widget."""
+
+from shotgun.tui.screens.chat_screen.hint_message import HintMessage, HintMessageWidget
+
+
+def test_hint_message_basic():
+    """Test basic HintMessage creation."""
+    hint = HintMessage(message="Test message")
+    assert hint.message == "Test message"
+    assert hint.kind == "hint"
+    assert hint.email is None
+    assert hint.markdown_after is None
+    assert hint.link is None
+    assert hint.link_text is None
+
+
+def test_hint_message_with_email():
+    """Test HintMessage with email field."""
+    hint = HintMessage(
+        message="Contact us for help",
+        email="support@example.com",
+        markdown_after="We'll get back to you soon.",
+    )
+    assert hint.message == "Contact us for help"
+    assert hint.email == "support@example.com"
+    assert hint.markdown_after == "We'll get back to you soon."
+
+
+def test_hint_message_with_link():
+    """Test HintMessage with link fields."""
+    hint = HintMessage(
+        message="Check out the docs",
+        link="https://example.com/docs",
+        link_text="Link to Documentation",
+    )
+    assert hint.message == "Check out the docs"
+    assert hint.link == "https://example.com/docs"
+    assert hint.link_text == "Link to Documentation"
+
+
+def test_hint_message_with_all_fields():
+    """Test HintMessage with all optional fields populated."""
+    hint = HintMessage(
+        message="Full featured message",
+        email="test@example.com",
+        markdown_after="Extra markdown content",
+        link="https://example.com",
+        link_text="Visit Website",
+    )
+    assert hint.message == "Full featured message"
+    assert hint.email == "test@example.com"
+    assert hint.markdown_after == "Extra markdown content"
+    assert hint.link == "https://example.com"
+    assert hint.link_text == "Visit Website"
+
+
+def test_hint_message_serialization():
+    """Test HintMessage JSON serialization."""
+    hint = HintMessage(
+        message="Test",
+        link="https://example.com",
+        link_text="Example Link",
+    )
+
+    # Serialize to dict
+    data = hint.model_dump()
+    assert data["message"] == "Test"
+    assert data["kind"] == "hint"
+    assert data["link"] == "https://example.com"
+    assert data["link_text"] == "Example Link"
+
+    # Deserialize back
+    hint2 = HintMessage.model_validate(data)
+    assert hint2.message == "Test"
+    assert hint2.link == "https://example.com"
+    assert hint2.link_text == "Example Link"
+
+
+def test_hint_message_widget_initialization():
+    """Test HintMessageWidget can be initialized."""
+    hint = HintMessage(message="Test message")
+    widget = HintMessageWidget(hint)
+    assert widget.message == hint
+
+
+def test_hint_message_widget_with_link():
+    """Test HintMessageWidget with link fields."""
+    hint = HintMessage(
+        message="Check our guide",
+        link="https://app.shotgun.sh/how-to-use",
+        link_text="Link to Getting started guide",
+    )
+    widget = HintMessageWidget(hint)
+    assert widget.message.link == "https://app.shotgun.sh/how-to-use"
+    assert widget.message.link_text == "Link to Getting started guide"


### PR DESCRIPTION
## Summary
- Added optional `link` and `link_text` fields to `HintMessage` model for displaying actionable links
- Added "Open in browser" and "Copy link" buttons to `HintMessageWidget` when a link is provided
- Welcome messages now include a link to the getting started guide (https://app.shotgun.sh/how-to-use)
- Extracted URL constants to `help_text.py` for DRY

## Test plan
- [ ] Start shotgun in a new directory - verify welcome message shows "Link to Getting started guide" with buttons
- [ ] Click "Open in browser" - verify browser opens to https://app.shotgun.sh/how-to-use
- [ ] Click "Copy link" - verify URL is copied to clipboard
- [ ] Run `uv run pytest test/unit/tui/screens/chat_screen/test_hint_message.py -v` - all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)