### PR TITLE
fix(agents): scope Anthropic cache to tool defs and static instructions

### DIFF
--- a/src/shotgun/agents/common.py
+++ b/src/shotgun/agents/common.py
@@ -18,7 +18,6 @@ from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
     ModelResponse,
-    SystemPromptPart,
     ToolCallPart,
 )
 from pydantic_ai.settings import ModelSettings
@@ -28,7 +27,7 @@ from shotgun.agents.config.constants import (
     WEB_SEARCH_STOP_THRESHOLD,
     WEB_SEARCH_WARNING_THRESHOLD,
 )
-from shotgun.agents.config.models import AnthropicCacheTTL
+from shotgun.agents.config.models import ANTHROPIC_CACHE_MODEL_SETTINGS
 from shotgun.agents.models import (
     AgentResponse,
     AgentSystemPromptContext,
@@ -283,11 +282,7 @@ async def create_base_agent(
                 new_parts = [
                     part
                     for part in msg.parts
-                    if not (
-                        isinstance(part, SystemPromptPart)
-                        and hasattr(part, "prompt_type")
-                        and part.prompt_type == "status"
-                    )
+                    if not isinstance(part, SystemStatusPrompt)
                 ]
                 if new_parts:
                     filtered_messages.append(
@@ -320,7 +315,7 @@ async def create_base_agent(
         history_processors=[history_processor],
         retries=3,  # Default retry count for tool calls and output validation
         toolsets=mcp_servers or None,
-        model_settings=AnthropicCacheTTL.SHORT.to_model_settings(),
+        model_settings=ANTHROPIC_CACHE_MODEL_SETTINGS,
     )
 
     # System prompt function is stored in deps and will be called manually in run_agent

--- a/src/shotgun/agents/config/models.py
+++ b/src/shotgun/agents/config/models.py
@@ -25,19 +25,10 @@ class KeyProvider(StrEnum):
     SHOTGUN = "shotgun"  # Shotgun Account (unified LiteLLM proxy)
 
 
-class AnthropicCacheTTL(StrEnum):
-    """Anthropic prompt caching TTL values."""
-
-    SHORT = "5m"  # Sub-agents: short-lived, lower cache duration
-    LONG = "1h"  # Router: long-lived session, higher cache duration
-
-    def to_model_settings(self) -> AnthropicModelSettings:
-        """Build AnthropicModelSettings with this TTL for all cache fields."""
-        return AnthropicModelSettings(
-            anthropic_cache_instructions=self.value,
-            anthropic_cache_tool_definitions=self.value,
-            anthropic_cache_messages=self.value,
-        )
+ANTHROPIC_CACHE_MODEL_SETTINGS = AnthropicModelSettings(
+    anthropic_cache_tool_definitions="1h",
+    anthropic_cache_instructions="1h",
+)
 
 
 class ModelName(StrEnum):

--- a/src/shotgun/agents/conversation/history/message_utils.py
+++ b/src/shotgun/agents/conversation/history/message_utils.py
@@ -80,5 +80,6 @@ def get_latest_system_status(messages: list[ModelMessage]) -> str | None:
         if isinstance(msg, ModelRequest):
             for part in msg.parts:
                 if isinstance(part, SystemStatusPrompt):
-                    return part.content
+                    content = part.content
+                    return content if isinstance(content, str) else None
     return None

--- a/src/shotgun/agents/messages.py
+++ b/src/shotgun/agents/messages.py
@@ -25,14 +25,20 @@ class AgentSystemPrompt(SystemPromptPart):
 
 
 @dataclass
-class SystemStatusPrompt(SystemPromptPart):
-    """System prompt containing current system status information.
+class SystemStatusPrompt(UserPromptPart):
+    """Dynamic system status injected as a user message (not a system prompt).
 
-    This includes table of contents, available files, and other contextual
-    information about the current state. Only the most recent status should
-    be preserved during compaction.
+    This includes table of contents, available files, datetime, and other
+    contextual information about the current state. Only the most recent
+    status should be preserved during compaction.
+
+    This extends UserPromptPart (not SystemPromptPart) so that it stays in
+    the messages array rather than being extracted into Anthropic's system
+    parameter. This allows the static AgentSystemPrompt to be cached via
+    anthropic_cache_instructions without the dynamic status invalidating it.
     """
 
+    part_kind: Literal["system-status"] = "system-status"  # type: ignore[assignment]
     prompt_type: str = "status"
 
 

--- a/src/shotgun/agents/router/router.py
+++ b/src/shotgun/agents/router/router.py
@@ -19,7 +19,7 @@ from shotgun.agents.common import (
     run_agent,
 )
 from shotgun.agents.config import ProviderType, get_provider_model
-from shotgun.agents.config.models import AnthropicCacheTTL
+from shotgun.agents.config.models import ANTHROPIC_CACHE_MODEL_SETTINGS
 from shotgun.agents.conversation.history import token_limit_compactor
 from shotgun.agents.models import AgentResponse, AgentRuntimeOptions, AgentType
 from shotgun.agents.router.models import RouterDeps
@@ -123,7 +123,7 @@ async def create_router_agent(
         history_processors=[history_processor],
         retries=3,
         tools=delegation_tools,
-        model_settings=AnthropicCacheTTL.LONG.to_model_settings(),
+        model_settings=ANTHROPIC_CACHE_MODEL_SETTINGS,
     )
 
     # Register plan management tools (router-specific, always available)

--- a/test/unit/agents/test_anthropic_cache_settings.py
+++ b/test/unit/agents/test_anthropic_cache_settings.py
@@ -8,7 +8,6 @@ from pydantic_ai.models.test import TestModel
 
 from shotgun.agents.common import build_agent_system_prompt, create_base_agent
 from shotgun.agents.config.models import (
-    AnthropicCacheTTL,
     ModelConfig,
     ModelName,
     ProviderType,
@@ -49,14 +48,14 @@ def mock_codebase_service():
 @patch("shotgun.agents.common.get_codebase_service")
 @patch("shotgun.agents.common.get_provider_model", new_callable=AsyncMock)
 @pytest.mark.asyncio
-async def test_sub_agent_has_5m_cache_settings(
+async def test_sub_agent_caches_only_tool_definitions(
     mock_get_model,
     mock_get_codebase,
     mock_model_config,
     mock_runtime_options,
     mock_codebase_service,
 ):
-    """Sub-agents created via create_base_agent should have 5m Anthropic cache TTL."""
+    """Sub-agents should only cache tool definitions at 1h TTL."""
     mock_get_model.return_value = mock_model_config
     mock_get_codebase.return_value = mock_codebase_service
 
@@ -69,22 +68,22 @@ async def test_sub_agent_has_5m_cache_settings(
 
     settings = agent.model_settings
     assert settings is not None
-    assert settings.get("anthropic_cache_instructions") == AnthropicCacheTTL.SHORT
-    assert settings.get("anthropic_cache_tool_definitions") == AnthropicCacheTTL.SHORT
-    assert settings.get("anthropic_cache_messages") == AnthropicCacheTTL.SHORT
+    assert settings.get("anthropic_cache_tool_definitions") == "1h"
+    assert settings.get("anthropic_cache_instructions") == "1h"
+    assert "anthropic_cache_messages" not in settings
 
 
 @patch("shotgun.agents.router.router.get_codebase_service")
 @patch("shotgun.agents.router.router.get_provider_model", new_callable=AsyncMock)
 @pytest.mark.asyncio
-async def test_router_agent_has_1h_cache_settings(
+async def test_router_agent_caches_tools_and_instructions(
     mock_get_model,
     mock_get_codebase,
     mock_model_config,
     mock_runtime_options,
     mock_codebase_service,
 ):
-    """Router agent should have 1h Anthropic cache TTL."""
+    """Router agent should cache tool definitions and instructions at 1h TTL."""
     mock_get_model.return_value = mock_model_config
     mock_get_codebase.return_value = mock_codebase_service
 
@@ -92,9 +91,9 @@ async def test_router_agent_has_1h_cache_settings(
 
     settings = agent.model_settings
     assert settings is not None
-    assert settings.get("anthropic_cache_instructions") == AnthropicCacheTTL.LONG
-    assert settings.get("anthropic_cache_tool_definitions") == AnthropicCacheTTL.LONG
-    assert settings.get("anthropic_cache_messages") == AnthropicCacheTTL.LONG
+    assert settings.get("anthropic_cache_tool_definitions") == "1h"
+    assert settings.get("anthropic_cache_instructions") == "1h"
+    assert "anthropic_cache_messages" not in settings
 
 
 @patch("shotgun.agents.router.router.get_codebase_service")
@@ -122,14 +121,14 @@ async def test_router_cache_settings_do_not_include_parallel_tool_calls(
 @patch("shotgun.agents.common.get_codebase_service")
 @patch("shotgun.agents.common.get_provider_model", new_callable=AsyncMock)
 @pytest.mark.asyncio
-async def test_cache_settings_different_between_router_and_sub_agents(
+async def test_router_and_sub_agents_share_same_cache_settings(
     mock_get_model,
     mock_get_codebase,
     mock_model_config,
     mock_runtime_options,
     mock_codebase_service,
 ):
-    """Router should have 1h cache TTL while sub-agents should have 5m."""
+    """Router and sub-agents should have identical cache settings."""
     mock_get_model.return_value = mock_model_config
     mock_get_codebase.return_value = mock_codebase_service
 
@@ -138,8 +137,6 @@ async def test_cache_settings_different_between_router_and_sub_agents(
 
     sub_settings = sub_agent.model_settings
     assert sub_settings is not None
-    assert sub_settings.get("anthropic_cache_instructions") == AnthropicCacheTTL.SHORT
-    assert (
-        sub_settings.get("anthropic_cache_tool_definitions") == AnthropicCacheTTL.SHORT
-    )
-    assert sub_settings.get("anthropic_cache_messages") == AnthropicCacheTTL.SHORT
+    assert sub_settings.get("anthropic_cache_tool_definitions") == "1h"
+    assert sub_settings.get("anthropic_cache_instructions") == "1h"
+    assert "anthropic_cache_messages" not in sub_settings

--- a/test/unit/agents/test_common.py
+++ b/test/unit/agents/test_common.py
@@ -12,6 +12,7 @@ from shotgun.agents.common import (
     build_agent_system_prompt,
     run_agent,
 )
+from shotgun.agents.messages import SystemStatusPrompt
 from shotgun.agents.models import AgentDeps, AgentRuntimeOptions
 
 
@@ -84,7 +85,7 @@ async def test_add_system_status_message_empty_history(mock_deps):
                     assert len(result) == 1
                     assert isinstance(result[0], ModelRequest)
                     assert len(result[0].parts) == 1
-                    assert isinstance(result[0].parts[0], SystemPromptPart)
+                    assert isinstance(result[0].parts[0], SystemStatusPrompt)
                     assert result[0].parts[0].content == "System state content"
 
                     mock_get_files.assert_called_once_with(None)


### PR DESCRIPTION
## Summary
- Move `SystemStatusPrompt` from `SystemPromptPart` to `UserPromptPart` so dynamic status stays in the messages array rather than Anthropic's `system` parameter, allowing the static `AgentSystemPrompt` to be cached without invalidation every turn
- Replace `AnthropicCacheTTL` enum with a single `ANTHROPIC_CACHE_MODEL_SETTINGS` constant — tool definitions and instructions cached at 1h TTL
- Remove `anthropic_cache_messages` entirely since the dynamic `SystemStatusPrompt` changes every turn, making message caching wasteful

## Test plan
- [ ] Verify `uv run ruff check .` passes
- [ ] Verify `uv run mypy src/` passes
- [ ] Verify `uv run pytest test/unit/ -m smoke` passes
- [ ] Verify cache hit rates improve in production (tool defs and instructions should hit cache on subsequent turns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)