### PR TITLE
feat(autopilot): add local/remote push option for cowboy mode

### DIFF
--- a/src/shotgun/agents/autopilot/autopilot_orchestrator.py
+++ b/src/shotgun/agents/autopilot/autopilot_orchestrator.py
@@ -332,63 +332,10 @@ class AutopilotOrchestrator:
 
         # Cowboy mode: self-review but skip human approval
         if self.state.mode == AutopilotMode.COWBOY:
-            # Self-review phase
-            stage.phase = StagePhase.REVIEWING
-            logger.info("Cowboy mode: Self-reviewing Stage %s", stage.number)
-            yield ClaudeOutput(
-                type=ClaudeOutputType.STDOUT,
-                content=f"🔍 Self-reviewing Stage {stage.number}...",
-            )
-
-            async for output in self._review_and_fix(stage):
+            async for output in self._cowboy_post_execution(stage):
                 yield output
                 if self._cancelled:
                     return
-
-            # Optionally push to remote and create PR
-            if self.config.push_to_remote:
-                stage.phase = StagePhase.CREATING_PR
-                logger.info("Cowboy mode: Pushing Stage %s to remote", stage.number)
-                yield ClaudeOutput(
-                    type=ClaudeOutputType.STDOUT,
-                    content=f"📤 Pushing Stage {stage.number} to remote...",
-                )
-                async for output in self._create_pr(stage):
-                    yield output
-                    if self._cancelled:
-                        return
-
-            # Mark complete and move on (no human approval)
-            stage.status = StageStatus.COMPLETED
-            stage.phase = None
-
-            push_label = (
-                "pushed to remote"
-                if self.config.push_to_remote
-                else "no PR, no human review"
-            )
-            logger.info(
-                "Stage %s complete (cowboy mode - %s)",
-                stage.number,
-                push_label,
-            )
-
-            # Track stage completion
-            track_event(
-                "autopilot_stage_completed",
-                {
-                    "stage_number": stage.number,
-                    "total_stages": len(self.state.stages),
-                    "has_pr": self.config.push_to_remote and stage.pr_url is not None,
-                    "mode": self.state.mode.value,
-                    "push_to_remote": self.config.push_to_remote,
-                },
-            )
-
-            yield ClaudeOutput(
-                type=ClaudeOutputType.STDOUT,
-                content=f"✅ Stage {stage.number} complete",
-            )
 
             # Auto-advance to next stage
             if self.advance_to_next_stage():
@@ -684,9 +631,9 @@ class AutopilotOrchestrator:
         Yields:
             ClaudeOutput with review progress.
         """
-        # In cowboy mode with local-only, don't instruct Claude to push review fixes
-        push_in_review = not (
-            self.state.mode == AutopilotMode.COWBOY and not self.config.push_to_remote
+        # Push review fixes unless we're in cowboy mode with local-only
+        push_in_review = (
+            self.state.mode != AutopilotMode.COWBOY or self.config.push_to_remote
         )
         prompt = render_review_code(
             tasks_file_path=self.state.tasks_file_path,
@@ -734,6 +681,11 @@ class AutopilotOrchestrator:
             prev_stage = self.state.stages[self.state.current_stage_index - 1]
             base_branch = f"{self.config.branch_prefix}{prev_stage.number}"
 
+        # In cowboy mode with local-only, tell Claude not to push
+        push_to_remote = (
+            self.state.mode != AutopilotMode.COWBOY or self.config.push_to_remote
+        )
+
         return render_execute_stage(
             tasks_file_path=self.state.tasks_file_path,
             stage_number=stage.number,
@@ -741,6 +693,7 @@ class AutopilotOrchestrator:
             pending_tasks=pending_tasks,
             branch_name=branch_name,
             base_branch=base_branch,
+            push_to_remote=push_to_remote,
         )
 
     async def _run_claude(
@@ -1150,6 +1103,75 @@ class AutopilotOrchestrator:
                     async for output in self._post_execution_workflow(stage):
                         yield output
 
+    async def _cowboy_post_execution(
+        self, stage: Stage
+    ) -> AsyncGenerator[ClaudeOutput, None]:
+        """Run the cowboy mode post-execution workflow: self-review, optional push, mark complete.
+
+        Shared by both sequential (run_stage_workflow) and parallel (_post_execution_workflow)
+        cowboy mode flows.
+
+        Args:
+            stage: The completed stage.
+
+        Yields:
+            ClaudeOutput as the workflow progresses.
+        """
+        # Self-review phase
+        stage.phase = StagePhase.REVIEWING
+        logger.info("Cowboy mode: Self-reviewing Stage %s", stage.number)
+        yield ClaudeOutput(
+            type=ClaudeOutputType.STDOUT,
+            content=f"🔍 Self-reviewing Stage {stage.number}...",
+        )
+
+        async for output in self._review_and_fix(stage):
+            yield output
+            if self._cancelled:
+                return
+
+        # Optionally push to remote and create PR
+        if self.config.push_to_remote:
+            stage.phase = StagePhase.CREATING_PR
+            logger.info("Cowboy mode: Pushing Stage %s to remote", stage.number)
+            yield ClaudeOutput(
+                type=ClaudeOutputType.STDOUT,
+                content=f"📤 Pushing Stage {stage.number} to remote...",
+            )
+            async for output in self._create_pr(stage):
+                yield output
+                if self._cancelled:
+                    return
+
+        # Mark complete (no human approval in cowboy mode)
+        stage.status = StageStatus.COMPLETED
+        stage.phase = None
+
+        push_label = (
+            "pushed to remote" if self.config.push_to_remote else "local only, no PR"
+        )
+        logger.info(
+            "Stage %s complete (cowboy mode - %s)",
+            stage.number,
+            push_label,
+        )
+
+        track_event(
+            "autopilot_stage_completed",
+            {
+                "stage_number": stage.number,
+                "total_stages": len(self.state.stages),
+                "has_pr": self.config.push_to_remote and stage.pr_url is not None,
+                "mode": self.state.mode.value,
+                "push_to_remote": self.config.push_to_remote,
+            },
+        )
+
+        yield ClaudeOutput(
+            type=ClaudeOutputType.STDOUT,
+            content=f"✅ Stage {stage.number} complete",
+        )
+
     async def _post_execution_workflow(
         self, stage: Stage
     ) -> AsyncGenerator[ClaudeOutput, None]:
@@ -1165,48 +1187,10 @@ class AutopilotOrchestrator:
             ClaudeOutput as the workflow progresses.
         """
         if self.state.mode == AutopilotMode.COWBOY:
