### PR TITLE
feat(cli): add --spec-dir flag to use custom spec directory

### DIFF
--- a/src/shotgun/agents/conversation/models.py
+++ b/src/shotgun/agents/conversation/models.py
@@ -62,6 +62,8 @@ class ConversationHistory(BaseModel):
     )  # Stores serialized ModelMessage and HintMessage objects
     last_agent_model: str = "research"
     updated_at: datetime = Field(default_factory=datetime.now)
+    # Write-only debugging field: records the --spec-dir override if set (never read back)
+    spec_dir_override: str | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/src/shotgun/main.py
+++ b/src/shotgun/main.py
@@ -37,6 +37,7 @@ from shotgun.logging_config import configure_root_logger, get_logger
 from shotgun.posthog_telemetry import setup_posthog_observability
 from shotgun.telemetry import setup_logfire_observability
 from shotgun.tui import app as tui_app
+from shotgun.utils.file_system_utils import set_spec_dir
 from shotgun.utils.update_checker import perform_auto_update_async
 
 # Load environment variables from .env file
@@ -180,9 +181,20 @@ def main(
             help="Model name for sub-agents (requires --model to be set)",
         ),
     ] = None,
+    spec_dir: Annotated[
+        str | None,
+        typer.Option(
+            "--spec-dir",
+            help="Custom spec directory path (default: .shotgun/ in current directory)",
+        ),
+    ] = None,
 ) -> None:
     """Shotgun - AI-powered CLI tool."""
     logger.debug("Starting shotgun CLI application")
+
+    # Set spec dir override early so it applies to both TUI and subcommands
+    if spec_dir and not ctx.resilient_parsing:
+        set_spec_dir(spec_dir)
 
     # Start async update check and install (non-blocking)
     if not ctx.resilient_parsing:
@@ -212,6 +224,7 @@ def main(
                     force_reindex=force_reindex,
                     model_override=model,
                     sub_agent_model_override=sub_agent_model,
+                    spec_dir_override=spec_dir,
                 )
             finally:
                 # Ensure PostHog is shut down cleanly even if server exits unexpectedly

--- a/src/shotgun/tui/app.py
+++ b/src/shotgun/tui/app.py
@@ -447,6 +447,7 @@ def serve(
     force_reindex: bool = False,
     model_override: str | None = None,
     sub_agent_model_override: str | None = None,
+    spec_dir_override: str | None = None,
 ) -> None:
     """Serve the TUI application as a web application.
 
@@ -459,6 +460,7 @@ def serve(
         force_reindex: If True, force re-indexing of codebase (ignores existing index).
         model_override: If provided, pass --model flag to spawned process.
         sub_agent_model_override: If provided, pass --sub-agent-model flag to spawned process.
+        spec_dir_override: If provided, pass --spec-dir flag to spawned process.
     """
     # Detect database issues BEFORE starting the TUI
     # Note: In serve mode, issues are logged but user interaction happens in
@@ -508,6 +510,8 @@ def serve(
         command += f" --model={model_override}"
     if sub_agent_model_override:
         command += f" --sub-agent-model={sub_agent_model_override}"
+    if spec_dir_override:
+        command += f" --spec-dir={spec_dir_override}"
 
     # Get the path to our custom templates directory
     templates_path = Path(__file__).parent / "templates"

--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -327,6 +327,9 @@ class ChatScreen(Screen[None]):
         if self.show_pull_hint:
             self.call_later(self._show_pull_hint)
 
+        # Show spec dir hint if --spec-dir override is active
+        self.call_later(self._show_spec_dir_hint)
+
         self.call_later(self.check_if_codebase_is_indexed)
         # Initial update of context indicator
         self.call_later(self.update_context_indicator)
@@ -1130,6 +1133,16 @@ class ChatScreen(Screen[None]):
     ) -> None:
         hint = HintMessage(message=markdown, link=link, link_text=link_text)
         self.agent_manager.add_hint_message(hint)
+
+    def _show_spec_dir_hint(self) -> None:
+        """Show hint when --spec-dir override is active."""
+        from shotgun.utils.file_system_utils import get_spec_dir_override
+
+        override = get_spec_dir_override()
+        if override is None:
+            return
+
+        self.mount_hint(f"Using custom spec directory: `{override}`")
 
     def _show_pull_hint(self) -> None:
         """Show hint about recently pulled spec from meta.json."""

--- a/src/shotgun/tui/services/conversation_service.py
+++ b/src/shotgun/tui/services/conversation_service.py
@@ -67,8 +67,11 @@ class ConversationService:
             state = agent_manager.get_conversation_state()
 
             # Create conversation history object
+            from shotgun.utils.file_system_utils import get_spec_dir_override
+
             conversation = ConversationHistory(
                 last_agent_model=state.agent_type,
+                spec_dir_override=get_spec_dir_override(),
             )
             conversation.set_agent_messages(state.agent_messages)
             conversation.set_ui_messages(state.ui_messages)

--- a/src/shotgun/utils/__init__.py
+++ b/src/shotgun/utils/__init__.py
@@ -1,6 +1,15 @@
 """Utility functions for the Shotgun package."""
 
