### PR TITLE
feat(telemetry): add Context7 README docs and MCP server telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,22 @@ _**Mode switching:** `Shift+Tab` cycles through modes_
 
  **Note:** CLI available in [docs/CLI.md](docs/CLI.md), but TUI is recommended.
 
+### Context7 Documentation Lookup (Experimental)
+
+The Research agent can fetch up-to-date library documentation via [Context7](https://context7.com). When configured, the agent will prefer Context7 over web search for documentation lookups.
+
+To enable it, set your Context7 API key:
+
+```bash
+shotgun config set-context7 --api-key <your-context7-api-key>
+```
+
+To remove it:
+
+```bash
+shotgun config clear-context7
+```
+
 ---
 
 # 🤝 Share Specs with Your Team

--- a/src/shotgun/agents/agent_manager.py
+++ b/src/shotgun/agents/agent_manager.py
@@ -677,6 +677,24 @@ class AgentManager(Widget):
         }
         return deps_map[agent_type]
 
+    async def _get_configured_mcp_servers(self) -> dict[str, bool]:
+        """Get which MCP servers are configured.
+
+        Returns a dict mapping MCP server names to their availability status.
+        Extensible for future MCP integrations beyond Context7.
+
+        Returns:
+            Dict of MCP server names to boolean availability.
+        """
+        from shotgun.agents.config import get_config_manager
+
+        config_manager = get_config_manager()
+        context7_key = await config_manager.get_context7_api_key()
+
+        return {
+            "context7": context7_key is not None,
+        }
+
     def _create_merged_deps(self, agent_type: AgentType) -> AgentDeps:
         """Create merged dependencies combining shared and agent-specific deps.
 
@@ -945,6 +963,11 @@ class AgentManager(Widget):
                     anthropic_tier == AnthropicTier.TIER_1
                 )
                 event_properties["anthropic_tier"] = anthropic_tier
+
+        # Track which MCP servers are configured (extensible for future MCP integrations)
+        if self._current_agent_type == AgentType.ROUTER:
+            mcp_servers = await self._get_configured_mcp_servers()
+            event_properties["mcp_servers"] = mcp_servers
 
         track_event(event_name, event_properties)
 

--- a/test/unit/test_context7.py
+++ b/test/unit/test_context7.py
@@ -284,3 +284,61 @@ async def test_config_manager_loads_v8_config_with_migration():
         assert config.context7 is not None
         assert config.context7.api_key is None
         assert config.shotgun_instance_id == "test-user-id-12345"
+
+
+# --- MCP servers telemetry tests ---
+
+
+def test_mcp_servers_telemetry_event_structure_with_context7():
+    """Test that mcp_servers telemetry dict includes context7 when key is set."""
+    mcp_servers = {
+        "context7": True,
+    }
+
+    assert mcp_servers["context7"] is True
+    # Extensible - future MCP servers can be added
+    assert isinstance(mcp_servers, dict)
+
+
+def test_mcp_servers_telemetry_event_structure_without_context7():
+    """Test that mcp_servers telemetry dict shows context7=False when no key."""
+    mcp_servers = {
+        "context7": False,
+    }
+
+    assert mcp_servers["context7"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_configured_mcp_servers_with_context7_key():
+    """Test _get_configured_mcp_servers returns context7=True when key is set."""
+    mock_manager = AsyncMock()
+    mock_manager.get_context7_api_key.return_value = "test-key"
+
+    with patch(
+        "shotgun.agents.config.get_config_manager", return_value=mock_manager
+    ):
+        from shotgun.agents.agent_manager import AgentManager
+
+        # Call the static-like method directly by creating a minimal instance
+        result = await AgentManager._get_configured_mcp_servers(
+            AsyncMock(spec=AgentManager)
+        )
+        assert result == {"context7": True}
+
+
+@pytest.mark.asyncio
+async def test_get_configured_mcp_servers_without_context7_key():
+    """Test _get_configured_mcp_servers returns context7=False when no key."""
+    mock_manager = AsyncMock()
+    mock_manager.get_context7_api_key.return_value = None
+
+    with patch(
+        "shotgun.agents.config.get_config_manager", return_value=mock_manager
+    ):
+        from shotgun.agents.agent_manager import AgentManager
+
+        result = await AgentManager._get_configured_mcp_servers(
+            AsyncMock(spec=AgentManager)
+        )
+        assert result == {"context7": False}


### PR DESCRIPTION
## Summary
- Add Context7 API key setup instructions to README under Usage section
- Track configured MCP servers in `message_send_router` PostHog event via extensible `mcp_servers` dict (e.g., `{"context7": true}`)
- 4 new tests for MCP telemetry structure and `_get_configured_mcp_servers` method

## Test plan
- [x] `uv run ruff check .` passes
- [x] `uv run mypy src/` passes
- [x] `uv run pytest test/unit/ -x -m smoke` passes (7/7)
- [x] `uv run pytest test/unit/test_context7.py -x` passes (20/20)
- [ ] Verify PostHog receives `mcp_servers` property on `message_send_router` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)