### PR TITLE
fix(tui): prevent filenames from rendering as clickable URLs

### DIFF
--- a/src/shotgun/tui/markdown.py
+++ b/src/shotgun/tui/markdown.py
@@ -1,13 +1,14 @@
-"""Custom markdown parser configuration for the TUI.
+"""Custom markdown widget for the TUI.
 
-Provides a parser factory that disables fuzzy link detection, preventing
+Provides a Markdown subclass that disables fuzzy link detection, preventing
 filenames like 'specification.md' from being rendered as clickable URLs.
 """
 
 from markdown_it import MarkdownIt
+from textual.widgets import Markdown as _TextualMarkdown
 
 
-def create_markdown_parser() -> MarkdownIt:
+def _create_markdown_parser() -> MarkdownIt:
     """Create a MarkdownIt parser with fuzzy link detection disabled.
 
     The default 'gfm-like' parser uses linkify with fuzzy matching enabled,
@@ -22,3 +23,29 @@ def create_markdown_parser() -> MarkdownIt:
     if parser.linkify is not None:
         parser.linkify.set({"fuzzy_link": False, "fuzzy_email": False})
     return parser
+
+
+class Markdown(_TextualMarkdown):
+    """Markdown widget with fuzzy link detection disabled.
+
+    Drop-in replacement for textual's Markdown that prevents bare filenames
+    (e.g., 'specification.md') from being rendered as clickable URLs.
+    """
+
+    def __init__(
+        self,
+        markdown: str | None = None,
+        *,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+        open_links: bool = True,
+    ) -> None:
+        super().__init__(
+            markdown,
+            name=name,
+            id=id,
+            classes=classes,
+            parser_factory=_create_markdown_parser,
+            open_links=open_links,
+        )

--- a/src/shotgun/tui/screens/chat/codebase_index_prompt_screen.py
+++ b/src/shotgun/tui/screens/chat/codebase_index_prompt_screen.py
@@ -9,9 +9,9 @@ from textual.app import ComposeResult
 from textual.containers import Container, VerticalScroll
 from textual.events import Resize
 from textual.screen import ModalScreen
-from textual.widgets import Button, Label, Markdown, Static
+from textual.widgets import Button, Label, Static
 
-from shotgun.tui.markdown import create_markdown_parser
+from shotgun.tui.markdown import Markdown
 from shotgun.utils.file_system_utils import get_shotgun_home
 
 # Use a higher threshold than the global default since this dialog has more content
@@ -186,11 +186,7 @@ We take your privacy seriously. You can read our full [privacy policy](https://a
                 )
                 # Full mode: show detailed content
                 with VerticalScroll(id="index-prompt-content"):
