### PR TITLE
feat(agents): enforce implementation plan belongs in plan.md not specification.md

### DIFF
--- a/src/shotgun/prompts/agents/partials/common_agent_system_prompt.j2
+++ b/src/shotgun/prompts/agents/partials/common_agent_system_prompt.j2
@@ -12,6 +12,17 @@ Your deliverable is always a document file (.md), not code execution
 When your work is complete, the user will take your documents to a coding agent (Claude Code, Cursor, etc.)
 </YOUR_ROLE>
 
+<DOCUMENT_BOUNDARIES priority="CRITICAL">
+Each document in the pipeline has a strict content boundary. NEVER put content in the wrong document:
+
+- **specification.md** → WHAT to build and WHY (requirements, architecture, behavior, acceptance criteria). Must NEVER contain implementation plans, phased approaches, or staged delivery breakdowns.
+- **plan.md** → HOW to build it and IN WHAT ORDER (implementation stages, dependencies, delivery sequence). This is the ONLY place for implementation plans.
+- **tasks.md** → Granular, executable tasks for AI coding agents, organized by stages from plan.md.
+- **research.md** → Background research, findings, and analysis to inform the specification.
+
+If you encounter content in the wrong document (e.g., an implementation plan in specification.md), do NOT propagate that mistake. Flag it or ignore it and follow the correct boundaries.
+</DOCUMENT_BOUNDARIES>
+
 <KEY_RULES>
 {% if interactive_mode %}
 Ask CLARIFYING QUESTIONS using structured output for complex or multi-step tasks when the request lacks sufficient detail.

--- a/src/shotgun/prompts/agents/plan.j2
+++ b/src/shotgun/prompts/agents/plan.j2
@@ -53,6 +53,7 @@ You are the **Plan agent**. Your file is `plan.md` - this is the ONLY file you c
 - You have exclusive write access to: `plan.md`
 - MUST READ `research.md` and `specification.md` BEFORE asking questions or creating plans
 - Cannot write to research.md or specification.md - they are read-only context
+- **plan.md is the ONLY place for implementation plans** - if specification.md contains an "Implementation Plan" section, do NOT copy it into plan.md verbatim; instead, create your own plan based on the requirements in the specification
 - This is your persistent memory store - ALWAYS load it first
 - Compress content regularly to stay within context limits
 - Keep your file updated as you work - it's your memory across sessions

--- a/src/shotgun/prompts/agents/router.j2
+++ b/src/shotgun/prompts/agents/router.j2
@@ -54,9 +54,11 @@ Do NOT use file_requests for .pdf, .png, .jpg, .jpeg, .gif, or .webp files - the
 ## Your #1 Job: Guide Users to Complete Documentation
 
 By the end of working with a user, these THREE core files should exist:
-1. specification.md - What to build (requirements, API contracts, behavior)
-2. plan.md - How to build it (implementation stages, architecture decisions)
+1. specification.md - WHAT to build (requirements, architecture, behavior, acceptance criteria) — NO implementation plans
+2. plan.md - HOW to build it (implementation stages, architecture decisions, delivery order) — this is the ONLY place for implementation plans
 3. tasks.md - Step-by-step tasks for AI coding agents to execute
+
+**CRITICAL BOUNDARY**: specification.md must NEVER contain implementation plans, phased approaches, or staged delivery breakdowns. That content belongs exclusively in plan.md. If a user asks for an implementation plan in the spec, redirect it to plan.md.
 
 Supporting documents (created as needed):
 - research.md and research/* - Background research to inform the spec

--- a/src/shotgun/prompts/agents/specify.j2
+++ b/src/shotgun/prompts/agents/specify.j2
@@ -90,8 +90,15 @@ specification.md is your prose documentation file. It should contain:
 **DO NOT INCLUDE in specification.md:**
 - Code blocks, type definitions, or function signatures (those go in contracts/)
 - Implementation details or algorithms (describe behavior instead)
+- Implementation plans, phased approaches, or staged delivery breakdowns (those belong in plan.md, NOT in specification.md)
 - Actual configuration files or build manifests (describe what's needed instead)
 - Directory trees or file listings (keep structure descriptions succinct)
+
+**CRITICAL BOUNDARY - specification.md vs plan.md:**
+- specification.md defines WHAT to build and WHY (requirements, architecture, behavior, acceptance criteria)
+- plan.md defines HOW to build it and IN WHAT ORDER (implementation stages, dependencies, delivery sequence)
+- If you find yourself writing sections titled "Implementation Plan", "Phases", "Stages", or "Delivery Schedule", STOP - that content belongs in plan.md
+- The plan agent will read your specification and create the implementation plan from it
 
 **When you need to show structure:** Reference contract files instead of inline code.
 Example: "User authentication uses OAuth2. See contracts/auth_types.ts for AuthUser and AuthToken types."

--- a/src/shotgun/prompts/agents/tasks.j2
+++ b/src/shotgun/prompts/agents/tasks.j2
@@ -226,11 +226,12 @@ NON-INTERACTIVE MODE - MAKE REASONABLE ASSUMPTIONS:
 
 INTEGRATION WITH RESEARCH & PLAN:
 - Reference specific findings from research.md when creating tasks
-- Align tasks with action steps outlined in plan.md
+- Align tasks with action steps outlined in plan.md — plan.md is your primary source for implementation stages and ordering
 - Consider technical feasibility based on research
 - Include tasks for addressing challenges identified in plan
 - Create validation/testing tasks for success criteria from plan
 - Break down high-level plan steps into granular, executable tasks
+- If specification.md contains an "Implementation Plan" section, IGNORE it — use plan.md for implementation stages instead
 
 PATH VERIFICATION (CRITICAL):
 - Before generating tasks that reference specific file paths in `.shotgun/`, check the "Available Files" list in your System Status


### PR DESCRIPTION
## Summary
- Add `DOCUMENT_BOUNDARIES` rule to common agent system prompt so ALL agents (research, specify, plan, tasks, export) understand the strict content separation between pipeline documents
- Add explicit "Implementation plans" to the DO NOT INCLUDE list in the specify agent prompt, with a `CRITICAL BOUNDARY` callout explaining spec vs plan
- Update plan agent to note that plan.md is the ONLY place for implementation plans and to not copy verbatim from spec
- Update router agent to clearly label specification.md as "NO implementation plans" and plan.md as "the ONLY place for implementation plans"
- Update tasks agent to ignore any "Implementation Plan" section found in specification.md and use plan.md instead

## Test plan
- [x] `uv run mypy src/` passes
- [x] `uv run ruff check .` passes
- [x] Smoke tests pass (`pytest test/ -k "smoke"`)
- [ ] Verify specify agent no longer writes implementation plan sections into specification.md
- [ ] Verify plan agent creates its own plan from spec requirements rather than copying

🤖 Generated with [Claude Code](https://claude.com/claude-code)