### PR TITLE
fix(tui): validate model on screen resume and fall back to Ollama if needed

### DIFF
--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -320,6 +320,24 @@ class ChatScreen(Screen[None]):
         """
         self.run_worker(self._validate_current_model(), exclusive=True)
 
+    def _reset_agents_for_model_change(self) -> None:
+        """Reset agent instances so they get recreated with the new model.
+
+        This is called when the model configuration changes (either via model picker
+        or when falling back due to API key removal).
+        """
+        self.agent_manager._agents_initialized = False
+        self.agent_manager._research_agent = None
+        self.agent_manager._plan_agent = None
+        self.agent_manager._tasks_agent = None
+        self.agent_manager._specify_agent = None
+        self.agent_manager._export_agent = None
+        self.agent_manager._research_deps = None
+        self.agent_manager._plan_deps = None
+        self.agent_manager._tasks_deps = None
+        self.agent_manager._specify_deps = None
+        self.agent_manager._export_deps = None
+
     async def _validate_current_model(self) -> None:
         """Validate current model is still available, fall back if not.
 
@@ -352,17 +370,7 @@ class ChatScreen(Screen[None]):
                 self.agent_manager.deps.llm_model = valid_model
 
                 # Reset agents so they get recreated with new model
-                self.agent_manager._agents_initialized = False
-                self.agent_manager._research_agent = None
-                self.agent_manager._plan_agent = None
-                self.agent_manager._tasks_agent = None
-                self.agent_manager._specify_agent = None
-                self.agent_manager._export_agent = None
-                self.agent_manager._research_deps = None
-                self.agent_manager._plan_deps = None
-                self.agent_manager._tasks_deps = None
-                self.agent_manager._specify_deps = None
-                self.agent_manager._export_deps = None
+                self._reset_agents_for_model_change()
 
                 # Get display name for new model
                 new_model_display = valid_model_name
@@ -1531,17 +1539,7 @@ class ChatScreen(Screen[None]):
             self.agent_manager.deps.llm_model = result.model_config
 
             # Reset agents so they get recreated with new model
-            self.agent_manager._agents_initialized = False
-            self.agent_manager._research_agent = None
-            self.agent_manager._plan_agent = None
-            self.agent_manager._tasks_agent = None
-            self.agent_manager._specify_agent = None
-            self.agent_manager._export_agent = None
-            self.agent_manager._research_deps = None
-            self.agent_manager._plan_deps = None
-            self.agent_manager._tasks_deps = None
-            self.agent_manager._specify_deps = None
-            self.agent_manager._export_deps = None
+            self._reset_agents_for_model_change()
 
             # Get current analysis and update context indicator via coordinator
             analysis = await self.agent_manager.get_context_analysis()


### PR DESCRIPTION
## Summary
- Adds `on_screenresume` handler to validate current model is still available
- Falls back to Ollama (if enabled) when cloud model API keys are removed
- Updates UI, resets agents, and forces Drafting mode for Ollama fallback

## Bug description
Users could:
1. Set up an API key and enable Ollama
2. Select a cloud model (e.g., Sonnet 4.5)
3. Go to Provider Setup and remove the API key
4. Return to chat - UI still showed Sonnet 4.5 in Planning mode
5. Prompts would silently go to Ollama while displaying wrong model/mode

## Fix
The new `on_screenresume` handler:
1. Calls `get_provider_model()` to get the currently valid model
2. Compares with `deps.llm_model` to detect changes
3. If different, updates deps and agent_manager
4. Shows notification: "⚠️ Sonnet 4.5 no longer available, switched to ollama/..."
5. Calls `_ensure_ollama_drafting_mode()` if new model is Ollama

## Test plan
- [ ] Set up API key + enable Ollama
- [ ] Select a cloud model (e.g., Sonnet 4.5)
- [ ] Go to Provider Setup and clear the API key
- [ ] Return to chat - verify notification appears about model change
- [ ] Verify UI shows Ollama model name and Drafting mode
- [ ] Verify prompts work correctly with Ollama

🤖 Generated with [Claude Code](https://claude.com/claude-code)