-                    yield Markdown(
-                        content,
-                        id="index-prompt-info",
-                        parser_factory=create_markdown_parser,
-                    )
+                    yield Markdown(content, id="index-prompt-info")
                 with Container(id="index-prompt-buttons"):
                     yield Button(
                         "Not now",

--- a/src/shotgun/tui/screens/chat_screen/hint_message.py
+++ b/src/shotgun/tui/screens/chat_screen/hint_message.py
@@ -6,10 +6,10 @@ from textual import on
 from textual.app import ComposeResult
 from textual.containers import Horizontal
 from textual.widget import Widget
-from textual.widgets import Button, Label, Markdown, Static
+from textual.widgets import Button, Label, Static
 
 from shotgun.logging_config import get_logger
-from shotgun.tui.markdown import create_markdown_parser
+from shotgun.tui.markdown import Markdown
 
 logger = get_logger(__name__)
 
@@ -123,10 +123,7 @@ class HintMessageWidget(Widget):
         if self.message.compact:
             yield Static(self.message.message)
         else:
-            yield Markdown(
-                markdown=f"{self.message.message}",
-                parser_factory=create_markdown_parser,
-            )
+            yield Markdown(markdown=f"{self.message.message}")
 
         # Optional email copy section
         if self.message.email:
@@ -140,9 +137,7 @@ class HintMessageWidget(Widget):
 
             # Optional markdown after email
             if self.message.markdown_after:
-                yield Markdown(
-                    self.message.markdown_after, parser_factory=create_markdown_parser
-                )
+                yield Markdown(self.message.markdown_after)
 
         # Optional link section
         if self.message.link:

--- a/src/shotgun/tui/screens/chat_screen/history/agent_response.py
+++ b/src/shotgun/tui/screens/chat_screen/history/agent_response.py
@@ -12,9 +12,8 @@ from pydantic_ai.messages import (
 )
 from textual.app import ComposeResult
 from textual.widget import Widget
-from textual.widgets import Markdown
 
-from shotgun.tui.markdown import create_markdown_parser
+from shotgun.tui.markdown import Markdown
 
 from .formatters import ToolFormatter
 
@@ -49,11 +48,9 @@ class AgentResponseWidget(Widget):
     def compose(self) -> ComposeResult:
         self.display = self.item is not None
         if self.item is None:
-            yield Markdown(markdown="", parser_factory=create_markdown_parser)
+            yield Markdown(markdown="")
         else:
-            yield Markdown(
-                markdown=self.compute_output(), parser_factory=create_markdown_parser
-            )
+            yield Markdown(markdown=self.compute_output())
 
     def compute_output(self) -> str:
         """Compute the markdown output for the agent response."""

--- a/src/shotgun/tui/screens/chat_screen/history/user_question.py
+++ b/src/shotgun/tui/screens/chat_screen/history/user_question.py
@@ -10,10 +10,9 @@ from pydantic_ai.messages import (
 )
 from textual.app import ComposeResult
 from textual.widget import Widget
-from textual.widgets import Markdown
 
 from shotgun.agents.messages import InternalPromptPart
-from shotgun.tui.markdown import create_markdown_parser
+from shotgun.tui.markdown import Markdown
 
 
 class UserQuestionWidget(Widget):
@@ -26,10 +25,10 @@ class UserQuestionWidget(Widget):
     def compose(self) -> ComposeResult:
         self.display = self.item is not None
         if self.item is None:
-            yield Markdown(markdown="", parser_factory=create_markdown_parser)
+            yield Markdown(markdown="")
         else:
             prompt = self.format_prompt_parts(self.item.parts)
-            yield Markdown(markdown=prompt, parser_factory=create_markdown_parser)
+            yield Markdown(markdown=prompt)
 
     def format_prompt_parts(self, parts: Sequence[ModelRequestPart]) -> str:
         """Format user prompt parts into markdown."""

--- a/src/shotgun/tui/screens/chat_screen/welcome_message.py
+++ b/src/shotgun/tui/screens/chat_screen/welcome_message.py
@@ -11,10 +11,10 @@ from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.message import Message
 from textual.widget import Widget
-from textual.widgets import Markdown, Static
+from textual.widgets import Static
 
 from shotgun.logging_config import get_logger
-from shotgun.tui.markdown import create_markdown_parser
+from shotgun.tui.markdown import Markdown
 
 logger = get_logger(__name__)
 
@@ -285,9 +285,7 @@ class WelcomeWidget(Widget):
             'Once you have all of that you can either use Shotgun Autopilot ("/" + autopilot) to automate implementing '
             "with Claude Code or just prompt your AI Coding Agent directly."
         )
-        yield Markdown(
-            intro, classes="welcome-intro", parser_factory=create_markdown_parser
-        )
+        yield Markdown(intro, classes="welcome-intro")
 
         # Getting started link
         with Horizontal(classes="getting-started-row"):

--- a/src/shotgun/tui/screens/github_issue.py
+++ b/src/shotgun/tui/screens/github_issue.py
@@ -6,9 +6,9 @@ from textual import on
 from textual.app import ComposeResult
 from textual.containers import Container, Vertical
 from textual.screen import ModalScreen
-from textual.widgets import Button, Label, Markdown, Static
+from textual.widgets import Button, Label, Static
 
