### PR TITLE
fix(tui): show context indicator immediately on startup

### DIFF
--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -308,7 +308,7 @@ class ChatScreen(Screen[None]):
 
         self.call_later(self.check_if_codebase_is_indexed)
         # Initial update of context indicator
-        self.update_context_indicator()
+        self.call_later(self.update_context_indicator)
         # Check for updates in background (after other startup tasks)
         self.call_later(self.check_for_updates)
 


### PR DESCRIPTION
## Summary

- Fix context indicator (model name like "Sonnet 4.5") not showing immediately in bottom right footer on TUI startup
- Use `call_later()` for `update_context_indicator()` in `on_mount()` to ensure the update runs after the screen is fully mounted

## Test plan

- [ ] Start shotgun TUI with `shotgun` command
- [ ] Verify "Sonnet 4.5" (or current model) shows immediately in bottom right footer after dismissing any startup dialogs
- [ ] Verify context indicator updates properly during conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)