### PR TITLE
fix(tui): force drafting mode when switching to Ollama model mid-session

### DIFF
--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -1501,6 +1501,9 @@ class ChatScreen(Screen[None]):
                 )
             )
 
+            # Ensure Ollama models are forced to Drafting mode
+            self._ensure_ollama_drafting_mode()
+
         except Exception as e:
             logger.error(f"Failed to handle model selection: {e}")
             self.agent_manager.add_hint_message(


### PR DESCRIPTION
## Summary
- Fixes a bug where users could bypass the Ollama drafting mode lock by switching models mid-session
- Now calls `_ensure_ollama_drafting_mode()` after every model switch in `handle_model_selected()`

## Reproduction steps (before fix)
1. Set up Ollama
2. Add a Shotgun account
3. Switch to Opus and enable Planning mode
4. Switch back to Ollama - stays in Planning mode (bug)

## Test plan
- [ ] Verify Ollama models are forced to Drafting mode on startup
- [ ] Verify switching from a cloud model in Planning mode to Ollama forces Drafting mode
- [ ] Verify the hint message appears when mode is auto-switched

🤖 Generated with [Claude Code](https://claude.com/claude-code)