-from shotgun.tui.markdown import create_markdown_parser
+from shotgun.tui.markdown import Markdown
 
 
 class GitHubIssueScreen(ModalScreen[None]):
@@ -92,7 +92,6 @@ We review all issues and will respond as soon as possible!
 - Be specific about what you'd like for feature requests
                     """,
                     id="issue-markdown",
-                    parser_factory=create_markdown_parser,
                 )
             with Vertical(id="issue-buttons"):
                 yield Label("", id="issue-status")

--- a/src/shotgun/tui/screens/pipx_migration.py
+++ b/src/shotgun/tui/screens/pipx_migration.py
@@ -9,10 +9,10 @@ from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, VerticalScroll
 from textual.events import Resize
 from textual.screen import ModalScreen
-from textual.widgets import Button, Label, Markdown
+from textual.widgets import Button, Label
 
 from shotgun.tui.layout import COMPACT_HEIGHT_THRESHOLD
-from shotgun.tui.markdown import create_markdown_parser
+from shotgun.tui.markdown import Markdown
 
 if TYPE_CHECKING:
     pass
@@ -131,8 +131,7 @@ Or install permanently: `uv tool install shotgun-sh`
 **Discord:** https://discord.gg/5RmY6J2N7s
 
 **Full Migration Guide:** https://github.com/shotgun-sh/shotgun/blob/main/docs/PIPX_MIGRATION.md
-""",
-                    parser_factory=create_markdown_parser,
+"""
                 )
 
                 with Container(id="buttons-container"):

--- a/src/shotgun/tui/screens/provider_config.py
+++ b/src/shotgun/tui/screens/provider_config.py
@@ -18,7 +18,6 @@ from textual.widgets import (
     Label,
     ListItem,
     ListView,
-    Markdown,
     Static,
     TabbedContent,
     TabPane,
@@ -29,7 +28,7 @@ from shotgun.agents.config.tier_detection import AnthropicTier, detect_anthropic
 from shotgun.logging_config import get_logger
 from shotgun.posthog_telemetry import track_event
 from shotgun.tui.layout import COMPACT_HEIGHT_THRESHOLD
-from shotgun.tui.markdown import create_markdown_parser
+from shotgun.tui.markdown import Markdown
 from shotgun.tui.services.ollama import (
     OLLAMA_DOWNLOAD_URL,
     OllamaStatus,
@@ -249,7 +248,6 @@ class ProviderConfigScreen(Screen[None]):
                 yield Markdown(
                     "Don't have an API Key? Use these links to get one: [OpenAI](https://platform.openai.com/api-keys) | [Anthropic](https://console.anthropic.com) | [Google Gemini](https://aistudio.google.com)",
                     id="provider-links",
-                    parser_factory=create_markdown_parser,
                 )
                 yield ListView(*self._build_provider_items_sync(), id="provider-list")
                 yield Input(
@@ -287,7 +285,6 @@ class ProviderConfigScreen(Screen[None]):
                     "Context7 provides up-to-date documentation for libraries as MCP tools. "
                     "Get a free API key to enable documentation-aware specs.",
                     id="context7-info",
-                    parser_factory=create_markdown_parser,
                 )
                 with Horizontal(id="context7-link-actions"):
                     yield Button(

--- a/src/shotgun/tui/screens/shotgun_auth.py
+++ b/src/shotgun/tui/screens/shotgun_auth.py
@@ -11,7 +11,7 @@ from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.events import Resize
 from textual.screen import Screen
-from textual.widgets import Button, Label, Markdown, Static
+from textual.widgets import Button, Label, Static
 from textual.worker import Worker, WorkerState
 
 from shotgun.agents.config import ConfigManager
@@ -23,7 +23,7 @@ from shotgun.shotgun_web import (
 )
 from shotgun.shotgun_web.constants import DEFAULT_POLL_INTERVAL_SECONDS
 from shotgun.tui.layout import COMPACT_HEIGHT_THRESHOLD
-from shotgun.tui.markdown import create_markdown_parser
+from shotgun.tui.markdown import Markdown
 
 if TYPE_CHECKING:
     from ..app import ShotgunApp
@@ -130,7 +130,7 @@ class ShotgunAuthScreen(Screen[bool]):
 
         with Vertical(id="content"):
             yield Label("Initializing...", id="status")
-            yield Markdown("", id="auth-url", parser_factory=create_markdown_parser)
+            yield Markdown("", id="auth-url")
             yield Markdown(
                 "**Instructions:**\n"
                 "1. A browser window will open automatically\n"
@@ -138,7 +138,6 @@ class ShotgunAuthScreen(Screen[bool]):
                 "3. Complete payment if required\n"
                 "4. This window will automatically detect completion",
                 id="instructions",
-                parser_factory=create_markdown_parser,
             )
 
         with Vertical(id="actions"):

--- a/src/shotgun/tui/screens/tier1_warning_modal.py
+++ b/src/shotgun/tui/screens/tier1_warning_modal.py
@@ -3,9 +3,9 @@
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.screen import ModalScreen
-from textual.widgets import Button, Label, Markdown
+from textual.widgets import Button, Label
 
-from shotgun.tui.markdown import create_markdown_parser
+from shotgun.tui.markdown import Markdown
 
 
 class Tier1WarningModal(ModalScreen[bool]):
@@ -64,7 +64,6 @@ Shotgun's multi-agent workflow will hit these limits almost immediately, resulti
 2. **Upgrade your Anthropic account** to Tier 2 or higher
 """,
                 id="message",
