### PR TITLE
feat(config): change default Shotgun Account model to Sonnet 4.5

### DIFF
--- a/src/shotgun/agents/config/provider.py
+++ b/src/shotgun/agents/config/provider.py
@@ -114,7 +114,7 @@ def get_default_model_for_provider(config: ShotgunConfig) -> ModelName:
     """
     # Priority 1: Shotgun Account
     if _get_api_key(config.shotgun.api_key):
-        return ModelName.CLAUDE_OPUS_4_5
+        return ModelName.CLAUDE_SONNET_4_5
 
     # Priority 2: Individual provider keys
     if _get_api_key(config.anthropic.api_key):


### PR DESCRIPTION
## Summary
- Changes the default model for Shotgun Account users from Claude Opus 4.5 to Claude Sonnet 4.5
- Provides better cost efficiency while maintaining quality for new users

## Test plan
- [x] Ruff checks pass
- [x] Mypy checks pass
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)