### PR TITLE
fix(agents): clean up agent instances on shutdown and model change

### DIFF
--- a/src/shotgun/agents/agent_manager.py
+++ b/src/shotgun/agents/agent_manager.py
@@ -423,6 +423,27 @@ class AgentManager(Widget):
         )
         self._agents_initialized = True
 
+    async def cleanup_agents(self) -> None:
+        """Release all agent instances and their held resources."""
+        if self._router_deps is not None:
+            self._router_deps.sub_agent_cache.clear()
+            self._router_deps.parent_stream_handler = None
+            self._router_deps.on_plan_changed = None
+
+        self._research_agent = None
+        self._research_deps = None
+        self._plan_agent = None
+        self._plan_deps = None
+        self._tasks_agent = None
+        self._tasks_deps = None
+        self._specify_agent = None
+        self._specify_deps = None
+        self._export_agent = None
+        self._export_deps = None
+        self._router_agent = None
+        self._router_deps = None
+        self._agents_initialized = False
+
     @property
     def research_agent(self) -> ShotgunAgent:
         """Get research agent (must call _ensure_agents_initialized first)."""

--- a/src/shotgun/tui/app.py
+++ b/src/shotgun/tui/app.py
@@ -328,6 +328,10 @@ class ShotgunApp(App[None]):
 
     async def action_quit(self) -> None:
         """Quit the application."""
+        # Clean up agent instances to release tool contexts and model instances
+        if isinstance(self.screen, ChatScreen):
+            await self.screen.agent_manager.cleanup_agents()
+
         # Stop all file watchers to prevent resource leaks
         from shotgun.codebase.core.manager import CodebaseGraphManager
 

--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -374,23 +374,13 @@ class ChatScreen(Screen[None]):
             await widget.recompose()
             break
 
-    def _reset_agents_for_model_change(self) -> None:
+    async def _reset_agents_for_model_change(self) -> None:
         """Reset agent instances so they get recreated with the new model.
 
         This is called when the model configuration changes (either via model picker
         or when falling back due to API key removal).
         """