-from .file_system_utils import ensure_shotgun_directory_exists, get_shotgun_home
+from .file_system_utils import (
+    ensure_shotgun_directory_exists,
+    get_shotgun_home,
+    set_spec_dir,
+)
 from .format_utils import format_file_size
 
-__all__ = ["ensure_shotgun_directory_exists", "format_file_size", "get_shotgun_home"]
+__all__ = [
+    "ensure_shotgun_directory_exists",
+    "format_file_size",
+    "get_shotgun_home",
+    "set_spec_dir",
+]

--- a/src/shotgun/utils/file_system_utils.py
+++ b/src/shotgun/utils/file_system_utils.py
@@ -1,5 +1,6 @@
 """File system utility functions."""
 
+import logging
 import os
 from pathlib import Path
 
@@ -7,9 +8,42 @@ import aiofiles
 
 from shotgun.settings import settings
 
+logger = logging.getLogger(__name__)
+
+# Module-level override for the spec directory (set via --spec-dir CLI flag)
+_spec_dir_override: Path | None = None
+
+
+def set_spec_dir(spec_dir: str | None) -> None:
+    """Set a custom spec directory override.
+
+    When set, get_shotgun_base_path() will return this path instead of .shotgun/ in CWD.
+    Relative paths are resolved to absolute paths.
+
+    Args:
+        spec_dir: Path to custom spec directory, or None to clear the override.
+    """
+    global _spec_dir_override
+    if spec_dir:
+        _spec_dir_override = Path(spec_dir).resolve()
+        logger.info("Spec directory override set to: %s", _spec_dir_override)
+    else:
+        _spec_dir_override = None
+
+
+def get_spec_dir_override() -> str | None:
+    """Get the current spec directory override, if set.
+
+    Returns:
+        The override path as a string, or None if no override is active.
+    """
+    return str(_spec_dir_override) if _spec_dir_override is not None else None
+
 
 def get_shotgun_base_path() -> Path:
     """Get the absolute path to the .shotgun directory."""
+    if _spec_dir_override is not None:
+        return _spec_dir_override
     return Path.cwd() / ".shotgun"
 
 

--- a/test/unit/test_spec_dir_override.py
+++ b/test/unit/test_spec_dir_override.py
@@ -1,0 +1,71 @@
+"""Unit tests for --spec-dir override functionality."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from shotgun.utils.file_system_utils import (
+    ensure_shotgun_directory_exists,
+    get_shotgun_base_path,
+    set_spec_dir,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_spec_dir_override():
+    """Reset the spec dir override after each test."""
+    yield
+    set_spec_dir(None)
+
+
+def test_default_returns_cwd_shotgun():
+    """Without override, get_shotgun_base_path returns .shotgun in CWD."""
+    with patch("shotgun.utils.file_system_utils.Path.cwd") as mock_cwd:
+        mock_cwd.return_value = Path("/fake/project")
+        result = get_shotgun_base_path()
+        assert result == Path("/fake/project/.shotgun")
+
+
+def test_override_returns_custom_path():
+    """When override is set, get_shotgun_base_path returns the custom path."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        custom_path = Path(temp_dir) / "my_specs"
+        custom_path.mkdir()
+        set_spec_dir(str(custom_path))
+
+        result = get_shotgun_base_path()
+        assert result == custom_path.resolve()
+
+
+def test_override_resolves_relative_path():
+    """Relative paths are resolved to absolute paths."""
+    set_spec_dir("tmp/example_docs")
+    result = get_shotgun_base_path()
+    assert result.is_absolute()
+    assert result == Path("tmp/example_docs").resolve()
+
+
+def test_clear_override():
+    """Setting None clears the override back to default behavior."""
+    set_spec_dir("/some/custom/path")
+    assert get_shotgun_base_path() == Path("/some/custom/path")
+
+    set_spec_dir(None)
+    with patch("shotgun.utils.file_system_utils.Path.cwd") as mock_cwd:
+        mock_cwd.return_value = Path("/fake/project")
+        result = get_shotgun_base_path()
+        assert result == Path("/fake/project/.shotgun")
+
+
+def test_ensure_directory_creates_custom_dir():
+    """ensure_shotgun_directory_exists() works with the override."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        custom_path = Path(temp_dir) / "custom_specs"
+        set_spec_dir(str(custom_path))
+
+        result = ensure_shotgun_directory_exists()
+        assert result == custom_path.resolve()
+        assert result.exists()
+        assert result.is_dir()


### PR DESCRIPTION
## Summary

- Add `--spec-dir` CLI flag so users can point Shotgun at a custom spec directory instead of the default `.shotgun/` in CWD (e.g., `shotgun --spec-dir=tmp/example_docs`)
- Uses the same module-level global override pattern as `--model`, so all 10+ consumers of `get_shotgun_base_path()` automatically pick up the override with zero changes
- Threads the flag through web serve mode so it works with `--web` as well

## Test plan

- [x] `uv run ruff check .` passes
- [x] `uv run mypy src/` passes (0 issues in 273 files)
- [x] 5 new unit tests pass (`test/unit/test_spec_dir_override.py`)
- [x] All 1904 existing unit tests pass (no regressions)
- [ ] Manual: `shotgun --spec-dir=/tmp/test_specs` uses custom directory
- [ ] Manual: `shotgun --spec-dir=relative/path run "prompt"` resolves relative path correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)