-                parser_factory=create_markdown_parser,
             )
             with Vertical(id="button-container"):
                 yield Button("I Understand", variant="primary", id="understand-button")

--- a/src/shotgun/tui/screens/welcome.py
+++ b/src/shotgun/tui/screens/welcome.py
@@ -10,10 +10,10 @@ from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
 from textual.events import Resize
 from textual.screen import Screen
-from textual.widgets import Button, Markdown, Static
+from textual.widgets import Button, Static
 
 from shotgun.tui.layout import TINY_HEIGHT_THRESHOLD
-from shotgun.tui.markdown import create_markdown_parser
+from shotgun.tui.markdown import Markdown
 from shotgun.tui.services.ollama import has_ollama_models_available
 
 if TYPE_CHECKING:
@@ -202,7 +202,7 @@ class WelcomeScreen(Screen[None]):
                     if config.migration_backup_path:
                         backup_msg += f"\n\nYour old configuration (including API keys) has been backed up to:\n{config.migration_backup_path}"
                     backup_msg += "\n\nYou'll need to reconfigure Shotgun by choosing an option below."
-                    yield Markdown(backup_msg, parser_factory=create_markdown_parser)
+                    yield Markdown(backup_msg)
 
         with Container(id="options-container"):
             with Horizontal(id="options"):
@@ -215,7 +215,6 @@ class WelcomeScreen(Screen[None]):
                         "• We'll pick the optimal models to give you the best "
                         "experience for things like web search, codebase indexing",
                         classes="option-benefits",
