### PR TITLE
feat(agents): preload .shotgun/ files on sub-agent delegation

### DIFF
--- a/src/shotgun/agents/router/models.py
+++ b/src/shotgun/agents/router/models.py
@@ -194,6 +194,11 @@ class DelegationInput(BaseModel):
     context_hint: str | None = Field(
         default=None, description="Optional context to help the sub-agent"
     )
+    preload_files: list[str] = Field(
+        default_factory=list,
+        description=".shotgun/ file paths to preload into the sub-agent's context "
+        "(e.g., 'research.md', 'specification.md', 'contracts/auth.py').",
+    )
 
 
 # =============================================================================
@@ -230,6 +235,10 @@ class DelegationResult(BaseModel):
     tool_call_counts: dict[str, int] = Field(
         default_factory=dict,
         description="Count of each tool call made by sub-agent (tool_name -> count)",
+    )
+    files_preloaded: list[str] = Field(
+        default_factory=list,
+        description="Files successfully preloaded into the sub-agent's context",
     )
 
 

--- a/src/shotgun/agents/router/tools/delegation_tools.py
+++ b/src/shotgun/agents/router/tools/delegation_tools.py
@@ -7,11 +7,19 @@ Sub-agents run with isolated message histories to prevent context window bloat.
 """
 
 import time
+import uuid
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+import aiofiles
 from pydantic_ai import RunContext
-from pydantic_ai.messages import ModelResponse, ToolCallPart
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    ToolCallPart,
+    ToolReturnPart,
+)
 from pydantic_ai.tools import ToolDefinition
 
 from shotgun.agents.config.models import ProviderType
@@ -37,6 +45,7 @@ from shotgun.agents.tasks import create_tasks_agent, run_tasks_agent
 from shotgun.agents.tools.registry import ToolCategory, register_tool
 from shotgun.logging_config import get_logger
 from shotgun.posthog_telemetry import track_event
+from shotgun.utils.file_system_utils import get_shotgun_base_path
 
 logger = get_logger(__name__)
 
@@ -217,11 +226,79 @@ def _build_sub_agent_context(deps: RouterDeps) -> SubAgentContext:
     )
 
 
+async def build_preloaded_history(
+    preload_files: list[str],
+) -> tuple[list[ModelMessage], list[str]]:
+    """Build synthetic read_file tool call/return pairs for preloading .shotgun/ files.
+
+    Creates message history entries that look like the sub-agent already called
+    read_file for each requested file, saving LLM round-trips on predictable reads.
+
+    Args:
+        preload_files: List of .shotgun/-relative file paths
+            (e.g., 'research.md', 'specification.md', 'contracts/auth.py').
+
+    Returns:
+        Tuple of (messages, loaded_paths) where messages is a list of
+        ModelMessage pairs (ModelResponse + ModelRequest) for each successfully
+        read file, and loaded_paths is the list of files that were loaded.
+    """
+    if not preload_files:
+        return [], []
+
+    base_path = get_shotgun_base_path()
+    messages: list[ModelMessage] = []
+    loaded_paths: list[str] = []
+
+    for file_path in preload_files:
+        full_path = base_path / file_path
+        try:
+            async with aiofiles.open(full_path) as f:
+                content = await f.read()
+        except (FileNotFoundError, IsADirectoryError, PermissionError, OSError):
+            logger.debug("Skipping preload for %s: file not readable", file_path)
+            continue
+
+        tool_call_id = f"preload-{uuid.uuid4().hex[:12]}"
+
+        # Synthetic ModelResponse with a ToolCallPart (as if the agent called read_file)
+        call_msg = ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="read_file",
+                    args={"filename": file_path, "reason": "Preloaded by router"},
+                    tool_call_id=tool_call_id,
+                )
+            ]
+        )
+
+        # Synthetic ModelRequest with a ToolReturnPart (as if read_file returned)
+        return_msg = ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="read_file",
+                    content=content,
+                    tool_call_id=tool_call_id,
+                )
+            ]
+        )
+
+        messages.append(call_msg)
+        messages.append(return_msg)
+        loaded_paths.append(file_path)
+
+    if loaded_paths:
+        logger.info("Preloaded %d files: %s", len(loaded_paths), loaded_paths)
+
+    return messages, loaded_paths
+
+
 async def _run_sub_agent(
     ctx: RunContext[RouterDeps],
     agent_type: AgentType,
     task: str,
     context_hint: str | None = None,
+    preload_files: list[str] | None = None,
 ) -> DelegationResult:
     """Run a sub-agent with the given task.
 
