### PR TITLE
feat(agents): enable Anthropic prompt caching with tiered message TTLs

### DIFF
--- a/src/shotgun/agents/common.py
+++ b/src/shotgun/agents/common.py
@@ -27,7 +27,7 @@ from shotgun.agents.config.constants import (
     WEB_SEARCH_STOP_THRESHOLD,
     WEB_SEARCH_WARNING_THRESHOLD,
 )
-from shotgun.agents.config.models import ANTHROPIC_CACHE_MODEL_SETTINGS
+from shotgun.agents.config.models import ANTHROPIC_SUB_AGENT_CACHE_SETTINGS
 from shotgun.agents.models import (
     AgentResponse,
     AgentSystemPromptContext,
@@ -265,8 +265,9 @@ async def create_base_agent(
         """History processor with access to deps via closure.
 
         This processor runs before each turn and:
-        1. Updates web search count in the system status message
-        2. Applies token limit compaction
+        1. Counts web searches to update the system status message
+        2. Appends a fresh SystemStatusPrompt (old ones stay in place for caching)
+        3. Applies token limit compaction
         """
         # Count current web searches to update the status message
         web_search_count = count_web_searches(messages)
@@ -276,29 +277,9 @@ async def create_base_agent(
                 web_search_count,
             )
 
-        # Remove existing SystemStatusPrompt messages and re-add with updated count
-        # This ensures the agent sees accurate web search warnings on each turn
-        filtered_messages: list[ModelMessage] = []
-        for msg in messages:
-            if isinstance(msg, ModelRequest):
-                # Filter out SystemStatusPrompt parts
-                new_parts = [
-                    part
-                    for part in msg.parts
-                    if not isinstance(part, SystemStatusPrompt)
-                ]
-                if new_parts:
-                    filtered_messages.append(
-                        ModelRequest(parts=new_parts, instructions=msg.instructions)
-                    )
-            else:
-                filtered_messages.append(msg)
-
-        # Re-add system status with updated web search count
-        # Note: add_system_status_message will count from filtered_messages,
-        # but we already counted from original messages, so pass the count
-        filtered_messages = await add_system_status_message(
-            deps, filtered_messages, web_search_count=web_search_count
+        # Append fresh system status at the end (preserves cached message prefix)
+        messages = await add_system_status_message(
+            deps, messages, web_search_count=web_search_count
         )
 
         # Create a minimal context for compaction
@@ -308,7 +289,7 @@ async def create_base_agent(
                 self.usage = None  # Will be estimated from messages
 
         ctx = ProcessorContext(deps)
-        return await token_limit_compactor(ctx, filtered_messages)
+        return await token_limit_compactor(ctx, messages)
 
     agent = Agent(
         model,
@@ -318,7 +299,7 @@ async def create_base_agent(
         history_processors=[history_processor],
         retries=3,  # Default retry count for tool calls and output validation
         toolsets=mcp_servers or None,
-        model_settings=ANTHROPIC_CACHE_MODEL_SETTINGS,
+        model_settings=ANTHROPIC_SUB_AGENT_CACHE_SETTINGS,
     )
 
     # System prompt function is stored in deps and will be called manually in run_agent

--- a/src/shotgun/agents/config/models.py
+++ b/src/shotgun/agents/config/models.py
@@ -25,9 +25,16 @@ class KeyProvider(StrEnum):
     SHOTGUN = "shotgun"  # Shotgun Account (unified LiteLLM proxy)
 
 
-ANTHROPIC_CACHE_MODEL_SETTINGS = AnthropicModelSettings(
+ANTHROPIC_ROUTER_CACHE_SETTINGS = AnthropicModelSettings(
     anthropic_cache_tool_definitions="1h",
     anthropic_cache_instructions="1h",
+    anthropic_cache_messages="1h",
+)
+
+ANTHROPIC_SUB_AGENT_CACHE_SETTINGS = AnthropicModelSettings(
+    anthropic_cache_tool_definitions="1h",
+    anthropic_cache_instructions="1h",
+    anthropic_cache_messages="5m",
 )
 
 

--- a/src/shotgun/agents/conversation/history/compaction.py
+++ b/src/shotgun/agents/conversation/history/compaction.py
@@ -32,32 +32,10 @@ async def apply_persistent_compaction(
     Returns:
         Compacted message history that should be stored as conversation state
     """
-    from .file_content_deduplication import deduplicate_file_content
     from .history_processors import token_limit_compactor
 
     try:
-        # STEP 1: Deterministic pre-compaction (no LLM cost)
-        # Remove file content from tool returns - files are still accessible
-        # via retrieve_code (codebase) or read_file (.shotgun/ folder)
-        messages, tokens_saved = deduplicate_file_content(
-            messages,
-            retention_window=3,  # Keep last 3 messages' file content intact
-        )
-
-        if tokens_saved > 0:
-            logger.info(
-                f"Pre-compaction: removed ~{tokens_saved:,} tokens of file content"
-            )
-            track_event(
-                "file_content_deduplication",
-                {
-                    "tokens_saved_estimate": tokens_saved,
-                    "retention_window": 3,
-                    "model_name": deps.llm_model.name_str,
-                },
-            )
-
-        # STEP 2: Count tokens after pre-compaction
+        # Count tokens to decide if LLM-based compaction is needed
         estimated_tokens = await estimate_tokens_from_messages(messages, deps.llm_model)
 
         # Create minimal usage info for compaction check

--- a/src/shotgun/agents/conversation/history/history_processors.py
+++ b/src/shotgun/agents/conversation/history/history_processors.py
@@ -15,7 +15,7 @@ from pydantic_ai.messages import (
 
 from shotgun.agents.conversation.filters import filter_orphaned_tool_responses
 from shotgun.agents.llm import shotgun_model_request
-from shotgun.agents.messages import AgentSystemPrompt, SystemStatusPrompt
+from shotgun.agents.messages import AgentSystemPrompt
 from shotgun.agents.models import AgentDeps
 from shotgun.exceptions import ContextSizeLimitExceeded
 from shotgun.logging_config import get_logger
@@ -28,7 +28,6 @@ from .history_building import ensure_ends_with_model_request
 from .message_utils import (
     get_agent_system_prompt,
     get_first_user_request,
-    get_latest_system_status,
 )
 from .token_estimation import (
     calculate_max_summarization_tokens as _calculate_max_summarization_tokens,
@@ -376,7 +375,6 @@ async def token_limit_compactor(
 
         # Extract essential context from messages before the last summary (if any)
         agent_prompt = ""
-        system_status = ""
         first_user_prompt = ""
         if last_summary_index > 0:
             # Get agent system prompt and first user from original conversation
@@ -384,9 +382,6 @@ async def token_limit_compactor(
             first_user_prompt = (
                 get_first_user_request(messages[:last_summary_index]) or ""
             )
-
-        # Get the latest system status from all messages
-        system_status = get_latest_system_status(messages) or ""
 
         # Create the updated summary message
         updated_summary_message = ModelResponse(parts=[new_summary_part])
@@ -400,8 +395,6 @@ async def token_limit_compactor(
         parts: list[ModelRequestPart] = []
         if agent_prompt:
             parts.append(AgentSystemPrompt(content=agent_prompt))
-        if system_status:
-            parts.append(SystemStatusPrompt(content=system_status))
         if first_user_prompt:
             parts.append(UserPromptPart(content=first_user_prompt))
 
@@ -568,7 +561,6 @@ async def _full_compaction(
 
     # Build compacted history structure
     agent_prompt = get_agent_system_prompt(messages) or ""
-    system_status = get_latest_system_status(messages) or ""
     user_prompt = get_first_user_request(messages) or ""
 
     # Build parts for the initial request
@@ -577,8 +569,6 @@ async def _full_compaction(
     parts: list[ModelRequestPart] = []
     if agent_prompt:
         parts.append(AgentSystemPrompt(content=agent_prompt))
-    if system_status:
-        parts.append(SystemStatusPrompt(content=system_status))
     if user_prompt:
         parts.append(UserPromptPart(content=user_prompt))
 
@@ -816,7 +806,6 @@ def _build_chunked_compaction_result(
 
     # Extract system context from original messages
     agent_prompt = get_agent_system_prompt(original_messages) or ""
-    system_status = get_latest_system_status(original_messages) or ""
     first_user = get_first_user_request(original_messages) or ""
 
     # Create marked summary
@@ -830,8 +819,6 @@ def _build_chunked_compaction_result(
     parts: list[ModelRequestPart] = []
     if agent_prompt:
         parts.append(AgentSystemPrompt(content=agent_prompt))
-    if system_status:
-        parts.append(SystemStatusPrompt(content=system_status))
     if first_user:
         parts.append(UserPromptPart(content=first_user))
 

--- a/src/shotgun/agents/router/router.py
+++ b/src/shotgun/agents/router/router.py
@@ -19,7 +19,7 @@ from shotgun.agents.common import (
     run_agent,
 )
 from shotgun.agents.config import ProviderType, get_provider_model
-from shotgun.agents.config.models import ANTHROPIC_CACHE_MODEL_SETTINGS
+from shotgun.agents.config.models import ANTHROPIC_ROUTER_CACHE_SETTINGS
 from shotgun.agents.conversation.history import token_limit_compactor
 from shotgun.agents.models import AgentResponse, AgentRuntimeOptions, AgentType
 from shotgun.agents.router.models import RouterDeps
@@ -123,7 +123,7 @@ async def create_router_agent(
         history_processors=[history_processor],
         retries=3,
         tools=delegation_tools,
-        model_settings=ANTHROPIC_CACHE_MODEL_SETTINGS,
+        model_settings=ANTHROPIC_ROUTER_CACHE_SETTINGS,
     )
 
     # Register plan management tools (router-specific, always available)

--- a/test/unit/agents/test_anthropic_cache_settings.py
+++ b/test/unit/agents/test_anthropic_cache_settings.py
@@ -48,14 +48,14 @@ def mock_codebase_service():
 @patch("shotgun.agents.common.get_codebase_service")
 @patch("shotgun.agents.common.get_provider_model", new_callable=AsyncMock)
 @pytest.mark.asyncio
-async def test_sub_agent_caches_only_tool_definitions(
+async def test_sub_agent_caches_messages_at_5m(
     mock_get_model,
     mock_get_codebase,
     mock_model_config,
     mock_runtime_options,
     mock_codebase_service,
 ):
-    """Sub-agents should only cache tool definitions at 1h TTL."""
+    """Sub-agents should cache messages at 5m TTL for short task-scoped conversations."""
     mock_get_model.return_value = mock_model_config
     mock_get_codebase.return_value = mock_codebase_service
 
@@ -70,20 +70,20 @@ async def test_sub_agent_caches_only_tool_definitions(
     assert settings is not None
     assert settings.get("anthropic_cache_tool_definitions") == "1h"
     assert settings.get("anthropic_cache_instructions") == "1h"
-    assert "anthropic_cache_messages" not in settings
+    assert settings.get("anthropic_cache_messages") == "5m"
 
 
 @patch("shotgun.agents.router.router.get_codebase_service")
 @patch("shotgun.agents.router.router.get_provider_model", new_callable=AsyncMock)
 @pytest.mark.asyncio
-async def test_router_agent_caches_tools_and_instructions(
+async def test_router_agent_caches_messages_at_1h(
     mock_get_model,
     mock_get_codebase,
     mock_model_config,
     mock_runtime_options,
     mock_codebase_service,
 ):
-    """Router agent should cache tool definitions and instructions at 1h TTL."""
+    """Router agent should cache messages at 1h TTL for long-lived conversations."""
     mock_get_model.return_value = mock_model_config
     mock_get_codebase.return_value = mock_codebase_service
 
@@ -93,7 +93,7 @@ async def test_router_agent_caches_tools_and_instructions(
     assert settings is not None
     assert settings.get("anthropic_cache_tool_definitions") == "1h"
     assert settings.get("anthropic_cache_instructions") == "1h"
-    assert "anthropic_cache_messages" not in settings
+    assert settings.get("anthropic_cache_messages") == "1h"
 
 
 @patch("shotgun.agents.router.router.get_codebase_service")
@@ -121,14 +121,14 @@ async def test_router_cache_settings_do_not_include_parallel_tool_calls(
 @patch("shotgun.agents.common.get_codebase_service")
 @patch("shotgun.agents.common.get_provider_model", new_callable=AsyncMock)
 @pytest.mark.asyncio
-async def test_router_and_sub_agents_share_same_cache_settings(
+async def test_router_and_sub_agents_have_different_message_cache_ttls(
     mock_get_model,
     mock_get_codebase,
     mock_model_config,
     mock_runtime_options,
     mock_codebase_service,
 ):
-    """Router and sub-agents should have identical cache settings."""
+    """Router uses 1h message caching, sub-agents use 5m."""
     mock_get_model.return_value = mock_model_config
     mock_get_codebase.return_value = mock_codebase_service
 
@@ -139,4 +139,4 @@ async def test_router_and_sub_agents_share_same_cache_settings(
     assert sub_settings is not None
     assert sub_settings.get("anthropic_cache_tool_definitions") == "1h"
     assert sub_settings.get("anthropic_cache_instructions") == "1h"
-    assert "anthropic_cache_messages" not in sub_settings
+    assert sub_settings.get("anthropic_cache_messages") == "5m"

--- a/test/unit/test_router_metrics.py
+++ b/test/unit/test_router_metrics.py
@@ -250,17 +250,25 @@ async def test_plan_step_removed_metric(mock_ctx):
         )
 
 
-@pytest.mark.asyncio
-async def test_delegation_started_metric():
-    """Test that delegation_started metric is tracked when delegating."""
-    mock_deps = MagicMock(spec=RouterDeps)
-    mock_deps.current_plan = None
-    mock_deps.active_sub_agent = None
-    mock_deps.parent_stream_handler = None
-    mock_deps.cancellation_event = None
+@pytest.fixture
+def mock_delegation_deps():
+    """Create mock RouterDeps with all attributes needed for delegation tests."""
+    deps = MagicMock(spec=RouterDeps)
+    deps.current_plan = None
+    deps.active_sub_agent = None
+    deps.parent_stream_handler = None
+    deps.cancellation_event = None
+    deps.usage_manager = AsyncMock()
+    deps.sub_agent_cache = {}
+    deps.sub_agent_tool_calls = {}
+    return deps
 
+
+@pytest.mark.asyncio
+async def test_delegation_started_metric(mock_delegation_deps):
+    """Test that delegation_started metric is tracked when delegating."""
     mock_ctx = MagicMock(spec=RunContext)
-    mock_ctx.deps = mock_deps
+    mock_ctx.deps = mock_delegation_deps
 
     with patch(
         "shotgun.agents.router.tools.delegation_tools.track_event"
@@ -273,6 +281,9 @@ async def test_delegation_started_metric():
             mock_sub_deps = MagicMock(spec=AgentDeps)
             mock_sub_deps.file_tracker = FileOperationTracker()
             mock_sub_deps.sub_agent_context = None
+            mock_sub_deps.llm_model = MagicMock()
+            mock_sub_deps.llm_model.name = "test-model"
+            mock_sub_deps.llm_model.provider = "anthropic"
             mock_get_agent.return_value = (mock_agent, mock_sub_deps)
 
             with patch(
@@ -308,16 +319,10 @@ async def test_delegation_started_metric():
 
 
 @pytest.mark.asyncio
-async def test_delegation_completed_metric():
+async def test_delegation_completed_metric(mock_delegation_deps):
     """Test that delegation_completed metric is tracked on successful delegation."""
-    mock_deps = MagicMock(spec=RouterDeps)
-    mock_deps.current_plan = None
-    mock_deps.active_sub_agent = None
-    mock_deps.parent_stream_handler = None
-    mock_deps.cancellation_event = None
-
     mock_ctx = MagicMock(spec=RunContext)
-    mock_ctx.deps = mock_deps
+    mock_ctx.deps = mock_delegation_deps
 
     with patch(
         "shotgun.agents.router.tools.delegation_tools.track_event"
@@ -330,6 +335,9 @@ async def test_delegation_completed_metric():
             mock_sub_deps = MagicMock(spec=AgentDeps)
             mock_sub_deps.file_tracker = FileOperationTracker()
             mock_sub_deps.sub_agent_context = None
+            mock_sub_deps.llm_model = MagicMock()
+            mock_sub_deps.llm_model.name = "test-model"
+            mock_sub_deps.llm_model.provider = "anthropic"
             mock_get_agent.return_value = (mock_agent, mock_sub_deps)
 
             with patch(


### PR DESCRIPTION
## Summary

- Split `ANTHROPIC_CACHE_MODEL_SETTINGS` into `ANTHROPIC_ROUTER_CACHE_SETTINGS` (1h) and `ANTHROPIC_SUB_AGENT_CACHE_SETTINGS` (5m) to enable `anthropic_cache_messages` with tiered TTLs
- Stop mutating message history between turns so cached prefixes remain stable: append fresh `SystemStatusPrompt` instead of strip-and-re-add, remove file content deduplication from persistent compaction, remove `SystemStatusPrompt` re-injection from all three compaction builders
- Fix pre-existing `test_router_metrics` delegation test failures (missing mock attributes for `usage_manager`, `sub_agent_cache`, `sub_agent_tool_calls`, `llm_model`)
- Improve Router escalation synopsis to be factual (what happened) rather than instructional (what to do)

## Test plan

- [x] `uv run ruff check .` — linting passes
- [x] `uv run ruff format --check .` — formatting passes
- [x] `uv run mypy src/` — type checking passes
- [x] `uv run pytest -m smoke -v` — 7/7 smoke tests pass
- [x] `uv run pytest test/unit/agents/test_anthropic_cache_settings.py -v` — 5/5 cache settings tests pass
- [x] `uv run pytest test/unit/agents/history/ -v` — 50/50 history tests pass
- [x] `uv run pytest test/unit/test_router_metrics.py -v` — 8/8 router metrics tests pass (previously 1 failing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)