### PR TITLE
docs(readme): add BetterStack status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 [![Website](https://img.shields.io/badge/-shotgun.sh-5865F2?style=social&logo=safari&logoColor=5865F2)](https://shotgun.sh)      [![Follow @ShotgunCLI](https://img.shields.io/badge/Follow%20@ShotgunCLI-1DA1F2?style=social&logo=x&logoColor=000000)](https://x.com/ShotgunCLI)    [![YouTube](https://img.shields.io/badge/-@shotgunCLI-FF0000?style=social&logo=youtube&logoColor=red)](https://www.youtube.com/@shotgunCLI)
 
-LLM Proxy Status: [![Better Stack Badge](https://uptime.betterstack.com/status-badges/v2/monitor/272wo.svg)](https://uptime.betterstack.com/?utm_source=status_badge) API Status: [![Better Stack Badge](https://uptime.betterstack.com/status-badges/v2/monitor/272wq.svg)](https://uptime.betterstack.com/?utm_source=status_badge)
+LLM Proxy Status: [![Better Stack Badge](https://uptime.betterstack.com/status-badges/v2/monitor/272wo.svg)](https://status.shotgun.sh/) API Status: [![Better Stack Badge](https://uptime.betterstack.com/status-badges/v2/monitor/272wq.svg)](https://status.shotgun.sh/)
 
 </div>
 


### PR DESCRIPTION
## Summary
- Adds LLM Proxy Status and API Status badges from BetterStack to the README header
- Badges link to the uptime dashboard and show live status

## Test plan
- [ ] Verify badges render correctly on the GitHub README
- [ ] Confirm badge images load from BetterStack

🤖 Generated with [Claude Code](https://claude.com/claude-code)