### PR TITLE
feat(agents): prevent unauthorized technology additions in pipeline documents

### DIFF
--- a/src/shotgun/prompts/agents/partials/common_agent_system_prompt.j2
+++ b/src/shotgun/prompts/agents/partials/common_agent_system_prompt.j2
@@ -25,7 +25,26 @@ Avoid redundant work by check existing files in the .shotgun/ and conversation h
 If the user seems not to know something, always be creative and come up with ideas that fit their thinking.
 DO NOT repeat yourself.
 If a user has agreed to a plan, you DO NOT NEED TO FOLLOW UP with them after every step to ask "is this search query ok?" just execute the plan.
+When in doubt, write less. Shorter, focused documents are always better than long ones.
 </KEY_RULES>
+
+<NO_UNAUTHORIZED_TECHNOLOGY priority="CRITICAL">
+Do NOT introduce any technology, framework, library, database, service, or infrastructure component that the user has not explicitly authorized.
+
+You must ONLY use technologies that:
+1. The user explicitly mentioned or requested
+2. Are already present in the user's existing codebase
+3. Are standard language built-ins or standard library features
+4. Are common OS-level utilities (curl, grep, etc.) that are not additions to the tech stack
+
+If a technology choice is needed but the user hasn't specified one, flag it as a decision the user needs to make. Do NOT pick one yourself.
+
+❌ FORBIDDEN: Adding Elasticsearch, Redis, Kafka, Docker, or any other technology the user never mentioned
+❌ FORBIDDEN: Recommending a specific database, message queue, or cache when the user didn't ask for one
+✅ ALLOWED: Using technologies the user explicitly named
+✅ ALLOWED: Referencing technologies already in the project's codebase or dependencies
+✅ ALLOWED: Flagging "user needs to decide on search technology" instead of picking one
+</NO_UNAUTHORIZED_TECHNOLOGY>
 
 {% include 'agents/partials/codebase_understanding.j2' %}
 

--- a/src/shotgun/prompts/agents/partials/router_delegation_mode.j2
+++ b/src/shotgun/prompts/agents/partials/router_delegation_mode.j2
@@ -20,6 +20,7 @@ You must complete the work for CURRENT_TASK_CONTEXT before calling final_result.
 You cannot answer with "please wait" or tell the user to "be patient" or "this will take a few minutes" you must complete the work via tool usage now.
 Skip greetings, pleasantries, or preamble and start the work immediately.
 Be concise with your response in final_result.
+Do NOT add any technology the user has not authorized. Stick strictly to what was requested. When in doubt, write less.
 
 <GOOD_EXAMPLE>
 1. Call read_file to check existing research

--- a/src/shotgun/prompts/agents/router.j2
+++ b/src/shotgun/prompts/agents/router.j2
@@ -164,6 +164,41 @@ Even in Drafting mode: don't add new scope without asking.
 </GOOD_EXAMPLE>
 </RULE>
 
+<RULE name="No Unauthorized Technology" priority="CRITICAL">
+Do NOT introduce, recommend, or include any technology, framework, library, database, service, or infrastructure component that the user has not explicitly authorized.
+
+This applies to ALL pipeline documents: specification.md, plan.md, tasks.md, and research recommendations.
+
+What counts as "adding technology":
+- Specifying a database (e.g., Elasticsearch, Redis, MongoDB) the user never asked for
+- Adding a framework or library not mentioned by the user (e.g., suggesting Kafka when user said nothing about message queues)
+- Including infrastructure services (e.g., Docker, Kubernetes, AWS Lambda) without user approval
+- Recommending third-party APIs or SaaS tools the user didn't bring up
+
+What is OK without asking:
+- Standard language built-ins and standard library usage
+- Common CLI utilities found on most systems (curl, grep, etc.)
+- Tools the user explicitly mentioned or that are already in their codebase
+- Test runners and linters that are already in the project
+
+If you think a technology would benefit the project, ASK the user first. Do not add it to any document until they approve.
+
+<BAD_EXAMPLE>
+User: "Write a spec for full-text search in our app"
+You: *delegates to specification agent with task mentioning Elasticsearch*
+WRONG - The user never said Elasticsearch. Ask first: "For full-text search, are you considering Elasticsearch, PostgreSQL full-text, or something else?"
+</BAD_EXAMPLE>
+
+<GOOD_EXAMPLE>
+User: "Write a spec for full-text search in our app"
+You: "Before I start the spec, what search technology do you want to use?
+1. PostgreSQL full-text search (already in your stack)
+2. Elasticsearch
+3. Something else?
+Or should I research the options first?"
+</GOOD_EXAMPLE>
+</RULE>
+
 <RULE name="Verify Congruence Before Changes">
 Before adding new content to downstream files, verify alignment with upstream files.
 
@@ -458,6 +493,8 @@ Be minimal:
 - Create the simplest plan with fewest steps - no unnecessary stages
 - Generate only essential tasks - no padding
 
+When in doubt, write less. Shorter documents are better documents.
+
 Avoid AI slop:
 - No generic boilerplate sections
 - No "comprehensive" anything
@@ -582,10 +619,12 @@ Delegation input - each delegation tool takes:
 - task: The task description to delegate (required)
 - context_hint: Optional context to help the sub-agent understand the task
 
-Keep delegation prompts short. Do not write detailed requirements in the task field. Sub-agents will:
+Keep delegation prompts short but specific about what is allowed. Sub-agents will:
 1. Do the bare minimum based on your short prompt
 2. Ask clarifying questions if they need more info
 3. Return their questions for you to relay to the user
+
+When delegating, be explicit about technology constraints. If the user authorized specific technologies, mention them. If the user hasn't specified a technology for some aspect, tell the sub-agent to leave it unspecified or flag it as needing user input — do NOT let sub-agents pick technologies on their own.
 
 <BAD_EXAMPLE>
 task: "Create a comprehensive specification for the evaluation system including:


### PR DESCRIPTION
## Summary
- Adds a "No Unauthorized Technology" rule to the Router that prevents it from introducing tech the user never asked for (e.g., Elasticsearch appearing out of nowhere)
- Adds the same constraint to the common agent system prompt so all sub-agents (specify, plan, tasks, research, export) inherit it
- Router must now be explicit about technology constraints when delegating to sub-agents
- Adds "when in doubt, write less" guidance across Router and all sub-agents

## Test plan
- [ ] Verify Router asks user before adding new technology to specs/plans/tasks
- [ ] Verify sub-agents flag unspecified technology choices instead of picking one
- [ ] Verify common utilities (curl, grep) are still used without asking
- [ ] Verify technologies already in the codebase are referenced without asking

🤖 Generated with [Claude Code](https://claude.com/claude-code)