### PR TITLE
fix(tui): stop spinner timer on unmount to prevent leak

### DIFF
--- a/src/shotgun/tui/components/spinner.py
+++ b/src/shotgun/tui/components/spinner.py
@@ -62,6 +62,12 @@ class Spinner(Widget):
         """Set up the animation timer when mounted."""
         self._timer = self.set_interval(0.1, self._advance_frame)
 
+    def on_unmount(self) -> None:
+        """Stop the animation timer when unmounted."""
+        if self._timer is not None:
+            self._timer.stop()
+            self._timer = None
+
     def _advance_frame(self) -> None:
         """Advance to the next animation frame."""
         self._frame_index = (self._frame_index + 1) % len(self.FRAMES)

--- a/test/unit/tui/components/test_spinner.py
+++ b/test/unit/tui/components/test_spinner.py
@@ -1,0 +1,48 @@
+"""Tests for the Spinner component."""
+
+from unittest.mock import MagicMock
+
+from textual.timer import Timer
+
+from shotgun.tui.components.spinner import Spinner
+
+
+def test_on_unmount_stops_timer():
+    """on_unmount should stop and clear the timer."""
+    spinner = Spinner()
+    mock_timer = MagicMock(spec=Timer)
+    spinner._timer = mock_timer
+
+    spinner.on_unmount()
+
+    mock_timer.stop.assert_called_once()
+    assert spinner._timer is None
+
+
+def test_on_unmount_with_no_timer():
+    """on_unmount should be safe when no timer exists."""
+    spinner = Spinner()
+    spinner._timer = None
+
+    spinner.on_unmount()
+
+    assert spinner._timer is None
+
+
+def test_mount_unmount_cycle_no_leak():
+    """Repeated mount/unmount cycles should not leak timers."""
+    spinner = Spinner()
+
+    timers = []
+    for _ in range(5):
+        mock_timer = MagicMock(spec=Timer)
+        spinner._timer = mock_timer
+        timers.append(mock_timer)
+
+        spinner.on_unmount()
+
+        assert spinner._timer is None
+        mock_timer.stop.assert_called_once()
+
+    # All timers were stopped
+    assert all(t.stop.called for t in timers)


### PR DESCRIPTION
## Summary
- The `Spinner` widget starts a `set_interval(0.1)` timer in `on_mount()` but never stops it on unmount
- Each mount/unmount cycle leaks a timer firing 10x/second, causing hundreds of orphaned timers over long sessions
- Added `on_unmount()` to stop and clear the timer

## Test plan
- [x] Unit tests for `on_unmount()` stopping the timer
- [x] Unit test for safe no-op when no timer exists
- [x] Unit test for repeated mount/unmount cycles not leaking
- [x] mypy passes
- [x] ruff passes
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)