-                        parser_factory=create_markdown_parser,
                     )
                     yield Button(
                         "Sign Up for/Use your Shotgun Account",
@@ -232,7 +231,6 @@ class WelcomeScreen(Screen[None]):
                         "• 100% Supported\n"
                         "• Use your existing API keys from OpenAI, Anthropic, or Google",
                         classes="option-benefits",
-                        parser_factory=create_markdown_parser,
                     )
                     yield Button(
                         "Configure API Keys",
@@ -250,7 +248,6 @@ class WelcomeScreen(Screen[None]):
                         "• Private - data stays on your computer\n"
                         "• Drafting mode only",
                         classes="option-benefits",
-                        parser_factory=create_markdown_parser,
                     )
                     yield Button(
                         "Set Up Ollama",

--- a/test/unit/tui/test_markdown_parser.py
+++ b/test/unit/tui/test_markdown_parser.py
@@ -1,13 +1,13 @@
-"""Tests for the custom markdown parser factory."""
+"""Tests for the custom Markdown widget with disabled fuzzy linking."""
 
 import pytest
 
-from shotgun.tui.markdown import create_markdown_parser
+from shotgun.tui.markdown import Markdown, _create_markdown_parser
 
 
 def test_filenames_not_linkified():
     """Filenames like specification.md should not be converted to links."""
-    parser = create_markdown_parser()
+    parser = _create_markdown_parser()
     tokens = parser.parse("Check specification.md for details")
     inline_tokens = [t for t in tokens if t.children]
     for token in inline_tokens:
@@ -19,7 +19,7 @@ def test_filenames_not_linkified():
 
 def test_various_filenames_not_linkified():
     """Common filenames with TLD-like extensions should not be linkified."""
-    parser = create_markdown_parser()
+    parser = _create_markdown_parser()
     filenames = ["tasks.md", "README.md", "config.py", "index.js", "style.css"]
     for filename in filenames:
         tokens = parser.parse(f"Updated {filename} with changes")
@@ -33,7 +33,7 @@ def test_various_filenames_not_linkified():
 
 def test_explicit_https_urls_still_linkified():
     """Explicit https:// URLs should still be converted to links."""
-    parser = create_markdown_parser()
+    parser = _create_markdown_parser()
     tokens = parser.parse("Visit https://example.com for details")
     inline_tokens = [t for t in tokens if t.children]
     linkify_found = any(
@@ -46,7 +46,7 @@ def test_explicit_https_urls_still_linkified():
 
 def test_explicit_http_urls_still_linkified():
     """Explicit http:// URLs should still be converted to links."""
-    parser = create_markdown_parser()
+    parser = _create_markdown_parser()
     tokens = parser.parse("Visit http://example.com for details")
     inline_tokens = [t for t in tokens if t.children]
     linkify_found = any(
@@ -59,7 +59,7 @@ def test_explicit_http_urls_still_linkified():
 
 def test_markdown_links_still_work():
     """Standard markdown [text](url) links should still be parsed."""
-    parser = create_markdown_parser()
+    parser = _create_markdown_parser()
     tokens = parser.parse("See [docs](https://example.com) for details")
     inline_tokens = [t for t in tokens if t.children]
     link_found = any(
@@ -81,7 +81,7 @@ def test_markdown_links_still_work():
 )
 def test_bare_domain_like_names_not_linkified(text: str):
     """Bare words with TLD-like extensions should not be linkified."""
-    parser = create_markdown_parser()
+    parser = _create_markdown_parser()
     tokens = parser.parse(f"See {text} for details")
     inline_tokens = [t for t in tokens if t.children]
     for token in inline_tokens:
@@ -89,3 +89,10 @@ def test_bare_domain_like_names_not_linkified(text: str):
             assert child.markup != "linkify", (
                 f"'{text}' was incorrectly linkified"
             )
+
+
+def test_markdown_subclass_is_drop_in_replacement():
+    """Our Markdown subclass should be a proper subclass of Textual's Markdown."""
+    from textual.widgets import Markdown as TextualMarkdown
+
+    assert issubclass(Markdown, TextualMarkdown)


### PR DESCRIPTION
## Summary
- Filenames like `specification.md` and `tasks.md` were being rendered as clickable URLs in the TUI because the markdown-it-py parser's `gfm-like` preset enables linkify with fuzzy link detection, treating file extensions (`.md`, `.io`, `.ai`) as top-level domains
- Added a custom `create_markdown_parser()` factory in `src/shotgun/tui/markdown.py` that disables `fuzzy_link` and `fuzzy_email` while preserving linkification for explicit URLs (`https://...`, `http://...`)
- Updated all 11 Markdown widget instantiations across the TUI to use the custom parser factory

## Test plan
- [x] 9 unit tests covering filenames not linkified, explicit URLs still linkified, and markdown links still working
- [x] mypy passes (281 files, no issues)
- [x] ruff passes on all modified files
- [x] All 294 existing TUI unit tests pass
- [x] All 7 smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)