### PR TITLE
fix(telemetry): flush PostHog event queue between agent runs

### DIFF
--- a/src/shotgun/agents/agent_manager.py
+++ b/src/shotgun/agents/agent_manager.py
@@ -86,6 +86,7 @@ from shotgun.agents.models import (
 )
 from shotgun.attachments import FileAttachment
 from shotgun.exceptions import IncompleteToolCallError
+from shotgun.posthog_telemetry import flush as flush_telemetry
 from shotgun.posthog_telemetry import track_event
 from shotgun.tui.screens.chat_screen.hint_message import HintMessage
 from shotgun.tui.screens.chat_screen.welcome_message import WelcomeMessage
@@ -1104,6 +1105,9 @@ class AgentManager(Widget):
             raise
         finally:
             self._stream_state = None
+            # Flush PostHog events between agent runs to prevent
+            # unbounded queue growth during long-running sessions
+            flush_telemetry()
 
         # Agent ALWAYS returns AgentResponse with structured output
         agent_response = result.output

--- a/src/shotgun/posthog_telemetry.py
+++ b/src/shotgun/posthog_telemetry.py
@@ -273,6 +273,20 @@ def capture_exception(
         logger.warning("Failed to capture exception in PostHog: %s", e)
 
 
+def flush() -> None:
+    """Flush any pending PostHog events without shutting down the client.
+
+    Call this between agent runs to prevent unbounded queue growth
+    during long-running sessions.
+    """
+    if _posthog_client is not None:
+        try:
+            _posthog_client.flush()  # type: ignore[no-untyped-call]
+            logger.debug("PostHog events flushed")
+        except Exception as e:
+            logger.warning("Error flushing PostHog events: %s", e)
+
+
 def shutdown() -> None:
     """Shutdown PostHog client and flush any pending events."""
     global _posthog_client

--- a/test/unit/test_posthog_telemetry.py
+++ b/test/unit/test_posthog_telemetry.py
@@ -230,6 +230,45 @@ def test_capture_exception_sends_regular_exceptions():
         posthog_telemetry._shotgun_instance_id = original_instance_id
 
 
+def test_flush_not_initialized():
+    """Test flush when PostHog is not initialized."""
+    original_client = posthog_telemetry._posthog_client
+    posthog_telemetry._posthog_client = None
+
+    try:
+        # Should not raise any exception
+        posthog_telemetry.flush()
+    finally:
+        posthog_telemetry._posthog_client = original_client
+
+
+def test_flush_initialized():
+    """Test flush when PostHog is initialized."""
+    mock_client = MagicMock()
+    original_client = posthog_telemetry._posthog_client
+    posthog_telemetry._posthog_client = mock_client
+
+    try:
+        posthog_telemetry.flush()
+        mock_client.flush.assert_called_once()
+    finally:
+        posthog_telemetry._posthog_client = original_client
+
+
+def test_flush_exception_handling():
+    """Test flush handles exceptions gracefully."""
+    mock_client = MagicMock()
+    mock_client.flush.side_effect = Exception("Flush error")
+    original_client = posthog_telemetry._posthog_client
+    posthog_telemetry._posthog_client = mock_client
+
+    try:
+        # Should not raise exception
+        posthog_telemetry.flush()
+    finally:
+        posthog_telemetry._posthog_client = original_client
+
+
 def test_shutdown_not_initialized():
     """Test shutdown when PostHog is not initialized."""
     original_client = posthog_telemetry._posthog_client


### PR DESCRIPTION
## Summary
- Adds a `flush()` function to `posthog_telemetry.py` that explicitly flushes pending events without shutting down the client
- Calls `flush_telemetry()` in the `AgentManager.run()` `finally` block so events are drained after every agent run (success or failure)
- Prevents unbounded queue growth during long-running TUI sessions where the PostHog SDK's background consumer thread may not keep up or could fail silently

## Test plan
- [x] Added unit tests for `flush()`: not initialized, initialized, and exception handling
- [x] All existing posthog telemetry tests pass (20/20)
- [x] mypy clean
- [x] ruff format clean
- [x] Smoke tests pass (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)