### PR TITLE
fix(tui): cap ui_message_history as circular buffer to prevent unbounded growth

### DIFF
--- a/src/shotgun/agents/agent_manager.py
+++ b/src/shotgun/agents/agent_manager.py
@@ -92,7 +92,7 @@ from shotgun.tui.screens.chat_screen.welcome_message import WelcomeMessage
 from shotgun.utils.source_detection import detect_source
 
 from .conversation.history.compaction import apply_persistent_compaction
-from .conversation.history.constants import MAX_UI_HINT_MESSAGES
+from .conversation.history.constants import MAX_UI_HISTORY_MESSAGES
 from .export import create_export_agent
 from .messages import AgentSystemPrompt, InternalPromptPart
 from .models import AgentDeps, AgentRuntimeOptions
@@ -1706,34 +1706,14 @@ class AgentManager(Widget):
         self._sub_agent_messages = []
 
     def _prune_ui_message_history(self) -> None:
-        """Remove oldest HintMessage/WelcomeMessage entries when over the limit.
+        """Keep only the last MAX_UI_HISTORY_MESSAGES items in ui_message_history.
 
-        Preserves all ModelMessage entries (which mirror the already-compacted
-        message_history) and keeps the most recent hint messages for context.
+        Acts as a circular buffer — oldest messages of any type are dropped.
         """
-        hint_indices = [
-            i
-            for i, msg in enumerate(self.ui_message_history)
-            if isinstance(msg, (HintMessage, WelcomeMessage))
-        ]
-        if len(hint_indices) <= MAX_UI_HINT_MESSAGES:
+        if len(self.ui_message_history) <= MAX_UI_HISTORY_MESSAGES:
             return
 
-        indices_to_remove = set(
-            hint_indices[: len(hint_indices) - MAX_UI_HINT_MESSAGES]
-        )
-        self.ui_message_history = [
-            msg
-            for i, msg in enumerate(self.ui_message_history)
-            if i not in indices_to_remove
-        ]
-        logger.debug(
-            "Pruned ui_message_history",
-            extra={
-                "removed_hints": len(indices_to_remove),
-                "remaining_total": len(self.ui_message_history),
-            },
-        )
+        self.ui_message_history = self.ui_message_history[-MAX_UI_HISTORY_MESSAGES:]
 
     def _build_partial_response(
         self, parts: list[ModelResponsePart | ToolCallPartDelta]

--- a/src/shotgun/agents/conversation/history/constants.py
+++ b/src/shotgun/agents/conversation/history/constants.py
@@ -15,10 +15,8 @@ CHUNK_TARGET_RATIO = 0.60  # Target chunk size as % of max_input_tokens
 CHUNK_SAFE_RATIO = 0.70  # Max safe ratio before triggering chunked compaction
 RETENTION_WINDOW_MESSAGES = 5  # Keep last N message groups outside compaction
 
-# UI history pruning constants
-MAX_UI_HINT_MESSAGES = (
-    50  # Max HintMessage/WelcomeMessage items kept in ui_message_history
-)
+# UI history pruning — keep the last N messages (any type) as a circular buffer
+MAX_UI_HISTORY_MESSAGES = 50
 
 
 class SummaryType(Enum):

--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -3237,8 +3237,6 @@ Then confirm what you changed.
         finally:
             self.processing_state.stop_processing()
 
-    _MAX_HINT_MESSAGES = 50
-
     @on(AutopilotOutputReceived)
     def handle_autopilot_output(self, event: AutopilotOutputReceived) -> None:
         """Handle output from Claude Code subprocess."""
@@ -3250,9 +3248,6 @@ Then confirm what you changed.
 
         # Always log to file regardless of UI display
         logger.info("[autopilot-output] [%s] %s", output.type.value, content)
-
-        # Trim old hint messages to keep UI performant
-        self._trim_old_hint_messages()
 
         # Format based on output type
         if output.type == ClaudeOutputType.STDOUT:
@@ -3286,39 +3281,6 @@ Then confirm what you changed.
                         source="autopilot",
                     )
                 )
-
-    def _trim_old_hint_messages(self) -> None:
-        """Remove oldest hint messages when over the visible limit.
-
-        Keeps only the last _MAX_HINT_MESSAGES hint messages in UI history,
-        removing oldest first (compact/tool-call messages prioritized for removal).
-        Rebuilds the list to avoid in-place index mutation.
-        """
-        history = self.agent_manager.ui_message_history
-        hint_indices = [
-            i for i, msg in enumerate(history) if isinstance(msg, HintMessage)
-        ]
-
-        excess = len(hint_indices) - self._MAX_HINT_MESSAGES
-        if excess <= 0:
-            return
-
-        # Pick indices to remove: prefer compact (tool-call noise) first
-        compact_indices = [
-            i
-            for i in hint_indices
-            if isinstance(history[i], HintMessage) and history[i].compact  # type: ignore[union-attr]
-        ]
-        non_compact_indices = [i for i in hint_indices if i not in compact_indices]
-
-        to_remove = set(compact_indices[:excess])
-        if len(to_remove) < excess:
-            to_remove.update(non_compact_indices[: excess - len(to_remove)])
-
-        # Rebuild list, skipping removed indices
-        self.agent_manager.ui_message_history = [
-            msg for i, msg in enumerate(history) if i not in to_remove
-        ]
 
     @on(AutopilotApprovalRequired)
     def handle_autopilot_approval_required(

--- a/test/unit/agents/test_agent_manager_pruning.py
+++ b/test/unit/agents/test_agent_manager_pruning.py
@@ -9,7 +9,7 @@ from pydantic_ai.messages import (
 )
 
 from shotgun.agents.agent_manager import AgentManager
-from shotgun.agents.conversation.history.constants import MAX_UI_HINT_MESSAGES
+from shotgun.agents.conversation.history.constants import MAX_UI_HISTORY_MESSAGES
 from shotgun.tui.screens.chat_screen.hint_message import HintMessage
 from shotgun.tui.screens.chat_screen.welcome_message import WelcomeMessage
 
@@ -42,108 +42,67 @@ def _make_model_response(text: str = "response") -> ModelResponse:
 
 
 def test_no_pruning_when_under_limit(agent_manager):
-    """No pruning occurs when hint count is at or below MAX_UI_HINT_MESSAGES."""
-    for i in range(MAX_UI_HINT_MESSAGES):
+    """No pruning occurs when message count is at or below MAX_UI_HISTORY_MESSAGES."""
+    for i in range(MAX_UI_HISTORY_MESSAGES):
         agent_manager.ui_message_history.append(_make_hint(f"hint-{i}"))
-    agent_manager.ui_message_history.append(_make_model_request())
 
     original_len = len(agent_manager.ui_message_history)
     agent_manager._prune_ui_message_history()
     assert len(agent_manager.ui_message_history) == original_len
 
 
-def test_pruning_removes_oldest_hints(agent_manager):
-    """Oldest HintMessages are removed when over the limit."""
-    total_hints = MAX_UI_HINT_MESSAGES + 20
-    for i in range(total_hints):
-        agent_manager.ui_message_history.append(_make_hint(f"hint-{i}"))
+def test_pruning_keeps_last_n_messages(agent_manager):
+    """Only the last MAX_UI_HISTORY_MESSAGES items are kept."""
+    total = MAX_UI_HISTORY_MESSAGES + 20
+    for i in range(total):
+        agent_manager.ui_message_history.append(_make_model_request(f"msg-{i}"))
 
     agent_manager._prune_ui_message_history()
 
-    remaining_hints = [
-        msg for msg in agent_manager.ui_message_history if isinstance(msg, HintMessage)
-    ]
-    assert len(remaining_hints) == MAX_UI_HINT_MESSAGES
-    # The kept hints should be the most recent ones
-    assert remaining_hints[0].message == f"hint-{20}"
-    assert remaining_hints[-1].message == f"hint-{total_hints - 1}"
+    assert len(agent_manager.ui_message_history) == MAX_UI_HISTORY_MESSAGES
+    # The kept messages should be the most recent ones
+    first_kept = agent_manager.ui_message_history[0]
+    assert isinstance(first_kept, ModelRequest)
+    assert first_kept.parts[0].content == f"msg-{20}"
 
 
-def test_pruning_preserves_all_model_messages(agent_manager):
-    """All ModelMessage entries are preserved during pruning."""
-    for i in range(MAX_UI_HINT_MESSAGES + 30):
-        agent_manager.ui_message_history.append(_make_hint(f"hint-{i}"))
-        if i % 5 == 0:
-            agent_manager.ui_message_history.append(_make_model_request(f"req-{i}"))
-            agent_manager.ui_message_history.append(_make_model_response(f"resp-{i}"))
-
-    model_msgs_before = [
-        msg
-        for msg in agent_manager.ui_message_history
-        if isinstance(msg, (ModelRequest, ModelResponse))
-    ]
-
-    agent_manager._prune_ui_message_history()
-
-    model_msgs_after = [
-        msg
-        for msg in agent_manager.ui_message_history
-        if isinstance(msg, (ModelRequest, ModelResponse))
-    ]
-    assert len(model_msgs_after) == len(model_msgs_before)
-    assert model_msgs_after == model_msgs_before
-
-
-def test_pruning_preserves_most_recent_hints(agent_manager):
-    """The most recent MAX_UI_HINT_MESSAGES hints are kept."""
-    total_hints = MAX_UI_HINT_MESSAGES + 10
-    for i in range(total_hints):
-        agent_manager.ui_message_history.append(_make_hint(f"hint-{i}"))
-
-    agent_manager._prune_ui_message_history()
-
-    remaining = [
-        msg for msg in agent_manager.ui_message_history if isinstance(msg, HintMessage)
-    ]
-    expected_start = total_hints - MAX_UI_HINT_MESSAGES
-    for idx, msg in enumerate(remaining):
-        assert msg.message == f"hint-{expected_start + idx}"
-
-
-def test_pruning_handles_mixed_ordering(agent_manager):
-    """Correctly handles interleaved hints, welcomes, and model messages."""
-    agent_manager.ui_message_history.append(_make_welcome())
-    for i in range(MAX_UI_HINT_MESSAGES + 5):
+def test_pruning_handles_mixed_types(agent_manager):
+    """Pruning keeps last N regardless of message type."""
+    for i in range(MAX_UI_HISTORY_MESSAGES + 10):
         agent_manager.ui_message_history.append(_make_model_request(f"req-{i}"))
         agent_manager.ui_message_history.append(_make_hint(f"hint-{i}"))
         agent_manager.ui_message_history.append(_make_model_response(f"resp-{i}"))
 
     agent_manager._prune_ui_message_history()
 
-    hint_welcome_count = sum(
-        1
-        for msg in agent_manager.ui_message_history
-        if isinstance(msg, (HintMessage, WelcomeMessage))
-    )
-    assert hint_welcome_count == MAX_UI_HINT_MESSAGES
+    assert len(agent_manager.ui_message_history) == MAX_UI_HISTORY_MESSAGES
 
 
-def test_welcome_messages_count_toward_limit(agent_manager):
-    """WelcomeMessage objects are counted and pruned alongside HintMessages."""
-    for _ in range(5):
-        agent_manager.ui_message_history.append(_make_welcome())
-    for i in range(MAX_UI_HINT_MESSAGES):
+def test_pruning_preserves_order(agent_manager):
+    """After pruning the remaining messages are in original order."""
+    items = []
+    for i in range(MAX_UI_HISTORY_MESSAGES + 5):
+        req = _make_model_request(f"req-{i}")
+        resp = _make_model_response(f"resp-{i}")
+        items.extend([req, resp])
+        agent_manager.ui_message_history.extend([req, resp])
+
+    agent_manager._prune_ui_message_history()
+
+    expected = items[-MAX_UI_HISTORY_MESSAGES:]
+    assert agent_manager.ui_message_history == expected
+
+
+def test_welcome_and_hints_pruned_same_as_model_messages(agent_manager):
+    """Welcome and hint messages are pruned the same as model messages."""
+    agent_manager.ui_message_history.append(_make_welcome())
+    for i in range(MAX_UI_HISTORY_MESSAGES + 5):
         agent_manager.ui_message_history.append(_make_hint(f"hint-{i}"))
 
     agent_manager._prune_ui_message_history()
 
-    hint_welcome_count = sum(
-        1
-        for msg in agent_manager.ui_message_history
-        if isinstance(msg, (HintMessage, WelcomeMessage))
-    )
-    assert hint_welcome_count == MAX_UI_HINT_MESSAGES
-    # The oldest messages (the welcome messages) should be removed
+    assert len(agent_manager.ui_message_history) == MAX_UI_HISTORY_MESSAGES
+    # Welcome message (oldest) should have been dropped
     welcome_count = sum(
         1 for msg in agent_manager.ui_message_history if isinstance(msg, WelcomeMessage)
     )


### PR DESCRIPTION
## Summary
- Replace hint-only pruning (`MAX_UI_HINT_MESSAGES`) with a simple circular buffer that keeps the last 50 messages of **any type** (`MAX_UI_HISTORY_MESSAGES`)
- Remove duplicate `_trim_old_hint_messages()` from `ChatScreen` — the agent manager's pruning now handles everything
- Remove DOM-side widget trimming from `ChatHistory` — no longer needed since the data layer is capped

## Test plan
- [x] `uv run ruff check` passes on all modified files
- [x] `uv run mypy` passes on all modified files
- [x] Pruning tests rewritten: under-limit no-op, keeps last N, mixed types, order preservation, welcome/hint same as model messages
- [x] All 285 TUI unit tests pass
- [ ] Manual: Long conversation stays responsive, old messages drop off naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)