### PR TITLE
fix: add async context manager to LiteLLMProxyClient to prevent connection leaks

### DIFF
--- a/src/shotgun/cli/context.py
+++ b/src/shotgun/cli/context.py
@@ -114,8 +114,8 @@ async def analyze_context() -> ContextAnalysisOutput:
     if model_config.is_shotgun_account:
         try:
             logger.debug("Fetching budget info for Shotgun Account")
-            client = LiteLLMProxyClient(model_config.api_key)
-            budget_info = await client.get_budget_info()
+            async with LiteLLMProxyClient(model_config.api_key) as client:
+                budget_info = await client.get_budget_info()
 
             # Format budget section for markdown
             budget_markdown = _format_budget_markdown(budget_info)

--- a/src/shotgun/llm_proxy/client.py
+++ b/src/shotgun/llm_proxy/client.py
@@ -101,6 +101,12 @@ class LiteLLMProxyClient:
         response.raise_for_status()
         return response
 
+    async def __aenter__(self) -> "LiteLLMProxyClient":
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.aclose()
+
     async def aclose(self) -> None:
         """Close the underlying HTTP client."""
         await self._client.aclose()
@@ -215,8 +221,5 @@ async def get_budget_info(api_key: str, base_url: str | None = None) -> BudgetIn
     Returns:
         Budget information
     """
-    client = LiteLLMProxyClient(api_key, base_url=base_url)
-    try:
+    async with LiteLLMProxyClient(api_key, base_url=base_url) as client:
         return await client.get_budget_info()
-    finally:
-        await client.aclose()

--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -796,8 +796,8 @@ class ChatScreen(Screen[None]):
                 from shotgun.llm_proxy import LiteLLMProxyClient
 
                 logger.debug("Fetching budget info for Shotgun Account")
-                client = LiteLLMProxyClient(self.deps.llm_model.api_key)
-                budget_info = await client.get_budget_info()
+                async with LiteLLMProxyClient(self.deps.llm_model.api_key) as client:
+                    budget_info = await client.get_budget_info()
 
                 # Format budget section
                 source_label = "Key" if budget_info.source == "key" else "Team"
@@ -2319,8 +2319,8 @@ class ChatScreen(Screen[None]):
         try:
             from shotgun.llm_proxy import LiteLLMProxyClient
 
-            client = LiteLLMProxyClient(self.deps.llm_model.api_key)
-            budget_info = await client.get_budget_info()
+            async with LiteLLMProxyClient(self.deps.llm_model.api_key) as client:
+                budget_info = await client.get_budget_info()
 
             # Show warning if remaining balance is $2.50 or less
             if budget_info.remaining <= 2.50:

--- a/test/unit/agents/conversation/test_filters.py
+++ b/test/unit/agents/conversation/test_filters.py
@@ -261,25 +261,19 @@ def test_is_tool_call_complete_with_none_args():
 
 def test_is_tool_call_complete_with_dict_args():
     """Tool call with dict args is considered complete."""
-    tc = ToolCallPart(
-        tool_name="test", args={"key": "value"}, tool_call_id="tc1"
-    )
+    tc = ToolCallPart(tool_name="test", args={"key": "value"}, tool_call_id="tc1")
     assert is_tool_call_complete(tc) is True
 
 
 def test_is_tool_call_complete_with_valid_json_string():
     """Tool call with valid JSON string args is considered complete."""
-    tc = ToolCallPart(
-        tool_name="test", args='{"key": "value"}', tool_call_id="tc1"
-    )
+    tc = ToolCallPart(tool_name="test", args='{"key": "value"}', tool_call_id="tc1")
     assert is_tool_call_complete(tc) is True
 
 
 def test_is_tool_call_complete_with_truncated_json():
     """Tool call with truncated JSON string is considered incomplete."""
-    tc = ToolCallPart(
-        tool_name="test", args='{"key": "val', tool_call_id="tc1"
-    )
+    tc = ToolCallPart(tool_name="test", args='{"key": "val', tool_call_id="tc1")
     assert is_tool_call_complete(tc) is False
 
 

--- a/test/unit/agents/test_agent_manager_pruning.py
+++ b/test/unit/agents/test_agent_manager_pruning.py
@@ -145,8 +145,6 @@ def test_welcome_messages_count_toward_limit(agent_manager):
     assert hint_welcome_count == MAX_UI_HINT_MESSAGES
     # The oldest messages (the welcome messages) should be removed
     welcome_count = sum(
-        1
-        for msg in agent_manager.ui_message_history
-        if isinstance(msg, WelcomeMessage)
+        1 for msg in agent_manager.ui_message_history if isinstance(msg, WelcomeMessage)
     )
     assert welcome_count == 0

--- a/test/unit/agents/tools/web_search/test_track_usage.py
+++ b/test/unit/agents/tools/web_search/test_track_usage.py
@@ -51,9 +51,7 @@ async def test_track_usage_passes_run_usage_directly(
 
     run_usage = RunUsage(input_tokens=300, output_tokens=150)
 
-    await track_usage(
-        run_usage, model_name="gpt-5-mini", provider=ProviderType.OPENAI
-    )
+    await track_usage(run_usage, model_name="gpt-5-mini", provider=ProviderType.OPENAI)
 
     mock_manager.add_usage.assert_called_once()
     call_args = mock_manager.add_usage.call_args

--- a/test/unit/test_update_checker.py
+++ b/test/unit/test_update_checker.py
@@ -76,8 +76,8 @@ def test_detect_installation_method_uvx(mock_path, mock_run):
     """Test detection of uvx (ephemeral) execution."""
     # Mock executable path to look like uvx cache
     mock_executable = Mock()
-    mock_executable.__str__ = (
-        lambda x: "/home/user/.cache/uv/tools/shotgun-sh/bin/python"
+    mock_executable.__str__ = lambda x: (
+        "/home/user/.cache/uv/tools/shotgun-sh/bin/python"
     )
     mock_path.return_value = mock_executable
 


### PR DESCRIPTION
## Summary

- Adds `__aenter__`/`__aexit__` to `LiteLLMProxyClient` so it can be used as `async with LiteLLMProxyClient(...) as client:`
- Fixes 3 call sites that were not calling `aclose()`, leaking `httpx.AsyncClient` connections
- Simplifies the `get_budget_info()` convenience function to use the new context manager

Follow-up to #445 which noted this cleanup was needed.

## Test plan

- [x] `uv run ruff check .` passes
- [x] `uv run mypy src/` passes
- [x] `uv run pytest test/ -x -m smoke` passes
- [x] Existing `test/unit/llm_proxy/` tests pass (20/20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)