### PR TITLE
fix(autopilot): display correct task counts in startup screen

### DIFF
--- a/src/shotgun/agents/autopilot/lightweight_parser.py
+++ b/src/shotgun/agents/autopilot/lightweight_parser.py
@@ -34,6 +34,10 @@ class ParsedStageStatus(BaseModel):
     status: StageCompletionStatus = Field(
         description="not_started if no tasks done, in_progress if some done, completed if all done"
     )
+    total_tasks: int = Field(description="Total number of tasks in this stage")
+    completed_tasks: int = Field(
+        description="Number of completed tasks (checkboxes with [x] or [X])"
+    )
 
 
 class ParsedStagesStatus(BaseModel):
@@ -61,17 +65,19 @@ STATUS_PARSER_PROMPT = """You are a markdown parser that extracts stage informat
 
 Your job is to:
 1. Find all stages (marked with ## Stage N: or ### Stage N: headers)
-2. For each stage, determine its status based on task completion
-3. Return the stage number, name, and status
+2. For each stage, count total tasks and completed tasks
+3. Determine the stage status based on task completion
+4. Return the stage number, name, status, and task counts
 
 Rules:
 - Stage headers contain "Stage" followed by an identifier and name
 - Tasks are checkboxes: - [ ] (incomplete) or - [x]/- [X] (complete)
+- Count ALL checkbox tasks under each stage (until the next stage header)
 - Status determination:
   * "not_started" if ALL tasks are incomplete (all [ ])
   * "in_progress" if SOME tasks are complete (mix of [x] and [ ])
   * "completed" if ALL tasks are complete (all [x])
-- Be precise with status determination
+- Be precise with task counts and status determination
 - Preserve exact stage identifiers (can be numeric or alphanumeric)"""
 
 SINGLE_STAGE_PARSER_PROMPT = """You are a markdown parser that extracts tasks from a SINGLE stage in a tasks.md file.
@@ -187,6 +193,8 @@ class LightweightTasksParser:
                 name=parsed_stage.name,
                 tasks=[],  # No individual tasks in status parse
                 status=stage_status,
+                task_count_override=parsed_stage.total_tasks,
+                completed_count_override=parsed_stage.completed_tasks,
             )
             stages.append(stage)
 

--- a/src/shotgun/agents/autopilot/models.py
+++ b/src/shotgun/agents/autopilot/models.py
@@ -100,6 +100,14 @@ class Stage(BaseModel):
     iteration_count: int = Field(
         default=0, description="Number of execution iterations for this stage"
     )
+    task_count_override: int | None = Field(
+        default=None,
+        description="Optional override for task count (used by lightweight parser)",
+    )
+    completed_count_override: int | None = Field(
+        default=None,
+        description="Optional override for completed count (used by lightweight parser)",
+    )
 
     @property
     def pending_tasks(self) -> list[Task]:
@@ -119,11 +127,17 @@ class Stage(BaseModel):
     @property
     def task_count(self) -> int:
         """Total number of tasks in this stage."""
+        # Use override if set (lightweight parser), otherwise compute from tasks
+        if self.task_count_override is not None:
+            return self.task_count_override
         return len(self.tasks)
 
     @property
     def completed_count(self) -> int:
         """Number of completed tasks."""
+        # Use override if set (lightweight parser), otherwise compute from tasks
+        if self.completed_count_override is not None:
+            return self.completed_count_override
         return len(self.completed_tasks)
 
     def format_task_list(self) -> str:

--- a/test/unit/agents/autopilot/test_models.py
+++ b/test/unit/agents/autopilot/test_models.py
@@ -127,6 +127,32 @@ def test_stage_task_count():
     assert stage.completed_count == 1
 
 
+def test_stage_task_count_override():
+    """Test Stage.task_count and completed_count with override fields."""
+    # Test with empty tasks but override counts (lightweight parser use case)
+    stage = Stage(
+        number="1",
+        name="Test Stage",
+        tasks=[],  # No tasks loaded
+        task_count_override=10,
+        completed_count_override=7,
+    )
+
+    assert stage.task_count == 10  # Uses override
+    assert stage.completed_count == 7  # Uses override
+
+    # Test that normal computation still works when override not set
+    tasks = [
+        Task(text="Task 1", completed=False, line_number=10),
+        Task(text="Task 2", completed=True, line_number=11),
+        Task(text="Task 3", completed=True, line_number=12),
+    ]
+    stage_normal = Stage(number="2", name="Normal Stage", tasks=tasks)
+
+    assert stage_normal.task_count == 3  # Computed from tasks
+    assert stage_normal.completed_count == 2  # Computed from tasks
+
+
 def test_stage_format_task_list():
     """Test Stage.format_task_list method."""
     tasks = [


### PR DESCRIPTION
## Summary
- The autopilot startup screen was showing "0/0 tasks done" because the lightweight parser creates Stage objects with empty task lists for performance
- Added `task_count_override` and `completed_count_override` fields to the Stage model so the lightweight parser can set accurate counts without loading all tasks
- Updated the lightweight parser to extract and set task counts from the LLM parse results

## Test plan
- [x] Unit tests added for override functionality
- [ ] Verify autopilot startup screen shows correct task counts
- [ ] Verify normal (non-lightweight) task loading still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)