-            # Self-review
-            stage.phase = StagePhase.REVIEWING
-            yield ClaudeOutput(
-                type=ClaudeOutputType.STDOUT,
-                content=f"Self-reviewing Stage {stage.number}...",
-            )
-            async for output in self._review_and_fix(stage):
+            async for output in self._cowboy_post_execution(stage):
                 yield output
                 if self._cancelled:
                     return
-
-            # Optionally push to remote
-            if self.config.push_to_remote:
-                stage.phase = StagePhase.CREATING_PR
-                yield ClaudeOutput(
-                    type=ClaudeOutputType.STDOUT,
-                    content=f"Pushing Stage {stage.number} to remote...",
-                )
-                async for output in self._create_pr(stage):
-                    yield output
-                    if self._cancelled:
-                        return
-
-            stage.status = StageStatus.COMPLETED
-            stage.phase = None
-
-            track_event(
-                "autopilot_stage_completed",
-                {
-                    "stage_number": stage.number,
-                    "total_stages": len(self.state.stages),
-                    "has_pr": self.config.push_to_remote and stage.pr_url is not None,
-                    "mode": self.state.mode.value,
-                    "parallel": True,
-                    "push_to_remote": self.config.push_to_remote,
-                },
-            )
-
-            yield ClaudeOutput(
-                type=ClaudeOutputType.STDOUT,
-                content=f"Stage {stage.number} complete (parallel)",
-            )
             return
 
         # Non-cowboy modes: PR creation, review, QA

--- a/src/shotgun/agents/autopilot/models.py
+++ b/src/shotgun/agents/autopilot/models.py
@@ -232,10 +232,6 @@ class AutopilotState(BaseModel):
         default=True,
         description="Use Claude Code Teams for parallel stage execution",
     )
-    push_to_remote: bool = Field(
-        default=False,
-        description="Whether to push changes to remote repo (cowboy mode only)",
-    )
 
     @property
     def current_stage(self) -> Stage | None:

--- a/src/shotgun/agents/autopilot/prompts/__init__.py
+++ b/src/shotgun/agents/autopilot/prompts/__init__.py
@@ -25,6 +25,7 @@ def render_execute_stage(
     pending_tasks: list[str],
     branch_name: str,
     base_branch: str,
+    push_to_remote: bool = True,
 ) -> str:
     """Render the execute stage prompt.
 
@@ -35,6 +36,7 @@ def render_execute_stage(
         pending_tasks: List of pending task descriptions.
         branch_name: The branch name to create/checkout for this stage.
         base_branch: The base branch to create from.
+        push_to_remote: Whether to allow pushing to remote.
 
     Returns:
         Rendered prompt string.
@@ -47,6 +49,7 @@ def render_execute_stage(
         pending_tasks=pending_tasks,
         branch_name=branch_name,
         base_branch=base_branch,
+        push_to_remote=push_to_remote,
     )
 
 

--- a/src/shotgun/agents/autopilot/prompts/execute_stage.j2
+++ b/src/shotgun/agents/autopilot/prompts/execute_stage.j2
@@ -24,6 +24,9 @@ Before starting work, ensure git is set up correctly:
 3. After completing each task, mark it done in {{ tasks_file_path }} by changing `- [ ]` to `- [x]`
 4. Commit your changes after completing tasks
 5. Focus on quality - make sure the implementation is correct
+{% if not push_to_remote %}
+6. **Keep all changes local. Under no circumstances should you push code to a remote repo.** Do not run `git push`, do not create pull requests, do not use `gh pr create`.
+{% endif %}
 
 ## IMPORTANT
 

--- a/src/shotgun/agents/autopilot/prompts/review_code.j2
+++ b/src/shotgun/agents/autopilot/prompts/review_code.j2
@@ -13,6 +13,8 @@ If you find any issues:
 2. Commit the fixes with message "fix: address review feedback for Stage {{ stage_number }}"
 {% if push_to_remote %}
 3. Push the changes
+{% else %}
+3. **Keep all changes local. Under no circumstances should you push code to a remote repo.** Do not run `git push`, do not create pull requests, do not use `gh pr create`.
 {% endif %}
 
 Be thorough but practical - focus on real issues, not style nitpicks.

--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -3107,7 +3107,6 @@ class ChatScreen(Screen[None]):
             self._autopilot_orchestrator.set_mode(AutopilotMode(mode.value))
             self._autopilot_orchestrator.state.stages = stages
             self._autopilot_orchestrator.state.use_teams = use_teams
-            self._autopilot_orchestrator.state.push_to_remote = push_to_remote
             # Initialize state based on task completion - skip completed stages
             self._autopilot_orchestrator.state.initialize_from_tasks()
 

--- a/test/unit/agents/autopilot/test_push_to_remote.py
+++ b/test/unit/agents/autopilot/test_push_to_remote.py
@@ -6,9 +6,10 @@ from shotgun.agents.autopilot.autopilot_orchestrator import (
 )
 from shotgun.agents.autopilot.models import (
     AutopilotMode,
-    AutopilotState,
+    Stage,
+    Task,
 )
-from shotgun.agents.autopilot.prompts import render_review_code
+from shotgun.agents.autopilot.prompts import render_execute_stage, render_review_code
 from shotgun.tui.screens.autopilot_startup import AutopilotStartResult
 
 
@@ -22,18 +23,6 @@ def test_autopilot_start_result_push_to_remote_true():
     """AutopilotStartResult.push_to_remote can be set to True."""
     result = AutopilotStartResult(started=True, push_to_remote=True)
     assert result.push_to_remote is True
-
-
-def test_autopilot_state_push_to_remote_defaults_false():
-    """AutopilotState.push_to_remote defaults to False."""
-    state = AutopilotState()
-    assert state.push_to_remote is False
-
-
-def test_autopilot_state_push_to_remote_true():
-    """AutopilotState.push_to_remote can be set to True."""
-    state = AutopilotState(push_to_remote=True)
-    assert state.push_to_remote is True
 
 
 def test_autopilot_config_push_to_remote_defaults_false():
@@ -68,6 +57,9 @@ def test_orchestrator_cowboy_mode_push_enabled():
     assert orchestrator.state.mode == AutopilotMode.COWBOY
 
 
+# --- Review code prompt tests ---
+
+
 def test_render_review_code_with_push():
     """Review code prompt includes push instruction when push_to_remote=True."""
     prompt = render_review_code(
@@ -77,10 +69,11 @@ def test_render_review_code_with_push():
         push_to_remote=True,
     )
     assert "Push the changes" in prompt
+    assert "Under no circumstances" not in prompt
 
 
 def test_render_review_code_without_push():
-    """Review code prompt omits push instruction when push_to_remote=False."""
+    """Review code prompt includes keep-local instruction when push_to_remote=False."""
     prompt = render_review_code(
         tasks_file_path=".shotgun/tasks.md",
         stage_number="1",
@@ -88,6 +81,9 @@ def test_render_review_code_without_push():
         push_to_remote=False,
     )
     assert "Push the changes" not in prompt
+    assert "Under no circumstances should you push code to a remote repo" in prompt
+    assert "git push" in prompt
+    assert "gh pr create" in prompt
 
 
 def test_render_review_code_defaults_to_push():
@@ -98,3 +94,103 @@ def test_render_review_code_defaults_to_push():
         stage_name="Auth",
     )
     assert "Push the changes" in prompt
+
+
+# --- Execute stage prompt tests ---
+
+
+def test_render_execute_stage_with_push():
+    """Execute stage prompt does not include keep-local warning when push_to_remote=True."""
+    prompt = render_execute_stage(
+        tasks_file_path=".shotgun/tasks.md",
+        stage_number="1",
+        stage_name="Auth",
+        pending_tasks=["Add login form"],
+        branch_name="autopilot/stage-1",
+        base_branch="main",
+        push_to_remote=True,
+    )
+    assert "Under no circumstances" not in prompt
+
+
+def test_render_execute_stage_without_push():
+    """Execute stage prompt includes keep-local warning when push_to_remote=False."""
+    prompt = render_execute_stage(
+        tasks_file_path=".shotgun/tasks.md",
+        stage_number="1",
+        stage_name="Auth",
+        pending_tasks=["Add login form"],
+        branch_name="autopilot/stage-1",
+        base_branch="main",
+        push_to_remote=False,
+    )
+    assert "Under no circumstances should you push code to a remote repo" in prompt
+    assert "git push" in prompt
+    assert "gh pr create" in prompt
+
+
+def test_render_execute_stage_defaults_to_push():
+    """Execute stage prompt defaults to allowing push (no local-only warning)."""
+    prompt = render_execute_stage(
+        tasks_file_path=".shotgun/tasks.md",
+        stage_number="1",
+        stage_name="Auth",
+        pending_tasks=["Add login form"],
+        branch_name="autopilot/stage-1",
+        base_branch="main",
+    )
+    assert "Under no circumstances" not in prompt
+
+
+# --- Orchestrator prompt integration tests ---
+
+
+def test_build_execution_prompt_cowboy_local_includes_keep_local():
+    """Cowboy mode with local-only includes keep-local instruction in execution prompt."""
+    config = AutopilotConfig(push_to_remote=False)
+    orchestrator = AutopilotOrchestrator(config)
+    orchestrator.set_mode(AutopilotMode.COWBOY)
+
+    stage = Stage(
+        number="1",
+        name="Auth",
+        tasks=[Task(text="Add login", completed=False, line_number=1)],
+    )
+    orchestrator.state.stages = [stage]
+
+    prompt = orchestrator._build_execution_prompt(stage)
+    assert "Under no circumstances should you push code to a remote repo" in prompt
+
+
+def test_build_execution_prompt_cowboy_push_no_keep_local():
+    """Cowboy mode with push enabled does not include keep-local instruction."""
+    config = AutopilotConfig(push_to_remote=True)
+    orchestrator = AutopilotOrchestrator(config)
+    orchestrator.set_mode(AutopilotMode.COWBOY)
+
+    stage = Stage(
+        number="1",
+        name="Auth",
+        tasks=[Task(text="Add login", completed=False, line_number=1)],
+    )
+    orchestrator.state.stages = [stage]
+
+    prompt = orchestrator._build_execution_prompt(stage)
+    assert "Under no circumstances" not in prompt
+
+
+def test_build_execution_prompt_non_cowboy_no_keep_local():
+    """Non-cowboy modes do not include keep-local instruction."""
+    config = AutopilotConfig(push_to_remote=False)
+    orchestrator = AutopilotOrchestrator(config)
+    orchestrator.set_mode(AutopilotMode.PAUSE_BETWEEN)
+
+    stage = Stage(
+        number="1",
+        name="Auth",
+        tasks=[Task(text="Add login", completed=False, line_number=1)],
+    )
+    orchestrator.state.stages = [stage]
+
+    prompt = orchestrator._build_execution_prompt(stage)
+    assert "Under no circumstances" not in prompt


### PR DESCRIPTION
## Summary
- Adds a "Remote" radio button group to the autopilot cowboy mode startup screen with two options: "Keep changes local only" (default) and "Push changes to remote repo (caution)"
- The push option section only appears when cowboy mode is selected
- When push is enabled, cowboy mode will create PRs after self-review; when disabled (default), changes stay local only

## Test plan
- [x] mypy passes (0 issues)
- [x] ruff check passes
- [x] Smoke tests pass (7/7)
- [x] 11 new unit tests in `test_push_to_remote.py` all pass
- [x] All 125 autopilot unit tests pass
- [ ] Manual: select cowboy mode → verify "Remote" section appears
- [ ] Manual: select pause/auto-continue → verify "Remote" section is hidden
- [ ] Manual: cowboy + local only → verify no push occurs
- [ ] Manual: cowboy + push to remote → verify PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)