### PR TITLE
feat(tui): add Ollama install prompts to provider setup and model picker

### DIFF
--- a/src/shotgun/tui/screens/model_picker.py
+++ b/src/shotgun/tui/screens/model_picker.py
@@ -41,6 +41,7 @@ from shotgun.agents.config.provider import (
 )
 from shotgun.logging_config import get_logger
 from shotgun.tui.services.ollama import (
+    OLLAMA_DOWNLOAD_URL,
     OllamaStatus,
     get_ollama_status,
     sanitize_ollama_model_name_for_id,
@@ -433,7 +434,7 @@ class ModelPickerScreen(Screen[ModelConfigUpdated | None]):
     @on(Button.Pressed, "#install-ollama-button")
     def _on_install_ollama_pressed(self) -> None:
         """Open Ollama download page in browser."""
-        webbrowser.open("https://ollama.com/download")
+        webbrowser.open(OLLAMA_DOWNLOAD_URL)
 
     async def _open_provider_setup(self) -> None:
         """Open provider setup screen to Ollama tab and refresh on return."""

--- a/src/shotgun/tui/screens/provider_config.py
+++ b/src/shotgun/tui/screens/provider_config.py
@@ -27,6 +27,7 @@ from textual.widgets import (
 from shotgun.agents.config import ConfigManager, ProviderType
 from shotgun.tui.layout import COMPACT_HEIGHT_THRESHOLD
 from shotgun.tui.services.ollama import (
+    OLLAMA_DOWNLOAD_URL,
     OllamaStatus,
     get_ollama_status,
 )
@@ -370,7 +371,7 @@ class ProviderConfigScreen(Screen[None]):
     @on(Button.Pressed, "#ollama-install-button")
     def _on_ollama_install_pressed(self) -> None:
         """Open Ollama installation page in browser."""
-        webbrowser.open("https://ollama.com/download")
+        webbrowser.open(OLLAMA_DOWNLOAD_URL)
 
     @on(Checkbox.Changed, "#ollama-enable-checkbox")
     def _on_ollama_enable_changed(self, event: Checkbox.Changed) -> None:

--- a/src/shotgun/tui/services/ollama.py
+++ b/src/shotgun/tui/services/ollama.py
@@ -16,6 +16,7 @@ logger = get_logger(__name__)
 
 DEFAULT_OLLAMA_URL = "http://localhost:11434"
 DEFAULT_TIMEOUT = 3.0
+OLLAMA_DOWNLOAD_URL = "https://ollama.com/download"
 
 
 class OllamaCapability(StrEnum):


### PR DESCRIPTION
## Summary
- Add "Install Ollama" button in Provider Setup when Ollama isn't detected
- Add "Enable Ollama" and "Install Ollama" buttons in Model Picker's Local Models tab
- Helps users discover and set up Ollama when navigating directly to model selector

## Changes

### Provider Setup Screen (Ollama tab)
- Shows "Install Ollama" button when Ollama is not connected
- Opens https://ollama.com/download in browser
- Includes hint text: "Free, runs locally on your machine"
- Hidden when Ollama is already running

### Model Picker Screen (Local Models tab)
- Shows "Enable Ollama" button when Ollama is not enabled → goes to Provider Setup
- Shows "Install Ollama" button when enabled but not running → opens download page
- Both buttons hidden when Ollama is running with models

## Test plan
- [ ] Verify "Install Ollama" button appears in Provider Setup when Ollama isn't running
- [ ] Verify clicking the button opens ollama.com/download
- [ ] Verify button is hidden when Ollama is connected
- [ ] Verify "Enable Ollama" button appears in Model Picker when Ollama is disabled
- [ ] Verify "Install Ollama" button appears in Model Picker when Ollama is enabled but not running
- [ ] Verify buttons are hidden when Ollama is running with models

🤖 Generated with [Claude Code](https://claude.com/claude-code)