### PR TITLE
refactor(agents): deduplicate router/planner factories and add PromptTemplate enum

### DIFF
--- a/src/shotgun/agents/agent_manager.py
+++ b/src/shotgun/agents/agent_manager.py
@@ -404,6 +404,7 @@ class AgentManager(Widget):
         # The model config actually running the current agent (may differ from
         # self.deps.llm_model which is the user-selected model for UI display).
         # Set by _create_merged_deps for Router/Planner tiered mode.
+        # Lifetime: set on each agent run, cleared by reset_agents().
         self._running_model_config: ModelConfig | None = None
 
     async def _ensure_agents_initialized(self) -> None:
@@ -434,6 +435,28 @@ class AgentManager(Widget):
             agent_runtime_options=self._agent_runtime_options
         )
         self._agents_initialized = True
+
+    def reset_agents(self) -> None:
+        """Reset all agent instances so they get recreated with a new model.
+
+        Called when the model configuration changes (e.g., via model picker
+        or when falling back due to API key removal).
+        """
+        self._agents_initialized = False
+        self._research_agent = None
+        self._plan_agent = None
+        self._tasks_agent = None
+        self._specify_agent = None
+        self._export_agent = None
+        self._router_agent = None
+        self._planner_agent = None
+        self._research_deps = None
+        self._plan_deps = None
+        self._tasks_deps = None
+        self._specify_deps = None
+        self._export_deps = None
+        self._router_deps = None
+        self._planner_deps = None
 
     @property
     def research_agent(self) -> ShotgunAgent:

--- a/src/shotgun/agents/common.py
+++ b/src/shotgun/agents/common.py
@@ -1,5 +1,6 @@
 """Common utilities for agent creation and management."""
 
+import traceback
 from collections.abc import AsyncIterable, Awaitable, Callable, Sequence
 from pathlib import Path
 from typing import Any
@@ -32,6 +33,7 @@ from shotgun.agents.models import (
     AgentResponse,
     AgentSystemPromptContext,
     AgentType,
+    PromptTemplate,
     ShotgunAgent,
 )
 from shotgun.logging_config import get_logger
@@ -64,6 +66,15 @@ logger = get_logger(__name__)
 
 # Global prompt loader instance
 prompt_loader = PromptLoader()