@@ -230,6 +307,7 @@ async def _run_sub_agent(
     - Getting or creating the sub-agent from cache
     - Setting up SubAgentContext
     - Managing active_sub_agent state for UI updates
+    - Preloading .shotgun/ files into the sub-agent's message history
     - Running the sub-agent with isolated message history
     - Extracting files_modified and handling errors with retries
 
@@ -238,6 +316,7 @@ async def _run_sub_agent(
         agent_type: The type of sub-agent to run.
         task: The task to delegate to the sub-agent.
         context_hint: Optional context to help the sub-agent.
+        preload_files: Optional list of .shotgun/-relative file paths to preload.
 
     Returns:
         DelegationResult with success/failure status, response, and files_modified.
@@ -277,6 +356,14 @@ async def _run_sub_agent(
     deps.active_sub_agent = agent_type
     logger.info("Delegating to %s agent: %s", agent_type.value, task[:100])
 
+    # Build preloaded message history if files requested
+    preloaded_history: list[ModelMessage] = []
+    files_preloaded: list[str] = []
+    if preload_files:
+        preloaded_history, files_preloaded = await build_preloaded_history(
+            preload_files
+        )
+
     # Track delegation start time and event
     start_time = time.time()
     track_event(
@@ -285,6 +372,7 @@ async def _run_sub_agent(
             "target_agent": agent_type.value,
             "task_length": len(task),
             "has_context_hint": context_hint is not None,
+            "preloaded_file_count": len(files_preloaded),
         },
     )
 
@@ -296,12 +384,12 @@ async def _run_sub_agent(
     retries_attempted = 0
     for attempt in range(MAX_RETRIES + 1):
         try:
-            # Run sub-agent with isolated message history and streaming support
+            # Run sub-agent with preloaded history (or empty) and streaming support
             result = await run_fn(
                 agent=agent,
                 prompt=prompt,
                 deps=sub_agent_deps,
-                message_history=[],  # Isolated context
+                message_history=preloaded_history,
                 event_stream_handler=deps.parent_stream_handler,  # Forward streaming
             )
 
@@ -370,6 +458,7 @@ async def _run_sub_agent(
                     "has_questions": has_questions,
                     "duration_seconds": round(time.time() - start_time, 2),
                     "tool_call_count": sum(tool_call_counts.values()),
+                    "preloaded_file_count": len(files_preloaded),
                 },
             )
 
@@ -384,6 +473,7 @@ async def _run_sub_agent(
                 has_questions=has_questions,
                 questions=questions,
                 tool_call_counts=tool_call_counts,
+                files_preloaded=files_preloaded,
             )
 
         except Exception as e:
@@ -471,6 +561,7 @@ async def delegate_to_research(
         AgentType.RESEARCH,
         input.task,
         input.context_hint,
+        input.preload_files,
     )
 
 
@@ -502,6 +593,7 @@ async def delegate_to_specification(
         AgentType.SPECIFY,
         input.task,
         input.context_hint,
+        input.preload_files,
     )
 
 
@@ -533,6 +625,7 @@ async def delegate_to_plan(
         AgentType.PLAN,
         input.task,
         input.context_hint,
+        input.preload_files,
     )
 
 
@@ -564,6 +657,7 @@ async def delegate_to_tasks(
         AgentType.TASKS,
         input.task,
         input.context_hint,
+        input.preload_files,
     )
 
 
@@ -595,4 +689,5 @@ async def delegate_to_export(
         AgentType.EXPORT,
         input.task,
         input.context_hint,
+        input.preload_files,
     )

--- a/src/shotgun/prompts/agents/router.j2
+++ b/src/shotgun/prompts/agents/router.j2
@@ -581,6 +581,17 @@ CORRECT - Each agent updates only their own files.
 Delegation input - each delegation tool takes:
 - task: The task description to delegate (required)
 - context_hint: Optional context to help the sub-agent understand the task
+- preload_files: Optional list of .shotgun/ file paths to preload into the sub-agent's context
+
+Use preload_files to give the sub-agent instant access to existing .shotgun/ artifact files,
+saving round-trips that would otherwise be spent on read_file calls. Only preload files the
+sub-agent will definitely need based on pipeline order:
+
+- Specification agent: preload_files=["research.md"] (needs research context)
+- Plan agent: preload_files=["specification.md"] (needs spec to plan against)
+- Tasks agent: preload_files=["specification.md", "plan.md"] (needs spec + plan)
+
+Include contracts/ or research/ files when relevant to the task.
 
 Keep delegation prompts short. Do not write detailed requirements in the task field. Sub-agents will:
 1. Do the bare minimum based on your short prompt

--- a/test/unit/agents/router/test_delegation.py
+++ b/test/unit/agents/router/test_delegation.py
@@ -534,7 +534,7 @@ async def test_delegate_to_research(mock_context, mock_agent_result):
         result = await delegate_to_research(mock_context, input_data)
 
     mock_run.assert_called_once_with(
-        mock_context, AgentType.RESEARCH, "Find OAuth docs", "Security"
+        mock_context, AgentType.RESEARCH, "Find OAuth docs", "Security", []
     )
     assert result.success is True
 
@@ -551,7 +551,7 @@ async def test_delegate_to_specification(mock_context, mock_agent_result):
         result = await delegate_to_specification(mock_context, input_data)
 
     mock_run.assert_called_once_with(
-        mock_context, AgentType.SPECIFY, "Write auth spec", None
+        mock_context, AgentType.SPECIFY, "Write auth spec", None, []
     )
     assert result.success is True
 
@@ -568,7 +568,7 @@ async def test_delegate_to_plan(mock_context, mock_agent_result):
         result = await delegate_to_plan(mock_context, input_data)
 
     mock_run.assert_called_once_with(
-        mock_context, AgentType.PLAN, "Create implementation plan", None
+        mock_context, AgentType.PLAN, "Create implementation plan", None, []
     )
     assert result.success is True
 
@@ -585,7 +585,7 @@ async def test_delegate_to_tasks(mock_context, mock_agent_result):
         result = await delegate_to_tasks(mock_context, input_data)
 
     mock_run.assert_called_once_with(
-        mock_context, AgentType.TASKS, "Generate task list", None
+        mock_context, AgentType.TASKS, "Generate task list", None, []
     )
     assert result.success is True
 
@@ -602,7 +602,7 @@ async def test_delegate_to_export(mock_context, mock_agent_result):
         result = await delegate_to_export(mock_context, input_data)
 
     mock_run.assert_called_once_with(
-        mock_context, AgentType.EXPORT, "Export deliverables", None
+        mock_context, AgentType.EXPORT, "Export deliverables", None, []
     )
     assert result.success is True
 

--- a/test/unit/agents/router/test_preload_files.py
+++ b/test/unit/agents/router/test_preload_files.py
@@ -1,0 +1,406 @@
+"""Tests for .shotgun/ file preloading on sub-agent delegation."""
+
+from asyncio import Queue
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic_ai.agent import AgentRunResult
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    ToolCallPart,
+    ToolReturnPart,
+)
+
+from shotgun.agents.config.models import KeyProvider, ModelConfig, ProviderType
+from shotgun.agents.models import (
+    AgentResponse,
+    AgentType,
+    FileOperationTracker,
+)
+from shotgun.agents.router.models import (
+    DelegationInput,
+    DelegationResult,
+    RouterDeps,
+    RouterMode,
+)
+from shotgun.agents.router.tools.delegation_tools import (
+    _run_sub_agent,
+    build_preloaded_history,
+    delegate_to_specification,
+)
+
+# =============================================================================
+# Tests for build_preloaded_history
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_build_preloaded_history_empty_list():
+    """Empty preload_files list returns empty history and paths."""
+    messages, loaded = await build_preloaded_history([])
+    assert messages == []
+    assert loaded == []
+
+
+@pytest.mark.asyncio
+async def test_build_preloaded_history_single_file(tmp_path):
+    """Single file creates correct read_file call/return pair."""
+    # Create a test file
+    shotgun_dir = tmp_path / ".shotgun"
+    shotgun_dir.mkdir()
+    test_file = shotgun_dir / "research.md"
+    test_file.write_text("# Research\nSome findings here.")
+
+    with patch(
+        "shotgun.agents.router.tools.delegation_tools.get_shotgun_base_path",
+        return_value=shotgun_dir,
+    ):
+        messages, loaded = await build_preloaded_history(["research.md"])
+
+    assert loaded == ["research.md"]
+    assert len(messages) == 2
+
+    # First message: ModelResponse with ToolCallPart
+    call_msg = messages[0]
+    assert isinstance(call_msg, ModelResponse)
+    assert len(call_msg.parts) == 1
+    call_part = call_msg.parts[0]
+    assert isinstance(call_part, ToolCallPart)
+    assert call_part.tool_name == "read_file"
+    assert call_part.args == {
+        "filename": "research.md",
+        "reason": "Preloaded by router",
+    }
+    assert call_part.tool_call_id is not None
+    assert call_part.tool_call_id.startswith("preload-")
+
+    # Second message: ModelRequest with ToolReturnPart
+    return_msg = messages[1]
+    assert isinstance(return_msg, ModelRequest)
+    assert len(return_msg.parts) == 1
+    return_part = return_msg.parts[0]
+    assert isinstance(return_part, ToolReturnPart)
+    assert return_part.tool_name == "read_file"
+    assert return_part.content == "# Research\nSome findings here."
+    assert return_part.tool_call_id == call_part.tool_call_id
+
+
+@pytest.mark.asyncio
+async def test_build_preloaded_history_multiple_files(tmp_path):
+    """Multiple files each get their own call/return pair."""
+    shotgun_dir = tmp_path / ".shotgun"
+    shotgun_dir.mkdir()
+    (shotgun_dir / "research.md").write_text("Research content")
+    (shotgun_dir / "specification.md").write_text("Spec content")
+
+    with patch(
+        "shotgun.agents.router.tools.delegation_tools.get_shotgun_base_path",
+        return_value=shotgun_dir,
+    ):
+        messages, loaded = await build_preloaded_history(
+            ["research.md", "specification.md"]
+        )
+
+    assert loaded == ["research.md", "specification.md"]
+    assert len(messages) == 4  # 2 pairs
+
+    # Check second pair has spec content
+    return_part = messages[3].parts[0]
+    assert isinstance(return_part, ToolReturnPart)
+    assert return_part.content == "Spec content"
+
+
+@pytest.mark.asyncio
+async def test_build_preloaded_history_nonexistent_file_skipped(tmp_path):
+    """Non-existent files are silently skipped."""
+    shotgun_dir = tmp_path / ".shotgun"
+    shotgun_dir.mkdir()
+    (shotgun_dir / "research.md").write_text("Research content")
+
+    with patch(
+        "shotgun.agents.router.tools.delegation_tools.get_shotgun_base_path",
+        return_value=shotgun_dir,
+    ):
+        messages, loaded = await build_preloaded_history(
+            ["research.md", "nonexistent.md"]
+        )
+
+    assert loaded == ["research.md"]
+    assert len(messages) == 2  # Only 1 pair for existing file
+
+
+@pytest.mark.asyncio
+async def test_build_preloaded_history_directory_skipped(tmp_path):
+    """Directories are silently skipped."""
+    shotgun_dir = tmp_path / ".shotgun"
+    shotgun_dir.mkdir()
+    (shotgun_dir / "contracts").mkdir()
+
+    with patch(
+        "shotgun.agents.router.tools.delegation_tools.get_shotgun_base_path",
+        return_value=shotgun_dir,
+    ):
+        messages, loaded = await build_preloaded_history(["contracts"])
+
+    assert loaded == []
+    assert messages == []
+
+
+@pytest.mark.asyncio
+async def test_build_preloaded_history_tool_call_id_matches():
+    """Tool call ID must match between call and return parts."""
+    # Already tested in single_file test, but let's be explicit
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        shotgun_dir = Path(tmp) / ".shotgun"
+        shotgun_dir.mkdir()
+        (shotgun_dir / "plan.md").write_text("Plan content")
+
+        with patch(
+            "shotgun.agents.router.tools.delegation_tools.get_shotgun_base_path",
+            return_value=shotgun_dir,
+        ):
+            messages, loaded = await build_preloaded_history(["plan.md"])
+
+    call_part = messages[0].parts[0]
+    return_part = messages[1].parts[0]
+    assert isinstance(call_part, ToolCallPart)
+    assert isinstance(return_part, ToolReturnPart)
+    assert call_part.tool_call_id == return_part.tool_call_id
+
+
+@pytest.mark.asyncio
+async def test_build_preloaded_history_subdirectory_files(tmp_path):
+    """Files in subdirectories (e.g., contracts/auth.py) work correctly."""
+    shotgun_dir = tmp_path / ".shotgun"
+    shotgun_dir.mkdir()
+    contracts_dir = shotgun_dir / "contracts"
+    contracts_dir.mkdir()
+    (contracts_dir / "auth.py").write_text("class AuthContract: pass")
+
+    with patch(
+        "shotgun.agents.router.tools.delegation_tools.get_shotgun_base_path",
+        return_value=shotgun_dir,
+    ):
+        messages, loaded = await build_preloaded_history(["contracts/auth.py"])
+
+    assert loaded == ["contracts/auth.py"]
+    return_part = messages[1].parts[0]
+    assert isinstance(return_part, ToolReturnPart)
+    assert return_part.content == "class AuthContract: pass"
+
+
+# =============================================================================
+# Tests for DelegationInput backward compatibility
+# =============================================================================
+
+
+def test_delegation_input_default_preload_files():
+    """DelegationInput.preload_files defaults to empty list (backward compat)."""
+    input_data = DelegationInput(task="Test task")
+    assert input_data.preload_files == []
+
+
+def test_delegation_input_with_preload_files():
+    """DelegationInput accepts preload_files."""
+    input_data = DelegationInput(
+        task="Write spec",
+        preload_files=["research.md"],
+    )
+    assert input_data.preload_files == ["research.md"]
+
+
+# =============================================================================
+# Tests for DelegationResult.files_preloaded
+# =============================================================================
+
+
+def test_delegation_result_default_files_preloaded():
+    """DelegationResult.files_preloaded defaults to empty list."""
+    result = DelegationResult(success=True, response="Done")
+    assert result.files_preloaded == []
+
+
+def test_delegation_result_with_files_preloaded():
+    """DelegationResult accepts files_preloaded."""
+    result = DelegationResult(
+        success=True,
+        response="Done",
+        files_preloaded=["research.md", "specification.md"],
+    )
+    assert result.files_preloaded == ["research.md", "specification.md"]
+
+
+# =============================================================================
+# Tests for _run_sub_agent with preload_files
+# =============================================================================
+
+
+def _create_mock_sub_agent_deps():
+    """Helper to create properly configured mock sub-agent deps."""
+    mock_sub_deps = MagicMock()
+    mock_sub_deps.file_tracker = FileOperationTracker()
+    mock_sub_deps.sub_agent_context = None
+    return mock_sub_deps
+
+
+def _create_mock_router_deps():
+    """Helper to create mock RouterDeps."""
+    deps = MagicMock(spec=RouterDeps)
+    deps.router_mode = RouterMode.DRAFTING
+    deps.current_plan = None
+    deps.file_tracker = FileOperationTracker()
+    deps.active_sub_agent = None
+    deps.sub_agent_cache = {}
+    deps.interactive_mode = True
+    deps.working_directory = Path("/test/dir")
+    deps.is_tui_context = True
+    deps.max_iterations = 100
+    deps.queue = Queue()
+    deps.tasks = []
+    deps.parent_stream_handler = None
+    deps.pending_approval = None
+    deps.cancellation_event = None
+    deps.usage_manager = MagicMock()
+    deps.usage_manager.add_usage = AsyncMock()
+    deps.sub_agent_tool_calls = {}
+    deps.llm_model = ModelConfig(
+        name="test-model",
+        provider=ProviderType.OPENAI_COMPATIBLE,
+        key_provider=KeyProvider.BYOK,
+        max_input_tokens=128000,
+        max_output_tokens=16000,
+        api_key="test-key",
+    )
+    return deps
+
+
+@pytest.mark.asyncio
+async def test_run_sub_agent_passes_preloaded_history(tmp_path):
+    """_run_sub_agent passes preloaded history as message_history."""
+    # Set up shotgun directory with a file
+    shotgun_dir = tmp_path / ".shotgun"
+    shotgun_dir.mkdir()
+    (shotgun_dir / "research.md").write_text("Research findings")
+
+    deps = _create_mock_router_deps()
+    mock_agent = MagicMock()
+    mock_sub_deps = _create_mock_sub_agent_deps()
+
+    mock_result = MagicMock(spec=AgentRunResult)
+    mock_result.output = AgentResponse(response="Done")
+
+    captured_kwargs = {}
+
+    async def capture_run_kwargs(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return mock_result
+
+    from pydantic_ai import RunContext
+
+    ctx = MagicMock(spec=RunContext)
+    ctx.deps = deps
+
+    with (
+        patch.dict(
+            "shotgun.agents.router.tools.delegation_tools.AGENT_FACTORIES",
+            {
+                AgentType.RESEARCH: (
+                    AsyncMock(return_value=(mock_agent, mock_sub_deps)),
+                    capture_run_kwargs,
+                )
+            },
+        ),
+        patch(
+            "shotgun.agents.router.tools.delegation_tools.get_shotgun_base_path",
+            return_value=shotgun_dir,
+        ),
+    ):
+        result = await _run_sub_agent(
+            ctx,
+            AgentType.RESEARCH,
+            "Test task",
+            preload_files=["research.md"],
+        )
+
+    assert result.success is True
+    assert result.files_preloaded == ["research.md"]
+    # Verify the message_history was passed with preloaded content
+    assert "message_history" in captured_kwargs
+    history = captured_kwargs["message_history"]
+    assert len(history) == 2
+    assert isinstance(history[0], ModelResponse)
+    assert isinstance(history[1], ModelRequest)
+
+
+@pytest.mark.asyncio
+async def test_run_sub_agent_no_preload_files_empty_history():
+    """_run_sub_agent with no preload_files passes empty message_history."""
+    deps = _create_mock_router_deps()
+    mock_agent = MagicMock()
+    mock_sub_deps = _create_mock_sub_agent_deps()
+
+    mock_result = MagicMock(spec=AgentRunResult)
+    mock_result.output = AgentResponse(response="Done")
+
+    captured_kwargs = {}
+
+    async def capture_run_kwargs(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return mock_result
+
+    from pydantic_ai import RunContext
+
+    ctx = MagicMock(spec=RunContext)
+    ctx.deps = deps
+
+    with patch.dict(
+        "shotgun.agents.router.tools.delegation_tools.AGENT_FACTORIES",
+        {
+            AgentType.RESEARCH: (
+                AsyncMock(return_value=(mock_agent, mock_sub_deps)),
+                capture_run_kwargs,
+            )
+        },
+    ):
+        result = await _run_sub_agent(
+            ctx,
+            AgentType.RESEARCH,
+            "Test task",
+        )
+
+    assert result.success is True
+    assert result.files_preloaded == []
+    assert captured_kwargs["message_history"] == []
+
+
+@pytest.mark.asyncio
+async def test_delegate_to_specification_passes_preload_files():
+    """delegate_to_specification forwards preload_files to _run_sub_agent."""
+    from pydantic_ai import RunContext
+
+    ctx = MagicMock(spec=RunContext)
+    ctx.deps = _create_mock_router_deps()
+
+    with patch(
+        "shotgun.agents.router.tools.delegation_tools._run_sub_agent",
+        new_callable=AsyncMock,
+        return_value=DelegationResult(success=True, response="Spec done"),
+    ) as mock_run:
+        input_data = DelegationInput(
+            task="Write auth spec",
+            preload_files=["research.md"],
+        )
+        result = await delegate_to_specification(ctx, input_data)
+
+    mock_run.assert_called_once_with(
+        ctx,
+        AgentType.SPECIFY,
+        "Write auth spec",
+        None,
+        ["research.md"],
+    )
+    assert result.success is True


### PR DESCRIPTION
## Summary
- Add `preload_files` field to `DelegationInput` so the Router can specify `.shotgun/` artifact files to preload into a sub-agent's message history
- Add `build_preloaded_history()` that reads files and creates synthetic `read_file` tool call/return pairs (`ModelResponse` + `ModelRequest`)
- Wire preloading through `_run_sub_agent()` and all `delegate_to_*` tools, with `files_preloaded` tracked in `DelegationResult` and telemetry
- Document recommended preload patterns in the Router system prompt (e.g., spec agent gets `research.md`, plan agent gets `specification.md`)

## Test plan
- [x] 14 new unit tests in `test_preload_files.py` covering: empty list, single/multiple files, non-existent files skipped, directories skipped, tool_call_id matching, subdirectory files, backward compat, integration with `_run_sub_agent`, delegation passthrough
- [x] All 70 existing delegation/model tests pass (backward compat confirmed)
- [x] Full unit suite (2111 tests) passes
- [x] mypy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)