### PR TITLE
feat(config): add --sub-agent-model flag for OpenAI-compatible endpoints

### DIFF
--- a/src/shotgun/agents/config/provider.py
+++ b/src/shotgun/agents/config/provider.py
@@ -35,6 +35,7 @@ _model_cache: dict[tuple[ProviderType, KeyProvider, ModelName | str, str], Model
 
 # Module-level model override for OpenAI-compatible mode (set via --model CLI flag)
 _openai_compat_model_override: str | None = None
+_openai_compat_sub_agent_model_override: str | None = None
 
 # Default model for OpenAI-compatible endpoints
 OPENAI_COMPAT_DEFAULT_MODEL = "gpt-5.2"
@@ -50,6 +51,18 @@ def set_openai_compat_model(model: str | None) -> None:
     """
     global _openai_compat_model_override
     _openai_compat_model_override = model
+
+
+def set_openai_compat_sub_agent_model(model: str | None) -> None:
+    """Set the sub-agent model override for OpenAI-compatible endpoints.
+
+    This is called by the CLI when --sub-agent-model is specified.
+
+    Args:
+        model: Model name to use for sub-agents, or None to use the main model.
+    """
+    global _openai_compat_sub_agent_model_override
+    _openai_compat_sub_agent_model_override = model
 
 
 def _create_openai_compat_model(
@@ -274,13 +287,23 @@ async def get_provider_model(
         compat_api_key = settings.openai_compat.api_key
 
         # Use CLI override if set, otherwise use hardcoded default
-        model_name = _openai_compat_model_override or OPENAI_COMPAT_DEFAULT_MODEL
+        main_model = _openai_compat_model_override or OPENAI_COMPAT_DEFAULT_MODEL
 
-        logger.info(
-            "Using OpenAI-compatible endpoint: %s with model: %s",
-            settings.openai_compat.base_url,
-            model_name,
-        )
+        # For sub-agents, use sub-agent model if specified, otherwise fall back to main model
+        if for_sub_agent and _openai_compat_sub_agent_model_override:
+            model_name = _openai_compat_sub_agent_model_override
+            logger.info(
+                "Using OpenAI-compatible endpoint: %s with sub-agent model: %s",
+                settings.openai_compat.base_url,
+                model_name,
+            )
+        else:
+            model_name = main_model
+            logger.info(
+                "Using OpenAI-compatible endpoint: %s with model: %s",
+                settings.openai_compat.base_url,
+                model_name,
+            )
 
         return ModelConfig(
             name=model_name,

--- a/src/shotgun/main.py
+++ b/src/shotgun/main.py
@@ -173,6 +173,13 @@ def main(
             help="Model name to use (requires SHOTGUN_OPENAI_COMPAT_BASE_URL to be set)",
         ),
     ] = None,
+    sub_agent_model: Annotated[
+        str | None,
+        typer.Option(
+            "--sub-agent-model",
+            help="Model name for sub-agents (requires --model to be set)",
+        ),
+    ] = None,
 ) -> None:
     """Shotgun - AI-powered CLI tool."""
     logger.debug("Starting shotgun CLI application")
@@ -184,9 +191,14 @@ def main(
     if ctx.invoked_subcommand is None and not ctx.resilient_parsing:
         # If --model is specified, set it for OpenAI-compatible mode
         if model:
-            from shotgun.agents.config.provider import set_openai_compat_model
+            from shotgun.agents.config.provider import (
+                set_openai_compat_model,
+                set_openai_compat_sub_agent_model,
+            )
 
             set_openai_compat_model(model)
+            if sub_agent_model:
+                set_openai_compat_sub_agent_model(sub_agent_model)
 
         if web:
             logger.debug("Launching shotgun TUI as web application")
@@ -198,7 +210,8 @@ def main(
                     no_update_check=no_update_check,
                     continue_session=continue_session,
                     force_reindex=force_reindex,
-                    model_override=model,  # Passed to construct command line for spawned process
+                    model_override=model,
+                    sub_agent_model_override=sub_agent_model,
                 )
             finally:
                 # Ensure PostHog is shut down cleanly even if server exits unexpectedly

--- a/src/shotgun/tui/app.py
+++ b/src/shotgun/tui/app.py
@@ -438,6 +438,7 @@ def serve(
     continue_session: bool = False,
     force_reindex: bool = False,
     model_override: str | None = None,
+    sub_agent_model_override: str | None = None,
 ) -> None:
     """Serve the TUI application as a web application.
 
@@ -448,7 +449,8 @@ def serve(
         no_update_check: If True, disable automatic update checks.
         continue_session: If True, continue from previous conversation.
         force_reindex: If True, force re-indexing of codebase (ignores existing index).
-        model_override: If provided, set SHOTGUN_OPENAI_COMPAT_DEFAULT_MODEL env var.
+        model_override: If provided, pass --model flag to spawned process.
+        sub_agent_model_override: If provided, pass --sub-agent-model flag to spawned process.
     """
     # Detect database issues BEFORE starting the TUI
     # Note: In serve mode, issues are logged but user interaction happens in
@@ -496,6 +498,8 @@ def serve(
         command += " --force-reindex"
     if model_override:
         command += f" --model={model_override}"
+    if sub_agent_model_override:
+        command += f" --sub-agent-model={sub_agent_model_override}"
 
     # Get the path to our custom templates directory
     templates_path = Path(__file__).parent / "templates"

--- a/test/unit/test_provider.py
+++ b/test/unit/test_provider.py
@@ -484,3 +484,75 @@ async def test_get_provider_model_openai_compatible_bypasses_other_providers():
     finally:
         settings_module.settings = settings_module.Settings()
         set_openai_compat_model(None)
+
+
+@patch.dict(
+    os.environ,
+    {
+        "SHOTGUN_OPENAI_COMPAT_BASE_URL": "https://api.example.com/v1",
+        "SHOTGUN_OPENAI_COMPAT_API_KEY": "test-compat-key",
+    },
+    clear=False,
+)
+@pytest.mark.asyncio
+async def test_get_provider_model_openai_compatible_sub_agent_model():
+    """Test get_provider_model uses --sub-agent-model for sub-agents."""
+    from shotgun import settings as settings_module
+    from shotgun.agents.config.provider import (
+        set_openai_compat_model,
+        set_openai_compat_sub_agent_model,
+    )
+
+    settings_module.settings = settings_module.Settings()
+    set_openai_compat_model("gpt-5.2")
+    set_openai_compat_sub_agent_model("gpt-5.1")
+
+    try:
+        # Router model (for_sub_agent=False) should use main model
+        router_model = await get_provider_model(for_sub_agent=False)
+        assert isinstance(router_model, ModelConfig)
+        assert router_model.name == "gpt-5.2"
+        assert router_model.provider == ProviderType.OPENAI_COMPATIBLE
+
+        # Sub-agent model (for_sub_agent=True) should use sub-agent model
+        sub_agent_model = await get_provider_model(for_sub_agent=True)
+        assert isinstance(sub_agent_model, ModelConfig)
+        assert sub_agent_model.name == "gpt-5.1"
+        assert sub_agent_model.provider == ProviderType.OPENAI_COMPATIBLE
+    finally:
+        settings_module.settings = settings_module.Settings()
+        set_openai_compat_model(None)
+        set_openai_compat_sub_agent_model(None)
+
+
+@patch.dict(
+    os.environ,
+    {
+        "SHOTGUN_OPENAI_COMPAT_BASE_URL": "https://api.example.com/v1",
+        "SHOTGUN_OPENAI_COMPAT_API_KEY": "test-compat-key",
+    },
+    clear=False,
+)
+@pytest.mark.asyncio
+async def test_get_provider_model_openai_compatible_sub_agent_fallback_to_main():
+    """Test sub-agent uses main model when --sub-agent-model is not set."""
+    from shotgun import settings as settings_module
+    from shotgun.agents.config.provider import (
+        set_openai_compat_model,
+        set_openai_compat_sub_agent_model,
+    )
+
+    settings_module.settings = settings_module.Settings()
+    set_openai_compat_model("gpt-5.2")
+    set_openai_compat_sub_agent_model(None)  # Not set
+
+    try:
+        # Sub-agent should fall back to main model when sub-agent model not set
+        sub_agent_model = await get_provider_model(for_sub_agent=True)
+        assert isinstance(sub_agent_model, ModelConfig)
+        assert sub_agent_model.name == "gpt-5.2"  # Falls back to main model
+        assert sub_agent_model.provider == ProviderType.OPENAI_COMPATIBLE
+    finally:
+        settings_module.settings = settings_module.Settings()
+        set_openai_compat_model(None)
+        set_openai_compat_sub_agent_model(None)


### PR DESCRIPTION
## Summary

- Adds `--sub-agent-model` CLI flag for specifying a different model for sub-agents
- When using OpenAI-compatible mode, allows cost optimization by using smaller model for sub-agents

## Usage

```bash
export SHOTGUN_OPENAI_COMPAT_BASE_URL=https://your-endpoint.com/v1
export SHOTGUN_OPENAI_COMPAT_API_KEY=your-api-key

# Router uses gpt-5.2, sub-agents use gpt-5.1
shotgun --model=openai/gpt-5.2 --sub-agent-model=openai/gpt-5.1
```

## Behavior

- When `--sub-agent-model` is specified, sub-agents use that model
- When `--sub-agent-model` is NOT specified, sub-agents fall back to the main model
- Only applies to OpenAI-compatible mode (when `SHOTGUN_OPENAI_COMPAT_BASE_URL` is set)

## Test plan

- [x] Unit tests for sub-agent model override
- [x] Unit tests for fallback to main model
- [x] Smoke tests pass
- [x] TUI tested with Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)