+
+
+class _CompactionContext:
+    """Minimal context object for the token_limit_compactor."""
+
+    def __init__(self, deps: AgentDeps):
+        self.deps = deps
+        self.usage = None
+
 
 # Web search tool names across all providers
 WEB_SEARCH_TOOL_NAMES: set[str] = {
@@ -301,13 +312,7 @@ async def create_base_agent(
             deps, filtered_messages, web_search_count=web_search_count
         )
 
-        # Create a minimal context for compaction
-        class ProcessorContext:
-            def __init__(self, deps: AgentDeps):
-                self.deps = deps
-                self.usage = None  # Will be estimated from messages
-
-        ctx = ProcessorContext(deps)
+        ctx = _CompactionContext(deps)
         return await token_limit_compactor(ctx, filtered_messages)
 
     agent = Agent(
@@ -545,14 +550,14 @@ def get_agent_existing_files(agent_mode: AgentType | None = None) -> list[str]:
 
 
 def build_agent_system_prompt(
-    agent_type: str,
+    agent_type: str | PromptTemplate,
     ctx: RunContext[AgentDeps],
     context_name: str | None = None,
 ) -> str:
     """Build system prompt for any agent type.
 
     Args:
-        agent_type: Type of agent ('research', 'plan', 'tasks')
+        agent_type: Type of agent ('research', 'plan', 'tasks') or PromptTemplate enum
         ctx: RunContext containing AgentDeps
         context_name: Optional context name for template rendering
 
@@ -716,3 +721,76 @@ async def run_agent(
         logger.info("📁 %s", summary)
 
     return result
+
+
+def create_history_processor(
+    deps: AgentDeps,
+) -> Callable[[list[ModelMessage]], Awaitable[list[ModelMessage]]]:
+    """Create a history processor that applies token limit compaction.
+
+    This is the standard history processor for agents that only need compaction
+    (no web search counting or system status updates). Used by Router, Planner,
+    and FileRead agents.
+
+    Args:
+        deps: Agent dependencies used for compaction context
+
+    Returns:
+        An async function suitable for use as a pydantic_ai history processor
+    """
+
+    async def _processor(messages: list[ModelMessage]) -> list[ModelMessage]:
+        ctx = _CompactionContext(deps)
+        return await token_limit_compactor(ctx, messages)
+
+    return _processor
+
+
+async def run_orchestrator_agent(
+    agent: Agent[Any, AgentResponse],
+    prompt: str,
+    deps: AgentDeps,
+    message_history: list[ModelMessage] | None = None,
+    agent_label: str = "Agent",
+) -> AgentRunResult[AgentResponse]:
+    """Run an orchestrator agent (Router or Planner) with standard setup.
+
+    Shared implementation for run_router_agent and run_planner_agent that handles:
+    - Adding system status messages
+    - Creating usage limits
+    - Disabling parallel tool calls
+    - Running the agent with error logging
+
+    Args:
+        agent: The configured orchestrator agent
+        prompt: User's request (or escalation prompt)
+        deps: Agent dependencies (RouterDeps or AgentDeps)
+        message_history: Optional existing message history
+        agent_label: Label for log messages (e.g., "Router", "Planner")
+
+    Returns:
+        Agent run result with response and any clarifying questions
+    """
+    logger.debug("Running %s agent with prompt: %s", agent_label, prompt[:100])
+
+    message_history = await add_system_status_message(deps, message_history)
+
+    try:
+        usage_limits = create_usage_limits()
+        model_settings: ModelSettings = {"parallel_tool_calls": False}
+
+        result = await run_agent(
+            agent=agent,
+            prompt=prompt,
+            deps=deps,
+            message_history=message_history,
+            usage_limits=usage_limits,
+            model_settings=model_settings,
+        )
+
+        logger.debug("%s agent completed successfully", agent_label)
+        return result
+
+    except Exception:
+        logger.error("%s agent error:\n%s", agent_label, traceback.format_exc())
+        raise

--- a/src/shotgun/agents/export.py
+++ b/src/shotgun/agents/export.py
@@ -17,7 +17,13 @@ from .common import (
     create_usage_limits,
     run_agent,
 )
-from .models import AgentDeps, AgentResponse, AgentRuntimeOptions, AgentType
+from .models import (
+    AgentDeps,
+    AgentResponse,
+    AgentRuntimeOptions,
+    AgentType,
+    PromptTemplate,
+)
 
 logger = get_logger(__name__)
 
@@ -39,7 +45,7 @@ async def create_export_agent(
     """
     logger.debug("Initializing export agent")
     # Use partial to create system prompt function for export agent
-    system_prompt_fn = partial(build_agent_system_prompt, "export")
+    system_prompt_fn = partial(build_agent_system_prompt, PromptTemplate.EXPORT)
 
     agent, deps = await create_base_agent(
         system_prompt_fn,

--- a/src/shotgun/agents/file_read.py
+++ b/src/shotgun/agents/file_read.py
@@ -26,9 +26,9 @@ from shotgun.utils import ensure_shotgun_directory_exists
 from .common import (
     EventStreamHandler,
     add_system_status_message,
+    create_history_processor,
     run_agent,
 )
-from .conversation.history import token_limit_compactor
 from .tools import directory_lister, file_read, read_file
 from .tools.file_read_tools import multimodal_file_read
 
@@ -88,16 +88,6 @@ async def create_file_read_agent(
         agent_mode=AgentType.FILE_READ,
     )
 
-    # History processor for context management
-    async def history_processor(messages: list[ModelMessage]) -> list[ModelMessage]:
-        class ProcessorContext:
-            def __init__(self, deps: AgentDeps):
-                self.deps = deps
-                self.usage = None
-
-        ctx = ProcessorContext(deps)
-        return await token_limit_compactor(ctx, messages)
-
     # Create agent with structured output
     model = model_config.model_instance
     agent: ShotgunAgent = Agent(
@@ -105,7 +95,7 @@ async def create_file_read_agent(
         output_type=AgentResponse,
         deps_type=AgentDeps,
         instrument=True,
-        history_processors=[history_processor],
+        history_processors=[create_history_processor(deps)],
         retries=3,
     )
 

--- a/src/shotgun/agents/models.py
+++ b/src/shotgun/agents/models.py
@@ -150,6 +150,19 @@ class AgentType(StrEnum):
     FILE_READ = "file_read"
 
 
+class PromptTemplate(StrEnum):
+    """Valid prompt template names for agent system prompts."""
+
+    EXPORT = "export"
+    FILE_READ = "file_read"
+    SPECIFY = "specify"
+    PLANNER = "planner"
+    RESEARCH = "research"
+    PLAN = "plan"
+    TASKS = "tasks"
+    ROUTER = "router"
+
+
 class PipelineConfigEntry(BaseModel):
     """Configuration for each agent in the pipeline.
 

--- a/src/shotgun/agents/plan.py
+++ b/src/shotgun/agents/plan.py
@@ -17,7 +17,13 @@ from .common import (
     create_usage_limits,
     run_agent,
 )
-from .models import AgentDeps, AgentResponse, AgentRuntimeOptions, AgentType
+from .models import (
+    AgentDeps,
+    AgentResponse,
+    AgentRuntimeOptions,
+    AgentType,
+    PromptTemplate,
+)
 
 logger = get_logger(__name__)
 
@@ -39,7 +45,7 @@ async def create_plan_agent(
     """
     logger.debug("Initializing plan agent")
     # Use partial to create system prompt function for plan agent
-    system_prompt_fn = partial(build_agent_system_prompt, "plan")
+    system_prompt_fn = partial(build_agent_system_prompt, PromptTemplate.PLAN)
 
     agent, deps = await create_base_agent(
         system_prompt_fn,

--- a/src/shotgun/agents/planner/planner.py
+++ b/src/shotgun/agents/planner/planner.py
@@ -9,40 +9,30 @@ It runs on the user's expensive model and has full access to:
 This is essentially the original Router agent before the tiered split.
 """
 
-import traceback
 from functools import partial
 
-from pydantic_ai import Agent, Tool
+from pydantic_ai import Agent
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.messages import ModelMessage
-from pydantic_ai.settings import ModelSettings
 
 from shotgun.agents.common import (
-    add_system_status_message,
     build_agent_system_prompt,
-    create_usage_limits,
-    run_agent,
+    create_history_processor,
+    run_orchestrator_agent,
 )
 from shotgun.agents.config import ProviderType, get_provider_model
 from shotgun.agents.config.models import ANTHROPIC_CACHE_MODEL_SETTINGS
-from shotgun.agents.conversation.history import token_limit_compactor
-from shotgun.agents.models import AgentResponse, AgentRuntimeOptions, AgentType
+from shotgun.agents.models import (
+    AgentResponse,
+    AgentRuntimeOptions,
+    AgentType,
+    PromptTemplate,
+)
 from shotgun.agents.router.models import RouterDeps
 from shotgun.agents.router.tools import (
-    add_step,
-    create_plan,
-    mark_step_done,
-    remove_step,
+    create_delegation_tools,
+    register_plan_management_tools,
 )
-from shotgun.agents.router.tools.delegation_tools import (
-    delegate_to_export,
-    delegate_to_plan,
-    delegate_to_research,
-    delegate_to_specification,
-    delegate_to_tasks,
-    prepare_delegation_tool,
-)
-from shotgun.agents.tools import read_file
 from shotgun.logging_config import get_logger
 from shotgun.sdk.services import get_codebase_service
 from shotgun.utils import ensure_shotgun_directory_exists
@@ -88,7 +78,7 @@ async def create_planner_agent(
 
     # Create RouterDeps (Planner shares the same deps type as Router)
     codebase_service = get_codebase_service()
-    system_prompt_fn = partial(build_agent_system_prompt, "planner")
+    system_prompt_fn = partial(build_agent_system_prompt, PromptTemplate.PLANNER)
 
     deps = RouterDeps(
         **agent_runtime_options.model_dump(),
@@ -98,47 +88,20 @@ async def create_planner_agent(
         agent_mode=AgentType.PLANNER,
     )
 
-    # Create history processor with access to deps via closure
-    async def history_processor(messages: list[ModelMessage]) -> list[ModelMessage]:
-        """History processor with access to deps via closure."""
-
-        class ProcessorContext:
-            def __init__(self, deps: RouterDeps):
-                self.deps = deps
-                self.usage = None
-
-        ctx = ProcessorContext(deps)
-        return await token_limit_compactor(ctx, messages)  # type: ignore[arg-type]
-
-    # Delegation tools with prepare function
-    delegation_tools = [
-        Tool(delegate_to_research, prepare=prepare_delegation_tool),
-        Tool(delegate_to_specification, prepare=prepare_delegation_tool),
-        Tool(delegate_to_plan, prepare=prepare_delegation_tool),
-        Tool(delegate_to_tasks, prepare=prepare_delegation_tool),
-        Tool(delegate_to_export, prepare=prepare_delegation_tool),
-    ]
-
     # Create the agent with delegation tools
     agent: Agent[RouterDeps, AgentResponse] = Agent(
         model,
         output_type=AgentResponse,
         deps_type=RouterDeps,
         instrument=True,
-        history_processors=[history_processor],
+        history_processors=[create_history_processor(deps)],
         retries=3,
-        tools=delegation_tools,
+        tools=create_delegation_tools(),
         model_settings=ANTHROPIC_CACHE_MODEL_SETTINGS,
     )
 
-    # Register plan management tools
-    agent.tool(create_plan)
-    agent.tool(mark_step_done)
-    agent.tool(add_step)
-    agent.tool(remove_step)
-
-    # Register read-only file access for .shotgun/ directory
-    agent.tool(read_file)
+    # Register plan management tools + read_file
+    register_plan_management_tools(agent)
 
     logger.debug("Planner agent tools registered")
     logger.info(
@@ -166,28 +129,4 @@ async def run_planner_agent(
     Returns:
         Agent run result with response and any clarifying questions
     """
-    logger.debug("Running planner agent with prompt: %s", prompt[:100])
-
-    message_history = await add_system_status_message(deps, message_history)
-
-    try:
-        usage_limits = create_usage_limits()
-
-        # Disable parallel tool calls (same as Router)
-        planner_model_settings: ModelSettings = {"parallel_tool_calls": False}
-
-        result = await run_agent(
-            agent=agent,  # type: ignore[arg-type]
-            prompt=prompt,
-            deps=deps,
-            message_history=message_history,
-            usage_limits=usage_limits,
-            model_settings=planner_model_settings,
-        )
-
-        logger.debug("Planner agent completed successfully")
-        return result
-
-    except Exception:
-        logger.error("Planner agent error:\n%s", traceback.format_exc())
-        raise
+    return await run_orchestrator_agent(agent, prompt, deps, message_history, "Planner")

--- a/src/shotgun/agents/research.py
+++ b/src/shotgun/agents/research.py
@@ -19,7 +19,13 @@ from .common import (
     create_usage_limits,
     run_agent,
 )
-from .models import AgentDeps, AgentResponse, AgentRuntimeOptions, AgentType
+from .models import (
+    AgentDeps,
+    AgentResponse,
+    AgentRuntimeOptions,
+    AgentType,
+    PromptTemplate,
+)
 from .tools import get_available_web_search_tools
 from .tools.context7 import get_context7_mcp_server
 
@@ -60,7 +66,7 @@ async def create_research_agent(
         logger.info("Research agent configured with Context7 documentation lookup")
 
     # Use partial to create system prompt function for research agent
-    system_prompt_fn = partial(build_agent_system_prompt, "research")
+    system_prompt_fn = partial(build_agent_system_prompt, PromptTemplate.RESEARCH)
 
     agent, deps = await create_base_agent(
         system_prompt_fn,

--- a/src/shotgun/agents/router/router.py
+++ b/src/shotgun/agents/router/router.py
@@ -6,38 +6,29 @@ tasks to the Planner agent. When the cheap and expensive models are the same
 (e.g., user selected Haiku), it falls back to single-tier mode with full tools.
 """
 
-import traceback
 from functools import partial
 
-from pydantic_ai import Agent, Tool
+from pydantic_ai import Agent
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.messages import ModelMessage
-from pydantic_ai.settings import ModelSettings
 
 from shotgun.agents.common import (
-    add_system_status_message,
     build_agent_system_prompt,
-    create_usage_limits,
-    run_agent,
+    create_history_processor,
+    run_orchestrator_agent,
 )
 from shotgun.agents.config import ProviderType, get_provider_model
 from shotgun.agents.config.models import ANTHROPIC_CACHE_MODEL_SETTINGS
-from shotgun.agents.conversation.history import token_limit_compactor
-from shotgun.agents.models import AgentResponse, AgentRuntimeOptions, AgentType
+from shotgun.agents.models import (
+    AgentResponse,
+    AgentRuntimeOptions,
+    AgentType,
+    PromptTemplate,
+)
 from shotgun.agents.router.models import RouterDeps
 from shotgun.agents.router.tools import (
-    add_step,
-    create_plan,
-    mark_step_done,
-    remove_step,
-)
-from shotgun.agents.router.tools.delegation_tools import (
-    delegate_to_export,
-    delegate_to_plan,
-    delegate_to_research,
-    delegate_to_specification,
-    delegate_to_tasks,
-    prepare_delegation_tool,
+    create_delegation_tools,
+    register_plan_management_tools,
 )
 from shotgun.agents.tools import read_file
 from shotgun.logging_config import get_logger
@@ -86,7 +77,7 @@ async def create_router_agent(
 
     if is_tiered:
         model_config = cheap_config
-        prompt_template = "router"
+        prompt_template = PromptTemplate.ROUTER
         logger.info(
             "Router in TIERED mode: cheap=%s, expensive=%s",
             cheap_config.name,
@@ -94,7 +85,8 @@ async def create_router_agent(
         )
     else:
         model_config = expensive_config
-        prompt_template = "planner"  # Use full planner prompt in single-tier mode
+        # Use full planner prompt in single-tier mode
+        prompt_template = PromptTemplate.PLANNER
         logger.info(
             "Router in SINGLE-TIER mode: model=%s (no Planner needed)",
             expensive_config.name,
@@ -114,18 +106,6 @@ async def create_router_agent(
         agent_mode=AgentType.ROUTER,
     )
 
-    # Create history processor with access to deps via closure
-    async def history_processor(messages: list[ModelMessage]) -> list[ModelMessage]:
-        """History processor with access to deps via closure."""
-
-        class ProcessorContext:
-            def __init__(self, deps: RouterDeps):
-                self.deps = deps
-                self.usage = None
-
-        ctx = ProcessorContext(deps)
-        return await token_limit_compactor(ctx, messages)  # type: ignore[arg-type]
-
     if is_tiered:
         # Tiered mode: Router has only read_file (escalation via structured output)
         agent: Agent[RouterDeps, AgentResponse] = Agent(
@@ -133,7 +113,7 @@ async def create_router_agent(
             output_type=AgentResponse,
             deps_type=RouterDeps,
             instrument=True,
-            history_processors=[history_processor],
+            history_processors=[create_history_processor(deps)],
             retries=3,
             model_settings=ANTHROPIC_CACHE_MODEL_SETTINGS,
         )
@@ -144,31 +124,18 @@ async def create_router_agent(
         logger.debug("Router agent tools registered (tiered mode: read_file only)")
     else:
         # Single-tier mode: Router has full tool suite (original behavior)
-        delegation_tools = [
-            Tool(delegate_to_research, prepare=prepare_delegation_tool),
-            Tool(delegate_to_specification, prepare=prepare_delegation_tool),
-            Tool(delegate_to_plan, prepare=prepare_delegation_tool),
-            Tool(delegate_to_tasks, prepare=prepare_delegation_tool),
-            Tool(delegate_to_export, prepare=prepare_delegation_tool),
-        ]
-
         agent = Agent(
             model,
             output_type=AgentResponse,
             deps_type=RouterDeps,
             instrument=True,
-            history_processors=[history_processor],
+            history_processors=[create_history_processor(deps)],
             retries=3,
-            tools=delegation_tools,
+            tools=create_delegation_tools(),
             model_settings=ANTHROPIC_CACHE_MODEL_SETTINGS,
         )
 
-        # Full tool suite
-        agent.tool(create_plan)
-        agent.tool(mark_step_done)
-        agent.tool(add_step)
-        agent.tool(remove_step)
-        agent.tool(read_file)
+        register_plan_management_tools(agent)
 
         logger.debug("Router agent tools registered (single-tier mode: full tools)")
 
@@ -197,28 +164,4 @@ async def run_router_agent(
     Returns:
         Agent run result with response and any clarifying questions
     """
-    logger.debug("Running router agent with prompt: %s", prompt[:100])
-
-    message_history = await add_system_status_message(deps, message_history)
-
-    try:
-        usage_limits = create_usage_limits()
-
-        # Disable parallel tool calls for the Router agent.
-        router_model_settings: ModelSettings = {"parallel_tool_calls": False}
-
-        result = await run_agent(
-            agent=agent,  # type: ignore[arg-type]
-            prompt=prompt,
-            deps=deps,
-            message_history=message_history,
-            usage_limits=usage_limits,
-            model_settings=router_model_settings,
-        )
-
-        logger.debug("Router agent completed successfully")
-        return result
-
-    except Exception:
-        logger.error("Router agent error:\n%s", traceback.format_exc())
-        raise
+    return await run_orchestrator_agent(agent, prompt, deps, message_history, "Router")

--- a/src/shotgun/agents/router/tools/__init__.py
+++ b/src/shotgun/agents/router/tools/__init__.py
@@ -1,18 +1,51 @@
 """Router tools package."""
 
+from typing import Any
+
+from pydantic_ai import Agent, Tool
+
+from shotgun.agents.router.tools.delegation_tools import (
+    delegate_to_export,
+    delegate_to_plan,
+    delegate_to_research,
+    delegate_to_specification,
+    delegate_to_tasks,
+    prepare_delegation_tool,
+)
 from shotgun.agents.router.tools.plan_tools import (
     add_step,
     create_plan,
     mark_step_done,
     remove_step,
 )
+from shotgun.agents.tools import read_file
 
-# Note: Delegation tools are imported directly in router.py to use
-# the prepare_delegation_tool function for conditional visibility.
+
+def create_delegation_tools() -> list[Tool]:
+    """Create the standard delegation tool list with prepare functions."""
+    return [
+        Tool(delegate_to_research, prepare=prepare_delegation_tool),  # type: ignore[arg-type]
+        Tool(delegate_to_specification, prepare=prepare_delegation_tool),  # type: ignore[arg-type]
+        Tool(delegate_to_plan, prepare=prepare_delegation_tool),  # type: ignore[arg-type]
+        Tool(delegate_to_tasks, prepare=prepare_delegation_tool),  # type: ignore[arg-type]
+        Tool(delegate_to_export, prepare=prepare_delegation_tool),  # type: ignore[arg-type]
+    ]
+
+
+def register_plan_management_tools(agent: Agent[Any, Any]) -> None:
+    """Register plan management + read_file tools on an agent."""
+    agent.tool(create_plan)
+    agent.tool(mark_step_done)
+    agent.tool(add_step)
+    agent.tool(remove_step)
+    agent.tool(read_file)
+
 
 __all__ = [
     "add_step",
+    "create_delegation_tools",
     "create_plan",
     "mark_step_done",
+    "register_plan_management_tools",
     "remove_step",
 ]

--- a/src/shotgun/agents/specify.py
+++ b/src/shotgun/agents/specify.py
@@ -17,7 +17,13 @@ from .common import (
     create_usage_limits,
     run_agent,
 )
-from .models import AgentDeps, AgentResponse, AgentRuntimeOptions, AgentType
+from .models import (
+    AgentDeps,
+    AgentResponse,
+    AgentRuntimeOptions,
+    AgentType,
+    PromptTemplate,
+)
 
 logger = get_logger(__name__)
 
@@ -39,7 +45,7 @@ async def create_specify_agent(
     """
     logger.debug("Initializing specify agent")
     # Use partial to create system prompt function for specify agent
-    system_prompt_fn = partial(build_agent_system_prompt, "specify")
+    system_prompt_fn = partial(build_agent_system_prompt, PromptTemplate.SPECIFY)
 
     agent, deps = await create_base_agent(
         system_prompt_fn,

--- a/src/shotgun/agents/tasks.py
+++ b/src/shotgun/agents/tasks.py
@@ -17,7 +17,13 @@ from .common import (
     create_usage_limits,
     run_agent,
 )
-from .models import AgentDeps, AgentResponse, AgentRuntimeOptions, AgentType
+from .models import (
+    AgentDeps,
+    AgentResponse,
+    AgentRuntimeOptions,
+    AgentType,
+    PromptTemplate,
+)
 
 logger = get_logger(__name__)
 
@@ -39,7 +45,7 @@ async def create_tasks_agent(
     """
     logger.debug("Initializing tasks agent")
     # Use partial to create system prompt function for tasks agent
-    system_prompt_fn = partial(build_agent_system_prompt, "tasks")
+    system_prompt_fn = partial(build_agent_system_prompt, PromptTemplate.TASKS)
 
     agent, deps = await create_base_agent(
         system_prompt_fn,

--- a/src/shotgun/prompts/agents/router.j2
+++ b/src/shotgun/prompts/agents/router.j2
@@ -87,6 +87,20 @@ Your synopsis must contain:
 4. Current state of .shotgun/ files if relevant (which exist, key contents)
 5. What specifically the Planner should do
 
+### CRITICAL: No tool calls during escalation
+When you decide to escalate, do NOT make any tool calls in the same turn.
+Do not call read_file or any other tool alongside an escalation.
+If you need information from files, read them FIRST in a prior turn, then escalate
+with a complete synopsis on the next turn.
+Your escalation response must contain ONLY:
+- A brief user-facing message in `response`
+- The escalation fields (`escalation_requested`, `escalation_reason`, `escalation_synopsis`)
+- NO tool calls
+
+Put extra effort into the `escalation_synopsis` — it is the ONLY context the Planner receives.
+Include everything the Planner needs: the user's exact request, all clarifications,
+relevant file contents you've read, and specific instructions for what the Planner should do.
+
 Example escalation response:
 ```json
 {

--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -348,26 +348,8 @@ class ChatScreen(Screen[None]):
         self.run_worker(self._validate_current_model(), exclusive=True)
 
     def _reset_agents_for_model_change(self) -> None:
-        """Reset agent instances so they get recreated with the new model.
-
-        This is called when the model configuration changes (either via model picker
-        or when falling back due to API key removal).
-        """
-        self.agent_manager._agents_initialized = False
-        self.agent_manager._research_agent = None
-        self.agent_manager._plan_agent = None
-        self.agent_manager._tasks_agent = None
-        self.agent_manager._specify_agent = None
-        self.agent_manager._export_agent = None
-        self.agent_manager._router_agent = None
-        self.agent_manager._planner_agent = None
-        self.agent_manager._research_deps = None
-        self.agent_manager._plan_deps = None
-        self.agent_manager._tasks_deps = None
-        self.agent_manager._specify_deps = None
-        self.agent_manager._export_deps = None
-        self.agent_manager._router_deps = None
-        self.agent_manager._planner_deps = None
+        """Reset agent instances so they get recreated with the new model."""
+        self.agent_manager.reset_agents()
 
     async def _validate_current_model(self) -> None:
         """Validate current model is still available, fall back if not.

--- a/test/unit/agents/router/test_escalation.py
+++ b/test/unit/agents/router/test_escalation.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic_ai.models.test import TestModel
 
 from shotgun.agents.config.models import KeyProvider, ModelConfig, ProviderType
 from shotgun.agents.models import AgentResponse, AgentRuntimeOptions, AgentType
@@ -11,8 +12,6 @@ from shotgun.codebase.service import CodebaseService
 
 def _make_model_config(name: str = "test-model") -> ModelConfig:
     """Create a ModelConfig with a test model_instance."""
-    from pydantic_ai.models.test import TestModel
-
     config = ModelConfig(
         name=name,
         provider=ProviderType.ANTHROPIC,


### PR DESCRIPTION
## Summary

- Extract shared code from Router/Planner agent factories into reusable helpers in `common.py` and `router/tools/__init__.py`
- Add `PromptTemplate` StrEnum to replace loose string literals for prompt template names across all agent factories
- Add `AgentManager.reset_agents()` public method to replace direct private attribute access from `chat_screen.py`
- Add no-tool-calls-during-escalation rule and synopsis quality guidance to Router prompt

## Test plan

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `mypy src/` passes with no errors
- [x] `pytest test/unit/agents/router/` passes (136 tests)
- [ ] CI unit tests pass (1 pre-existing failure in `test_router_metrics.py` unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)