### PR TITLE
fix(codebase): remove _operation_stats memory leak in CodebaseGraphManager

### DIFF
--- a/src/shotgun/codebase/core/manager.py
+++ b/src/shotgun/codebase/core/manager.py
@@ -183,7 +183,6 @@ class CodebaseGraphManager:
 
     # Operation tracking for async operations
     _operations: ClassVar[dict[str, asyncio.Task[Any]]] = {}
-    _operation_stats: ClassVar[dict[str, OperationStats]] = {}
 
     def __init__(self, storage_dir: Path):
         """Initialize graph manager.
@@ -256,8 +255,6 @@ class CodebaseGraphManager:
                 """,
                 {"graph_id": graph_id, "stats": stats.model_dump_json()},
             )
-            # Also store in memory for quick access
-            self._operation_stats[graph_id] = stats
         except Exception as e:
             logger.error(f"Failed to store operation stats: {e} - graph_id: {graph_id}")
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -51,7 +51,6 @@ def cleanup_before_tests():
     CodebaseGraphManager._watchers.clear()
     CodebaseGraphManager._handlers.clear()
     CodebaseGraphManager._operations.clear()
-    CodebaseGraphManager._operation_stats.clear()
     CodebaseGraphManager._lock = None
 
 
@@ -135,7 +134,6 @@ async def cleanup_kuzu_state():
         CodebaseGraphManager._watchers.clear()
         CodebaseGraphManager._handlers.clear()
         CodebaseGraphManager._operations.clear()
-        CodebaseGraphManager._operation_stats.clear()
 
         # 7. Reset the class-level lock
         CodebaseGraphManager._lock = None
@@ -151,7 +149,6 @@ async def cleanup_kuzu_state():
         CodebaseGraphManager._watchers.clear()
         CodebaseGraphManager._handlers.clear()
         CodebaseGraphManager._operations.clear()
-        CodebaseGraphManager._operation_stats.clear()
         CodebaseGraphManager._lock = None
 
 


### PR DESCRIPTION
## Summary

- Remove the `_operation_stats` ClassVar dict from `CodebaseGraphManager` which was never read from anywhere in the codebase
- Stats are always fetched from the database via `get_graph()`, making this an unused in-memory cache that grew indefinitely without cleanup
- Remove corresponding `.clear()` calls in test fixtures

## Test plan

- [x] `ruff check` passes
- [x] `mypy` passes
- [x] All unit tests pass (30/30)
- [x] All smoke tests pass (8/8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)