### PR TITLE
feat(tui): disable Ollama models without tool/function calling support

### DIFF
--- a/src/shotgun/tui/screens/model_picker.py
+++ b/src/shotgun/tui/screens/model_picker.py
@@ -161,6 +161,16 @@ class ModelPickerScreen(Screen[ModelConfigUpdated | None]):
         #ollama-setup-container Button {
             margin-right: 1;
         }
+
+        /* Disabled Ollama models (no tool support) */
+        #local-model-list ListItem.-disabled {
+            color: $text-muted;
+            text-style: italic;
+        }
+
+        #local-model-list ListItem.-disabled:hover {
+            background: transparent;
+        }
     """
 
     BINDINGS = [
@@ -358,6 +368,7 @@ class ModelPickerScreen(Screen[ModelConfigUpdated | None]):
 
         # Add model items, deduplicating by sanitized ID to avoid duplicate DOM IDs
         seen_ids: set[str] = set()
+        tool_capable_count = 0
         for model in status.models:
             safe_id = sanitize_ollama_model_name_for_id(model.name)
             if safe_id in seen_ids:
@@ -365,8 +376,28 @@ class ModelPickerScreen(Screen[ModelConfigUpdated | None]):
                 continue
             seen_ids.add(safe_id)
             size_str = format_file_size(model.size)
-            label = Label(f"{model.name} · {size_str}")
-            list_view.append(ListItem(label, id=f"ollama-model-{safe_id}"))
+
+            # Check if model supports tool calling
+            if model.supports_tools:
+                label_text = f"{model.name} · {size_str}"
+                tool_capable_count += 1
+            else:
+                label_text = f"{model.name} · {size_str} · No tool support"
+
+            label = Label(label_text)
+            item = ListItem(label, id=f"ollama-model-{safe_id}")
+
+            # Disable models that don't support tools
+            if not model.supports_tools:
+                item.disabled = True
+
+            list_view.append(item)
+
+        # Update status to show how many models support tools
+        if tool_capable_count < len(status.models):
+            status_label.update(
+                f"● {tool_capable_count}/{len(status.models)} model(s) support tools (Experimental)"
+            )
 
     def on_show(self) -> None:
         """Rebuild model list when screen is first shown."""

--- a/src/shotgun/tui/services/ollama.py
+++ b/src/shotgun/tui/services/ollama.py
@@ -24,6 +24,7 @@ class OllamaCapability(StrEnum):
 
     COMPLETION = "completion"
     VISION = "vision"
+    TOOLS = "tools"
 
 
 class OllamaModel(BaseModel):
@@ -38,6 +39,11 @@ class OllamaModel(BaseModel):
     def supports_vision(self) -> bool:
         """Check if this model supports vision/image input."""
         return OllamaCapability.VISION in self.capabilities
+
+    @property
+    def supports_tools(self) -> bool:
+        """Check if this model supports tool/function calling."""
+        return OllamaCapability.TOOLS in self.capabilities
 
 
 class OllamaStatus(BaseModel):
@@ -72,10 +78,13 @@ async def get_model_capabilities(
             data = response.json()
             # Ollama returns capabilities in model_info or details
             # The format varies, so we check multiple locations
-            capabilities: list[str] = data.get("capabilities", [])
+            capabilities: list[str] = list(data.get("capabilities", []))
+
             if not capabilities:
-                # Some versions put it in model_info
+                # Build capabilities from model_info
                 model_info = data.get("model_info", {})
+                capabilities = [OllamaCapability.COMPLETION]
+
                 if model_info:
                     # Check for vision capability markers
                     # Vision models typically have projector architecture
@@ -84,12 +93,20 @@ async def get_model_capabilities(
                         "clip" in arch.lower()
                         or OllamaCapability.VISION in str(model_info).lower()
                     ):
-                        capabilities = [
-                            OllamaCapability.COMPLETION,
-                            OllamaCapability.VISION,
-                        ]
-                    else:
-                        capabilities = [OllamaCapability.COMPLETION]
+                        capabilities.append(OllamaCapability.VISION)
+
+            # Check for tool/function calling support
+            # Ollama indicates this in the template or capabilities
+            template = data.get("template", "")
+            if OllamaCapability.TOOLS not in capabilities:
+                # Check if template has tool-related markers
+                # Models that support tools typically have {{.Tools}} in template
+                if "{{.Tools}}" in template or ".Tools" in template:
+                    capabilities.append(OllamaCapability.TOOLS)
+                # Also check if "tools" is explicitly in capabilities (newer Ollama)
+                elif "tools" in [c.lower() for c in data.get("capabilities", [])]:
+                    capabilities.append(OllamaCapability.TOOLS)
+
             return capabilities
     except Exception as e:
         logger.debug(f"Failed to fetch capabilities for {model_name}: {e}")


### PR DESCRIPTION
## Summary
- Detects which Ollama models support tool/function calling
- Disables models without tool support in the model picker
- Shows clear messaging about why models are disabled

## Changes

### Ollama Service
- Add `TOOLS` capability to `OllamaCapability` enum
- Add `supports_tools` property to `OllamaModel`
- Detect tool support by checking for `{{.Tools}}` in model template (Ollama's template marker for tool-capable models)

### Model Picker
- Disable list items for models without tool support
- Show "No tool support" label on disabled models
- Update status to show "X/Y model(s) support tools"
- Add CSS styling for disabled items (muted, italic)

## Why this matters
Shotgun relies heavily on tool calling for agent functionality (file operations, web search, etc.). Models without tool support cannot execute these actions, making them ineffective for Shotgun's use case.

## Test plan
- [ ] Verify models with tool support (e.g., llama3.2, qwen2.5) are selectable
- [ ] Verify models without tool support show "No tool support" and are disabled
- [ ] Verify status shows correct count (e.g., "2/5 model(s) support tools")
- [ ] Verify disabled items have muted/italic styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)