### PR TITLE
fix: use provider-aware cache settings instead of hardcoded Anthropic settings

### DIFF
--- a/src/shotgun/agents/common.py
+++ b/src/shotgun/agents/common.py
@@ -27,7 +27,7 @@ from shotgun.agents.config.constants import (
     WEB_SEARCH_STOP_THRESHOLD,
     WEB_SEARCH_WARNING_THRESHOLD,
 )
-from shotgun.agents.config.models import ANTHROPIC_SUB_AGENT_CACHE_SETTINGS
+from shotgun.agents.config.models import get_cache_settings
 from shotgun.agents.models import (
     AgentResponse,
     AgentSystemPromptContext,
@@ -291,6 +291,7 @@ async def create_base_agent(
         ctx = ProcessorContext(deps)
         return await token_limit_compactor(ctx, messages)
 
+    cache_settings = get_cache_settings(model_config.provider, is_router=False)
     agent = Agent(
         model,
         output_type=AgentResponse,
@@ -299,7 +300,7 @@ async def create_base_agent(
         history_processors=[history_processor],
         retries=3,  # Default retry count for tool calls and output validation
         toolsets=mcp_servers or None,
-        model_settings=ANTHROPIC_SUB_AGENT_CACHE_SETTINGS,
+        model_settings=cache_settings,
     )
 
     # System prompt function is stored in deps and will be called manually in run_agent

--- a/src/shotgun/agents/config/models.py
+++ b/src/shotgun/agents/config/models.py
@@ -7,6 +7,8 @@ from typing import TypeGuard
 from pydantic import BaseModel, Field, PrivateAttr, SecretStr
 from pydantic_ai.models import Model
 from pydantic_ai.models.anthropic import AnthropicModelSettings
+from pydantic_ai.models.openai import OpenAIChatModelSettings
+from pydantic_ai.settings import ModelSettings
 
 
 class ProviderType(StrEnum):
@@ -25,6 +27,7 @@ class KeyProvider(StrEnum):
     SHOTGUN = "shotgun"  # Shotgun Account (unified LiteLLM proxy)
 
 
+# Anthropic cache settings - uses Anthropic-specific cache control headers
 ANTHROPIC_ROUTER_CACHE_SETTINGS = AnthropicModelSettings(
     anthropic_cache_tool_definitions="1h",
     anthropic_cache_instructions="1h",
@@ -36,6 +39,28 @@ ANTHROPIC_SUB_AGENT_CACHE_SETTINGS = AnthropicModelSettings(
     anthropic_cache_instructions="1h",
     anthropic_cache_messages="5m",
 )
+
+# OpenAI cache settings - relies on OpenAI's automatic in-memory prompt caching
+# See: https://platform.openai.com/docs/guides/prompt-caching
+OPENAI_CACHE_SETTINGS = OpenAIChatModelSettings()
+
+
+def get_cache_settings(provider: "ProviderType", is_router: bool = False) -> ModelSettings:
+    """Get the appropriate cache settings for the given provider.
+
+    Args:
+        provider: The LLM provider type.
+        is_router: Whether this is for the router agent (longer cache TTL).
+
+    Returns:
+        Provider-appropriate model settings with caching configured.
+    """
+    if provider == ProviderType.ANTHROPIC:
+        return ANTHROPIC_ROUTER_CACHE_SETTINGS if is_router else ANTHROPIC_SUB_AGENT_CACHE_SETTINGS
+    elif provider == ProviderType.OPENAI:
+        return OPENAI_CACHE_SETTINGS
+    else:
+        return ModelSettings()
 
 
 class ModelName(StrEnum):

--- a/src/shotgun/agents/router/router.py
+++ b/src/shotgun/agents/router/router.py
@@ -19,7 +19,7 @@ from shotgun.agents.common import (
     run_agent,
 )
 from shotgun.agents.config import ProviderType, get_provider_model
-from shotgun.agents.config.models import ANTHROPIC_ROUTER_CACHE_SETTINGS
+from shotgun.agents.config.models import get_cache_settings
 from shotgun.agents.conversation.history import token_limit_compactor
 from shotgun.agents.models import AgentResponse, AgentRuntimeOptions, AgentType
 from shotgun.agents.router.models import RouterDeps
@@ -115,6 +115,7 @@ async def create_router_agent(
     ]
 
     # Create the agent with delegation tools that have prepare functions
+    cache_settings = get_cache_settings(model_config.provider, is_router=True)
     agent: Agent[RouterDeps, AgentResponse] = Agent(
         model,
         output_type=AgentResponse,
@@ -123,7 +124,7 @@ async def create_router_agent(
         history_processors=[history_processor],
         retries=3,
         tools=delegation_tools,
-        model_settings=ANTHROPIC_ROUTER_CACHE_SETTINGS,
+        model_settings=cache_settings,
     )
 
     # Register plan management tools (router-specific, always available)

--- a/test/unit/agents/config/test_models.py
+++ b/test/unit/agents/config/test_models.py
@@ -1,12 +1,16 @@
 """Tests for agents.config.models module."""
 
 from shotgun.agents.config.models import (
+    ANTHROPIC_ROUTER_CACHE_SETTINGS,
+    ANTHROPIC_SUB_AGENT_CACHE_SETTINGS,
     MODEL_SPECS,
+    OPENAI_CACHE_SETTINGS,
     KeyProvider,
     ModelConfig,
     ModelName,
     OllamaConfig,
     ProviderType,
+    get_cache_settings,
 )
 
 
@@ -105,3 +109,42 @@ def test_model_config_with_base_url():
     assert config.base_url == "http://localhost:11434/v1"
     assert config.name == "qwen3:32b"
     assert config.provider == ProviderType.OPENAI_COMPATIBLE
+
+
+def test_get_cache_settings_anthropic_router():
+    """Test that Anthropic router gets 1h message cache settings."""
+    settings = get_cache_settings(ProviderType.ANTHROPIC, is_router=True)
+    assert settings is ANTHROPIC_ROUTER_CACHE_SETTINGS
+    assert settings["anthropic_cache_messages"] == "1h"
+
+
+def test_get_cache_settings_anthropic_sub_agent():
+    """Test that Anthropic sub-agents get 5m message cache settings."""
+    settings = get_cache_settings(ProviderType.ANTHROPIC, is_router=False)
+    assert settings is ANTHROPIC_SUB_AGENT_CACHE_SETTINGS
+    assert settings["anthropic_cache_messages"] == "5m"
+
+
+def test_get_cache_settings_openai():
+    """Test that OpenAI models get OpenAI-specific cache settings."""
+    settings = get_cache_settings(ProviderType.OPENAI, is_router=True)
+    assert settings is OPENAI_CACHE_SETTINGS
+
+
+def test_get_cache_settings_openai_same_for_router_and_sub_agent():
+    """Test that OpenAI cache settings are the same regardless of is_router."""
+    router_settings = get_cache_settings(ProviderType.OPENAI, is_router=True)
+    sub_agent_settings = get_cache_settings(ProviderType.OPENAI, is_router=False)
+    assert router_settings == sub_agent_settings
+
+
+def test_get_cache_settings_google_returns_empty():
+    """Test that Google provider returns empty model settings."""
+    settings = get_cache_settings(ProviderType.GOOGLE)
+    assert settings == {}
+
+
+def test_get_cache_settings_openai_compatible_returns_empty():
+    """Test that OpenAI-compatible provider returns empty model settings."""
+    settings = get_cache_settings(ProviderType.OPENAI_COMPATIBLE)
+    assert settings == {}


### PR DESCRIPTION
## Summary
- Previously, both router and sub-agent creation hardcoded `AnthropicModelSettings` for prompt caching, which were silently ignored for OpenAI models (GPT-5.2 not caching tokens)
- Adds `get_cache_settings(provider, is_router)` helper that returns the appropriate cache settings per provider type
- OpenAI models now use `OpenAIChatModelSettings` to properly participate in OpenAI's automatic in-memory prompt caching

## Test plan
- [x] mypy passes (281 source files)
- [x] ruff passes on changed files
- [x] Smoke tests pass (7/7)
- [x] Unit tests pass (18/18 in config, 12/12 in common)
- [x] 6 new tests for `get_cache_settings` covering all provider/router combinations
- [ ] Verify GPT-5.2 shows cached tokens in `/usage` after a multi-turn conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)