-        self.agent_manager._agents_initialized = False
-        self.agent_manager._research_agent = None
-        self.agent_manager._plan_agent = None
-        self.agent_manager._tasks_agent = None
-        self.agent_manager._specify_agent = None
-        self.agent_manager._export_agent = None
-        self.agent_manager._research_deps = None
-        self.agent_manager._plan_deps = None
-        self.agent_manager._tasks_deps = None
-        self.agent_manager._specify_deps = None
-        self.agent_manager._export_deps = None
+        await self.agent_manager.cleanup_agents()
 
     async def _validate_current_model(self) -> None:
         """Validate current model is still available, fall back if not.
@@ -424,7 +414,7 @@ class ChatScreen(Screen[None]):
                 self.agent_manager.deps.llm_model = valid_model
 
                 # Reset agents so they get recreated with new model
-                self._reset_agents_for_model_change()
+                await self._reset_agents_for_model_change()
 
                 # Get display name for new model
                 new_model_display = valid_model_name
@@ -1606,7 +1596,7 @@ class ChatScreen(Screen[None]):
             self.agent_manager.deps.llm_model = result.model_config
 
             # Reset agents so they get recreated with new model
-            self._reset_agents_for_model_change()
+            await self._reset_agents_for_model_change()
 
             # Get current analysis and update context indicator via coordinator
             analysis = await self.agent_manager.get_context_analysis()

--- a/test/unit/agents/test_agent_manager_cleanup.py
+++ b/test/unit/agents/test_agent_manager_cleanup.py
@@ -1,0 +1,92 @@
+"""Test cleanup_agents() in AgentManager."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from shotgun.agents.agent_manager import AgentManager
+from shotgun.agents.models import AgentType
+
+
+@pytest.fixture
+def agent_manager():
+    """Create a minimal AgentManager with agent/deps fields set."""
+    manager = AgentManager.__new__(AgentManager)
+    manager._research_agent = MagicMock()
+    manager._research_deps = MagicMock()
+    manager._plan_agent = MagicMock()
+    manager._plan_deps = MagicMock()
+    manager._tasks_agent = MagicMock()
+    manager._tasks_deps = MagicMock()
+    manager._specify_agent = MagicMock()
+    manager._specify_deps = MagicMock()
+    manager._export_agent = MagicMock()
+    manager._export_deps = MagicMock()
+    manager._router_agent = MagicMock()
+    manager._router_deps = MagicMock()
+    manager._router_deps.sub_agent_cache = {AgentType.RESEARCH: MagicMock()}
+    manager._router_deps.parent_stream_handler = MagicMock()
+    manager._router_deps.on_plan_changed = MagicMock()
+    manager._agents_initialized = True
+    return manager
+
+
+@pytest.fixture
+def uninitialized_agent_manager():
+    """Create a minimal AgentManager that was never initialized."""
+    manager = AgentManager.__new__(AgentManager)
+    manager._research_agent = None
+    manager._research_deps = None
+    manager._plan_agent = None
+    manager._plan_deps = None
+    manager._tasks_agent = None
+    manager._tasks_deps = None
+    manager._specify_agent = None
+    manager._specify_deps = None
+    manager._export_agent = None
+    manager._export_deps = None
+    manager._router_agent = None
+    manager._router_deps = None
+    manager._agents_initialized = False
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_cleanup_sets_all_agents_to_none(agent_manager):
+    """cleanup_agents() should null all agent and deps references."""
+    await agent_manager.cleanup_agents()
+
+    assert agent_manager._research_agent is None
+    assert agent_manager._research_deps is None
+    assert agent_manager._plan_agent is None
+    assert agent_manager._plan_deps is None
+    assert agent_manager._tasks_agent is None
+    assert agent_manager._tasks_deps is None
+    assert agent_manager._specify_agent is None
+    assert agent_manager._specify_deps is None
+    assert agent_manager._export_agent is None
+    assert agent_manager._export_deps is None
+    assert agent_manager._router_agent is None
+    assert agent_manager._router_deps is None
+    assert agent_manager._agents_initialized is False
+
+
+@pytest.mark.asyncio
+async def test_cleanup_clears_router_deps_cache_and_callbacks(agent_manager):
+    """cleanup_agents() should clear sub_agent_cache and nullify callbacks."""
+    router_deps = agent_manager._router_deps
+
+    await agent_manager.cleanup_agents()
+
+    assert len(router_deps.sub_agent_cache) == 0
+    assert router_deps.parent_stream_handler is None
+    assert router_deps.on_plan_changed is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_safe_when_not_initialized(uninitialized_agent_manager):
+    """cleanup_agents() should be a no-op when agents were never initialized."""
+    await uninitialized_agent_manager.cleanup_agents()
+
+    assert uninitialized_agent_manager._agents_initialized is False
+    assert uninitialized_agent_manager._router_deps is None


### PR DESCRIPTION
## Summary

- Add `cleanup_agents()` method to `AgentManager` that releases all agent/deps references, clears router sub-agent cache, and resets the initialized flag
- Call `cleanup_agents()` during app quit (`action_quit`) to prevent orphaned agent instances holding tool contexts, model instances, and MCP connections
- Refactor `ChatScreen._reset_agents_for_model_change()` to use `cleanup_agents()`, fixing a bug where router agent, router deps, and `sub_agent_cache` were not cleared on model change

## Test plan

- [x] `uv run ruff check .` passes
- [x] `uv run mypy src/` passes (0 issues in 280 files)
- [x] `uv run pytest -m smoke` passes (7 passed)
- [x] New unit tests pass (`test/unit/agents/test_agent_manager_cleanup.py` — 3 tests)
- [x] Existing agent manager tests pass (31 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)