### PR TITLE
fix(conversation): remap custom part_kind values during deserialization to fix --continue

### DIFF
--- a/src/shotgun/agents/conversation/models.py
+++ b/src/shotgun/agents/conversation/models.py
@@ -24,6 +24,38 @@ from .filters import (
 
 SerializedMessage = dict[str, Any]
 
+# Mapping of custom part_kind values to their pydantic-ai base part_kind.
+# Custom subclasses (e.g. SystemStatusPrompt, InternalPromptPart) override
+# part_kind with values that ModelMessagesTypeAdapter doesn't recognise,
+# causing deserialization to fail. Remapping before validation fixes this.
+_CUSTOM_PART_KIND_MAP: dict[str, str] = {
+    "system-status": "user-prompt",  # SystemStatusPrompt -> UserPromptPart
+    "internal-prompt": "user-prompt",  # InternalPromptPart -> UserPromptPart
+}
+
+
+def _sanitize_parts(messages: list[SerializedMessage]) -> list[SerializedMessage]:
+    """Remap custom part_kind values so ModelMessagesTypeAdapter can deserialize them."""
+    sanitized: list[SerializedMessage] = []
+    for msg in messages:
+        parts = msg.get("parts")
+        if not parts:
+            sanitized.append(msg)
+            continue
+        new_parts = []
+        changed = False
+        for part in parts:
+            pk = part.get("part_kind")
+            if pk in _CUSTOM_PART_KIND_MAP:
+                part = {**part, "part_kind": _CUSTOM_PART_KIND_MAP[pk]}
+                changed = True
+            new_parts.append(part)
+        if changed:
+            sanitized.append({**msg, "parts": new_parts})
+        else:
+            sanitized.append(msg)
+    return sanitized
+
 
 class FileReference(BaseModel):
     """Placeholder for binary content that was loaded from a file.
@@ -162,8 +194,9 @@ class ConversationHistory(BaseModel):
         if not self.agent_history:
             return []
 
-        # Deserialize from JSON format back to ModelMessage objects
-        return ModelMessagesTypeAdapter.validate_python(self.agent_history)
+        # Sanitize custom part_kind values before deserialization
+        sanitized = _sanitize_parts(self.agent_history)
+        return ModelMessagesTypeAdapter.validate_python(sanitized)
 
     def get_ui_messages(self) -> list[ModelMessage | HintMessage | WelcomeMessage]:
         """Get ui_history as a list of Model, hint, or welcome messages."""
@@ -189,7 +222,9 @@ class ConversationHistory(BaseModel):
             payload = item
             if isinstance(payload, dict):
                 payload = {k: v for k, v in payload.items() if k != "message_type"}
-            deserialized = ModelMessagesTypeAdapter.validate_python([payload])
+            deserialized = ModelMessagesTypeAdapter.validate_python(
+                _sanitize_parts([payload])
+            )
             messages.append(deserialized[0])
 
         return messages

--- a/test/unit/test_conversation_history.py
+++ b/test/unit/test_conversation_history.py
@@ -258,6 +258,75 @@ def test_conversation_history_ui_messages_with_hints():
     assert isinstance(retrieved[2], HintMessage)
 
 
+def test_get_agent_messages_with_custom_part_kinds():
+    """Test that custom part_kind values (system-status, internal-prompt) are handled."""
+    history = ConversationHistory()
+    # Manually set agent_history with a system-status part_kind
+    # (as saved by SystemStatusPrompt)
+    history.agent_history = [
+        {
+            "parts": [
+                {"content": "Hello", "part_kind": "user-prompt"},
+                {
+                    "content": "Status info",
+                    "part_kind": "system-status",
+                    "prompt_type": "status",
+                },
+            ],
+            "kind": "request",
+        },
+        {
+            "parts": [{"content": "Response", "part_kind": "text"}],
+            "kind": "response",
+        },
+    ]
+
+    messages = history.get_agent_messages()
+    assert len(messages) == 2
+    assert isinstance(messages[0], ModelRequest)
+    assert isinstance(messages[1], ModelResponse)
+
+
+def test_get_agent_messages_with_internal_prompt_part_kind():
+    """Test that internal-prompt part_kind is remapped to user-prompt."""
+    history = ConversationHistory()
+    history.agent_history = [
+        {
+            "parts": [
+                {"content": "Internal continuation", "part_kind": "internal-prompt"},
+            ],
+            "kind": "request",
+        },
+    ]
+
+    messages = history.get_agent_messages()
+    assert len(messages) == 1
+    assert isinstance(messages[0], ModelRequest)
+
+
+def test_get_ui_messages_with_custom_part_kinds():
+    """Test that custom part_kind values are handled in UI messages."""
+    history = ConversationHistory()
+    history.ui_history = [
+        {
+            "parts": [
+                {"content": "Hello", "part_kind": "user-prompt"},
+                {
+                    "content": "Status",
+                    "part_kind": "system-status",
+                    "prompt_type": "status",
+                },
+            ],
+            "kind": "request",
+            "message_type": "model",
+        },
+    ]
+
+    messages = history.get_ui_messages()
+    assert len(messages) == 1
+    assert isinstance(messages[0], ModelRequest)
+
+
 def test_filter_orphaned_tool_responses_removes_orphans():
     """Test that orphaned tool responses are filtered out."""
     # Create messages with orphaned tool response (no matching tool call)


### PR DESCRIPTION
## Summary
- `shotgun --continue` was broken because conversation deserialization failed silently
- Custom message part subclasses (`SystemStatusPrompt`, `InternalPromptPart`) override `part_kind` with values (`system-status`, `internal-prompt`) that pydantic-ai's `ModelMessagesTypeAdapter` doesn't recognize
- Added `_sanitize_parts()` to remap custom `part_kind` values back to their base types before deserialization

## Test plan
- [x] Added 3 unit tests for custom part_kind handling in both agent and UI message deserialization
- [x] All 21 conversation history tests pass
- [x] All 7 smoke tests pass
- [x] mypy and ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)