### PR TITLE
feat(agents): upgrade Claude models from 4.5 to 4.6

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -6,16 +6,16 @@ Evaluation framework for testing Shotgun agent behaviors deterministically.
 
 ```bash
 # Run the router smoke test with a specific model
-uv run python -m evals.runner --suite router_smoke --model claude-opus-4-5
+uv run python -m evals.runner --suite router_smoke --model claude-opus-4-6
 
 # Run without LLM judge (faster, deterministic only)
-uv run python -m evals.runner --suite router_smoke --model claude-opus-4-5 --no-judge
+uv run python -m evals.runner --suite router_smoke --model claude-opus-4-6 --no-judge
 
 # Run a single test case
-uv run python -m evals.runner --case vague_prompt_clarifying_questions --model claude-opus-4-5
+uv run python -m evals.runner --case vague_prompt_clarifying_questions --model claude-opus-4-6
 
 # Compare multiple models
-uv run python -m evals.runner --suite router_smoke --model claude-opus-4-5 --model gpt-5.1 --model gemini-3-pro-preview
+uv run python -m evals.runner --suite router_smoke --model claude-opus-4-6 --model gpt-5.1 --model gemini-3-pro-preview
 ```
 
 ## Output Formats

--- a/evals/judges/file_requests_judge.py
+++ b/evals/judges/file_requests_judge.py
@@ -181,7 +181,7 @@ class FileRequestsJudge:
         """
         self.model_config = model_config or JudgeModelConfig(
             provider=JudgeProviderType.ANTHROPIC,
-            model_name="claude-opus-4-5-20251101",
+            model_name="claude-opus-4-6",
             temperature=0.2,  # Low temperature for consistency
             max_tokens=2000,
         )

--- a/evals/judges/router_quality_judge.py
+++ b/evals/judges/router_quality_judge.py
@@ -140,7 +140,7 @@ class RouterQualityJudge:
         """
         self.model_config = model_config or JudgeModelConfig(
             provider=JudgeProviderType.ANTHROPIC,
-            model_name="claude-opus-4-5-20251101",
+            model_name="claude-opus-4-6",
             temperature=0.2,  # Low temperature for consistency
             max_tokens=2000,
         )

--- a/evals/runner.py
+++ b/evals/runner.py
@@ -9,7 +9,7 @@ Usage:
     python -m evals.runner --suite router_core --report console
     python -m evals.runner --case local_models_clarifying_questions
     python -m evals.runner --tag smoke
-    python -m evals.runner --suite router_smoke --model claude-sonnet-4-5
+    python -m evals.runner --suite router_smoke --model claude-sonnet-4-6
     python -m evals.runner --suite router_smoke --models anthropic
 """
 
@@ -553,8 +553,8 @@ Examples:
     python -m evals.runner --tag smoke
 
 Model comparison examples:
-    python -m evals.runner --suite router_smoke --model claude-sonnet-4-5
-    python -m evals.runner --suite router_smoke --model claude-sonnet-4-5 --model gpt-5.1
+    python -m evals.runner --suite router_smoke --model claude-sonnet-4-6
+    python -m evals.runner --suite router_smoke --model claude-sonnet-4-6 --model gpt-5.1
     python -m evals.runner --suite router_smoke --models anthropic
     python -m evals.runner --suite router_smoke --models fast
 

--- a/src/shotgun/agents/autopilot/models.py
+++ b/src/shotgun/agents/autopilot/models.py
@@ -22,8 +22,8 @@ class ClaudeModel(StrEnum):
     """Available Claude models for autopilot execution."""
 
     DEFAULT = ""  # Use Claude Code's default
-    OPUS_4_5 = "claude-opus-4-5-20251101"
-    SONNET_4_5 = "claude-sonnet-4-5-20250514"
+    OPUS_4_6 = "claude-opus-4-6"
+    SONNET_4_6 = "claude-sonnet-4-6"
     HAIKU_4_5 = "claude-haiku-4-5-20250514"
 
     @classmethod
@@ -31,8 +31,8 @@ class ClaudeModel(StrEnum):
         """Get the display name for a model."""
         names = {
             cls.DEFAULT: "Default",
-            cls.OPUS_4_5: "Opus 4.5",
-            cls.SONNET_4_5: "Sonnet 4.5",
+            cls.OPUS_4_6: "Opus 4.6",
+            cls.SONNET_4_6: "Sonnet 4.6",
             cls.HAIKU_4_5: "Haiku 4.5",
         }
         return names.get(model, model.value)

--- a/src/shotgun/agents/autopilot/stage_monitor.py
+++ b/src/shotgun/agents/autopilot/stage_monitor.py
@@ -1,6 +1,6 @@
 """Stage monitor agent for intelligent autopilot orchestration.
 
-Uses the main model (e.g. Opus 4.5) with read-only file tools to verify
+Uses the main model (e.g. Opus 4.6) with read-only file tools to verify
 Claude Code's output against actual files on disk and decide what to do next.
 """
 
@@ -61,7 +61,7 @@ class MonitorDeps(BaseModel):
 class StageMonitor:
     """Monitors Claude Code output and decides next orchestration action.
 
-    Uses the main model (e.g. Opus 4.5) with read-only file tools to:
+    Uses the main model (e.g. Opus 4.6) with read-only file tools to:
     1. Read tasks.md to verify actual task completion state
     2. Read specification.md and plan.md for context
     3. Compare Claude Code's claims against reality

--- a/src/shotgun/agents/config/manager.py
+++ b/src/shotgun/agents/config/manager.py
@@ -54,7 +54,7 @@ class ConfigMigrationError(Exception):
 ProviderConfig = OpenAIConfig | AnthropicConfig | GoogleConfig | ShotgunAccountConfig
 
 # Current config version
-CURRENT_CONFIG_VERSION = 9
+CURRENT_CONFIG_VERSION = 10
 
 # Backup directory name
 BACKUP_DIR_NAME = "backup"
@@ -270,6 +270,35 @@ def _migrate_v8_to_v9(data: dict[str, Any]) -> dict[str, Any]:
     return data
 
 
+def _migrate_v9_to_v10(data: dict[str, Any]) -> dict[str, Any]:
+    """Migrate config from version 9 to version 10.
+
+    Changes:
+    - Rename Claude model references from 4.5 to 4.6
+
+    Args:
+        data: Config data dict at version 9
+
+    Returns:
+        Modified config data dict at version 10
+    """
+    model_renames = {
+        "claude-opus-4-5": "claude-opus-4-6",
+        "claude-sonnet-4-5": "claude-sonnet-4-6",
+    }
+    selected = data.get("selected_model")
+    if selected in model_renames:
+        data["selected_model"] = model_renames[selected]
+        logger.info(
+            "Migrated config v9->v10: renamed selected_model %s -> %s",
+            selected,
+            model_renames[selected],
+        )
+
+    data["config_version"] = 10
+    return data
+
+
 def _apply_migrations(data: dict[str, Any]) -> dict[str, Any]:
     """Apply all necessary migrations to bring config to current version.
 
@@ -294,6 +323,7 @@ def _apply_migrations(data: dict[str, Any]) -> dict[str, Any]:
         6: _migrate_v6_to_v7,
         7: _migrate_v7_to_v8,
         8: _migrate_v8_to_v9,
+        9: _migrate_v9_to_v10,
     }
 
     # Apply migrations sequentially

--- a/src/shotgun/agents/config/models.py
+++ b/src/shotgun/agents/config/models.py
@@ -43,8 +43,8 @@ class ModelName(StrEnum):
 
     GPT_5_1 = "gpt-5.1"
     GPT_5_2 = "gpt-5.2"
-    CLAUDE_OPUS_4_5 = "claude-opus-4-5"
-    CLAUDE_SONNET_4_5 = "claude-sonnet-4-5"
+    CLAUDE_OPUS_4_6 = "claude-opus-4-6"
+    CLAUDE_SONNET_4_6 = "claude-sonnet-4-6"
     CLAUDE_HAIKU_4_5 = "claude-haiku-4-5"
     GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite"
     GEMINI_3_PRO_PREVIEW = "gemini-3-pro-preview"
@@ -61,7 +61,7 @@ class ModelSpec(BaseModel):
     litellm_proxy_model_name: (
         str  # LiteLLM format (e.g., "openai/gpt-5", "gemini/gemini-2-pro")
     )
-    short_name: str  # Display name for UI (e.g., "Sonnet 4.5", "GPT-5")
+    short_name: str  # Display name for UI (e.g., "Sonnet 4.6", "GPT-5")
 
 
 class ModelConfig(BaseModel):
@@ -168,13 +168,13 @@ MODEL_SPECS: dict[ModelName, ModelSpec] = {
         litellm_proxy_model_name="openai/gpt-5.2",
         short_name="GPT-5.2",
     ),
-    ModelName.CLAUDE_SONNET_4_5: ModelSpec(
-        name=ModelName.CLAUDE_SONNET_4_5,
+    ModelName.CLAUDE_SONNET_4_6: ModelSpec(
+        name=ModelName.CLAUDE_SONNET_4_6,
         provider=ProviderType.ANTHROPIC,
         max_input_tokens=200_000,
         max_output_tokens=16_000,
-        litellm_proxy_model_name="anthropic/claude-sonnet-4-5",
-        short_name="Sonnet 4.5",
+        litellm_proxy_model_name="anthropic/claude-sonnet-4-6",
+        short_name="Sonnet 4.6",
     ),
     ModelName.CLAUDE_HAIKU_4_5: ModelSpec(
         name=ModelName.CLAUDE_HAIKU_4_5,
@@ -184,13 +184,13 @@ MODEL_SPECS: dict[ModelName, ModelSpec] = {
         litellm_proxy_model_name="anthropic/claude-haiku-4-5",
         short_name="Haiku 4.5",
     ),
-    ModelName.CLAUDE_OPUS_4_5: ModelSpec(
-        name=ModelName.CLAUDE_OPUS_4_5,
+    ModelName.CLAUDE_OPUS_4_6: ModelSpec(
+        name=ModelName.CLAUDE_OPUS_4_6,
         provider=ProviderType.ANTHROPIC,
         max_input_tokens=200_000,
         max_output_tokens=64_000,
-        litellm_proxy_model_name="anthropic/claude-opus-4-5",
-        short_name="Opus 4.5",
+        litellm_proxy_model_name="anthropic/claude-opus-4-6",
+        short_name="Opus 4.6",
     ),
     ModelName.GEMINI_2_5_FLASH_LITE: ModelSpec(
         name=ModelName.GEMINI_2_5_FLASH_LITE,
@@ -221,7 +221,7 @@ MODEL_SPECS: dict[ModelName, ModelSpec] = {
 # Default model for each provider (used when auto-selecting models)
 DEFAULT_PROVIDER_MODELS: dict[ProviderType, ModelName] = {
     ProviderType.OPENAI: ModelName.GPT_5_2,
-    ProviderType.ANTHROPIC: ModelName.CLAUDE_OPUS_4_5,
+    ProviderType.ANTHROPIC: ModelName.CLAUDE_OPUS_4_6,
     ProviderType.GOOGLE: ModelName.GEMINI_3_PRO_PREVIEW,
 }
 
@@ -229,8 +229,8 @@ DEFAULT_PROVIDER_MODELS: dict[ProviderType, ModelName] = {
 # Maps expensive models to cheaper alternatives from the same provider
 SUB_AGENT_MODEL_MAPPINGS: dict[ModelName, ModelName] = {
     # Anthropic: premium models use Haiku for sub-agents
-    ModelName.CLAUDE_OPUS_4_5: ModelName.CLAUDE_HAIKU_4_5,
-    ModelName.CLAUDE_SONNET_4_5: ModelName.CLAUDE_HAIKU_4_5,
+    ModelName.CLAUDE_OPUS_4_6: ModelName.CLAUDE_HAIKU_4_5,
+    ModelName.CLAUDE_SONNET_4_6: ModelName.CLAUDE_HAIKU_4_5,
     # Gemini: Pro uses Flash for sub-agents
     ModelName.GEMINI_3_PRO_PREVIEW: ModelName.GEMINI_3_FLASH_PREVIEW,
     # OpenAI: 5.2 uses 5.1 for sub-agents
@@ -395,7 +395,7 @@ class ShotgunConfig(BaseModel):
     shotgun_instance_id: str = Field(
         description="Unique shotgun instance identifier (also used for anonymous telemetry)",
     )
-    config_version: int = Field(default=9, description="Configuration schema version")
+    config_version: int = Field(default=10, description="Configuration schema version")
     shown_welcome_screen: bool = Field(
         default=False,
         description="Whether the welcome screen has been shown to the user",

--- a/src/shotgun/agents/config/provider.py
+++ b/src/shotgun/agents/config/provider.py
@@ -212,18 +212,18 @@ def get_default_model_for_provider(config: ShotgunConfig) -> ModelName:
     """
     # Priority 1: Shotgun Account
     if _get_api_key(config.shotgun.api_key):
-        return ModelName.CLAUDE_OPUS_4_5
+        return ModelName.CLAUDE_OPUS_4_6
 
     # Priority 2: Individual provider keys
     if _get_api_key(config.anthropic.api_key):
-        return ModelName.CLAUDE_OPUS_4_5
+        return ModelName.CLAUDE_OPUS_4_6
     if _get_api_key(config.openai.api_key):
         return ModelName.GPT_5_2
     if _get_api_key(config.google.api_key):
         return ModelName.GEMINI_3_PRO_PREVIEW
 
     # Fallback: system-wide default
-    return ModelName.CLAUDE_OPUS_4_5
+    return ModelName.CLAUDE_OPUS_4_6
 
 
 @lru_cache(maxsize=_MAX_MODEL_CACHE_SIZE)
@@ -413,7 +413,7 @@ async def get_provider_model(
             # This is important for web search tools that need specific provider APIs
             provider_defaults = {
                 ProviderType.OPENAI: ModelName.GPT_5_2,
-                ProviderType.ANTHROPIC: ModelName.CLAUDE_OPUS_4_5,
+                ProviderType.ANTHROPIC: ModelName.CLAUDE_OPUS_4_6,
                 ProviderType.GOOGLE: ModelName.GEMINI_3_FLASH_PREVIEW,
             }
             # For provider-based requests, use selected ModelName or default
@@ -626,11 +626,11 @@ async def get_provider_model(
                 "Anthropic API key not configured. Set via config or ANTHROPIC_API_KEY env var."
             )
 
-        # Use requested model or default to claude-opus-4-5
-        model_name = requested_model if requested_model else ModelName.CLAUDE_OPUS_4_5
+        # Use requested model or default to claude-opus-4-6
+        model_name = requested_model if requested_model else ModelName.CLAUDE_OPUS_4_6
         # Gracefully fall back if model doesn't exist
         if model_name not in MODEL_SPECS:
-            model_name = ModelName.CLAUDE_OPUS_4_5
+            model_name = ModelName.CLAUDE_OPUS_4_6
 
         # Apply sub-agent model mapping for cost optimization
         if for_sub_agent:

--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -391,7 +391,7 @@ class ChatScreen(Screen[None]):
         """Validate current model is still available, fall back if not.
 
         This handles the case where a user:
-        1. Has a cloud model selected (e.g., Sonnet 4.5)
+        1. Has a cloud model selected (e.g., Sonnet 4.6)
         2. Goes to Provider Setup and removes their API keys
         3. Returns to chat - we need to detect the model is no longer valid
            and fall back to Ollama if available

--- a/src/shotgun/tui/screens/chat_screen/welcome_message.py
+++ b/src/shotgun/tui/screens/chat_screen/welcome_message.py
@@ -102,7 +102,7 @@ async def build_welcome_state() -> WelcomeMessage:
     frontier_model_name = ""
 
     frontier_models = {
-        ModelName.CLAUDE_OPUS_4_5,
+        ModelName.CLAUDE_OPUS_4_6,
         ModelName.GPT_5_2,
         ModelName.GEMINI_3_PRO_PREVIEW,
     }
@@ -112,11 +112,11 @@ async def build_welcome_state() -> WelcomeMessage:
     elif not is_ollama:
         # Determine best available frontier model
         if is_shotgun_account:
-            frontier_model_label = "Select Opus 4.5"
-            frontier_model_name = ModelName.CLAUDE_OPUS_4_5
+            frontier_model_label = "Select Opus 4.6"
+            frontier_model_name = ModelName.CLAUDE_OPUS_4_6
         elif has_anthropic:
-            frontier_model_label = "Select Opus 4.5"
-            frontier_model_name = ModelName.CLAUDE_OPUS_4_5
+            frontier_model_label = "Select Opus 4.6"
+            frontier_model_name = ModelName.CLAUDE_OPUS_4_6
         elif has_openai:
             frontier_model_label = "Select GPT-5.2"
             frontier_model_name = ModelName.GPT_5_2

--- a/src/shotgun/tui/screens/model_picker.py
+++ b/src/shotgun/tui/screens/model_picker.py
@@ -615,7 +615,7 @@ class ModelPickerScreen(Screen[ModelConfigUpdated | None]):
         label = f"{display_name} · {input_fmt} context · {output_fmt} output"
 
         # Add cost indicator for expensive models
-        if model_name == ModelName.CLAUDE_OPUS_4_5:
+        if model_name == ModelName.CLAUDE_OPUS_4_6:
             label += " · Expensive"
 
         if is_current:
@@ -628,8 +628,8 @@ class ModelPickerScreen(Screen[ModelConfigUpdated | None]):
         names = {
             ModelName.GPT_5_1: "GPT-5.1 (OpenAI)",
             ModelName.GPT_5_2: "GPT-5.2 (OpenAI)",
-            ModelName.CLAUDE_OPUS_4_5: "Claude Opus 4.5 (Anthropic)",
-            ModelName.CLAUDE_SONNET_4_5: "Claude Sonnet 4.5 (Anthropic)",
+            ModelName.CLAUDE_OPUS_4_6: "Claude Opus 4.6 (Anthropic)",
+            ModelName.CLAUDE_SONNET_4_6: "Claude Sonnet 4.6 (Anthropic)",
             ModelName.CLAUDE_HAIKU_4_5: "Claude Haiku 4.5 (Anthropic)",
             ModelName.GEMINI_2_5_FLASH_LITE: "Gemini 2.5 Flash Lite (Google)",
             ModelName.GEMINI_3_PRO_PREVIEW: "Gemini 3 Pro Preview (Google)",

--- a/test/integration/codebase/tools/conftest.py
+++ b/test/integration/codebase/tools/conftest.py
@@ -243,7 +243,7 @@ def agent_deps(codebase_service: CodebaseService, temp_storage_dir: Path) -> Age
 
     # Create ModelConfig for testing
     model_config = ModelConfig(
-        name=ModelName.CLAUDE_OPUS_4_5,
+        name=ModelName.CLAUDE_OPUS_4_6,
         provider=ProviderType.ANTHROPIC,
         key_provider=KeyProvider.BYOK,
         max_input_tokens=200_000,

--- a/test/unit/agents/autopilot/test_claude_cli_subprocess.py
+++ b/test/unit/agents/autopilot/test_claude_cli_subprocess.py
@@ -47,7 +47,7 @@ def _make_mock_process(
 @pytest.mark.asyncio
 async def test_cli_subprocess_builds_correct_command():
     """Verify the command array includes required flags and the prompt."""
-    config = ClaudeSubprocessConfig(model="claude-sonnet-4-5-20250514")
+    config = ClaudeSubprocessConfig(model="claude-sonnet-4-6")
     cli = ClaudeCliSubprocess(config)
 
     cmd = cli._build_command("Do something")
@@ -60,7 +60,7 @@ async def test_cli_subprocess_builds_correct_command():
     assert "--permission-mode" in cmd
     assert cmd[cmd.index("--permission-mode") + 1] == "bypassPermissions"
     assert "--model" in cmd
-    assert cmd[cmd.index("--model") + 1] == "claude-sonnet-4-5-20250514"
+    assert cmd[cmd.index("--model") + 1] == "claude-sonnet-4-6"
     # Prompt is the last argument
     assert cmd[-1] == "Do something"
 

--- a/test/unit/agents/autopilot/test_stage_monitor_usage.py
+++ b/test/unit/agents/autopilot/test_stage_monitor_usage.py
@@ -13,7 +13,7 @@ from shotgun.agents.config.models import ModelConfig, ProviderType
 
 def _make_model_config() -> ModelConfig:
     return ModelConfig(
-        name="claude-opus-4-5",
+        name="claude-opus-4-6",
         provider=ProviderType.ANTHROPIC,
         key_provider="byok",
         max_input_tokens=200000,
@@ -62,7 +62,7 @@ async def test_stage_monitor_tracks_usage_after_evaluate(
     mock_manager.add_usage.assert_called_once()
     call_kwargs = mock_manager.add_usage.call_args
     assert call_kwargs[0][0] == mock_usage
-    assert call_kwargs[1]["model_name"] == "claude-opus-4-5"
+    assert call_kwargs[1]["model_name"] == "claude-opus-4-6"
     assert call_kwargs[1]["provider"] == ProviderType.ANTHROPIC
 
 
@@ -156,7 +156,7 @@ async def test_stage_monitor_get_agent_stores_model_config(
 
     # Use a MagicMock for model_config so .model_instance doesn't trigger real code
     model_config = MagicMock()
-    model_config.name = "claude-opus-4-5"
+    model_config.name = "claude-opus-4-6"
     model_config.provider = ProviderType.ANTHROPIC
     mock_get_provider_model.return_value = model_config
 

--- a/test/unit/agents/config/test_model_capabilities.py
+++ b/test/unit/agents/config/test_model_capabilities.py
@@ -10,7 +10,7 @@ from shotgun.agents.config.models import (
 def test_model_config_default_capabilities():
     """Test that ModelConfig defaults to supporting PDF and images."""
     config = ModelConfig(
-        name="claude-sonnet-4-5",
+        name="claude-sonnet-4-6",
         provider=ProviderType.ANTHROPIC,
         key_provider=KeyProvider.BYOK,
         max_input_tokens=200_000,

--- a/test/unit/agents/config/test_models.py
+++ b/test/unit/agents/config/test_models.py
@@ -11,15 +11,15 @@ from shotgun.agents.config.models import (
 
 
 def test_model_spec_short_name_claude_sonnet():
-    """Test ModelSpec short_name for Claude Sonnet 4.5."""
-    spec = MODEL_SPECS[ModelName.CLAUDE_SONNET_4_5]
-    assert spec.short_name == "Sonnet 4.5"
+    """Test ModelSpec short_name for Claude Sonnet 4.6."""
+    spec = MODEL_SPECS[ModelName.CLAUDE_SONNET_4_6]
+    assert spec.short_name == "Sonnet 4.6"
 
 
 def test_model_spec_short_name_claude_opus():
-    """Test ModelSpec short_name for Claude Opus 4.5."""
-    spec = MODEL_SPECS[ModelName.CLAUDE_OPUS_4_5]
-    assert spec.short_name == "Opus 4.5"
+    """Test ModelSpec short_name for Claude Opus 4.6."""
+    spec = MODEL_SPECS[ModelName.CLAUDE_OPUS_4_6]
+    assert spec.short_name == "Opus 4.6"
 
 
 def test_model_spec_short_name_claude_haiku():

--- a/test/unit/agents/config/test_sub_agent_models.py
+++ b/test/unit/agents/config/test_sub_agent_models.py
@@ -9,14 +9,14 @@ from shotgun.agents.config.models import (
 
 
 def test_anthropic_opus_maps_to_haiku():
-    """Claude Opus 4.5 should map to Claude Haiku 4.5 for sub-agents."""
-    assert get_sub_agent_model(ModelName.CLAUDE_OPUS_4_5) == ModelName.CLAUDE_HAIKU_4_5
+    """Claude Opus 4.6 should map to Claude Haiku 4.5 for sub-agents."""
+    assert get_sub_agent_model(ModelName.CLAUDE_OPUS_4_6) == ModelName.CLAUDE_HAIKU_4_5
 
 
 def test_anthropic_sonnet_maps_to_haiku():
-    """Claude Sonnet 4.5 should map to Claude Haiku 4.5 for sub-agents."""
+    """Claude Sonnet 4.6 should map to Claude Haiku 4.5 for sub-agents."""
     assert (
-        get_sub_agent_model(ModelName.CLAUDE_SONNET_4_5) == ModelName.CLAUDE_HAIKU_4_5
+        get_sub_agent_model(ModelName.CLAUDE_SONNET_4_6) == ModelName.CLAUDE_HAIKU_4_5
     )
 
 

--- a/test/unit/agents/router/test_delegation.py
+++ b/test/unit/agents/router/test_delegation.py
@@ -168,7 +168,7 @@ def test_create_agent_runtime_options_anthropic_does_not_inherit_model(
 ):
     """Test that ANTHROPIC provider does NOT inherit model config, allowing sub-agent substitution."""
     mock_router_deps.llm_model = ModelConfig(
-        name="claude-sonnet-4-5",
+        name="claude-sonnet-4-6",
         provider=ProviderType.ANTHROPIC,
         key_provider=KeyProvider.BYOK,
         max_input_tokens=200000,

--- a/test/unit/agents/test_agent_manager.py
+++ b/test/unit/agents/test_agent_manager.py
@@ -635,15 +635,15 @@ def test_model_config_updated():
     mock_model_config.key_provider = KeyProvider.BYOK
 
     event = ModelConfigUpdated(
-        old_model=ModelName.CLAUDE_OPUS_4_5,
-        new_model=ModelName.CLAUDE_SONNET_4_5,
+        old_model=ModelName.CLAUDE_OPUS_4_6,
+        new_model=ModelName.CLAUDE_SONNET_4_6,
         provider=ProviderType.ANTHROPIC,
         key_provider=KeyProvider.BYOK,
         model_config=mock_model_config,
     )
 
-    assert event.old_model == ModelName.CLAUDE_OPUS_4_5
-    assert event.new_model == ModelName.CLAUDE_SONNET_4_5
+    assert event.old_model == ModelName.CLAUDE_OPUS_4_6
+    assert event.new_model == ModelName.CLAUDE_SONNET_4_6
     assert event.provider == ProviderType.ANTHROPIC
     assert event.key_provider == KeyProvider.BYOK
     assert event.model_config == mock_model_config

--- a/test/unit/agents/test_anthropic_cache_settings.py
+++ b/test/unit/agents/test_anthropic_cache_settings.py
@@ -21,7 +21,7 @@ from shotgun.codebase.service import CodebaseService
 def mock_model_config():
     """Create a mock ModelConfig that returns a real TestModel instance."""
     config = MagicMock(spec=ModelConfig)
-    config.name = ModelName.CLAUDE_SONNET_4_5
+    config.name = ModelName.CLAUDE_SONNET_4_6
     config.provider = ProviderType.ANTHROPIC
     config.max_input_tokens = 200000
     config.max_output_tokens = 8192

--- a/test/unit/agents/test_context_analyzer.py
+++ b/test/unit/agents/test_context_analyzer.py
@@ -216,7 +216,7 @@ def test_format_analysis() -> None:
         total_messages=38,
         context_window=200_000,
         agent_context_tokens=agent_context_tokens,
-        model_name="claude-sonnet-4-5",
+        model_name="claude-sonnet-4-6",
         max_usable_tokens=max_usable_tokens,
         free_space_tokens=free_space_tokens,
     )
@@ -224,7 +224,7 @@ def test_format_analysis() -> None:
     formatted = ContextFormatter.format_markdown(analysis)
 
     assert "# Conversation Context Analysis" in formatted
-    assert "Model: claude-sonnet-4-5" in formatted
+    assert "Model: claude-sonnet-4-6" in formatted
     assert "Total Context:" in formatted
     assert "Free Space:" in formatted
     assert "Autocompact Buffer: 500 tokens" in formatted
@@ -270,7 +270,7 @@ def test_format_analysis_excludes_zero_counts() -> None:
         total_messages=4,
         context_window=200_000,
         agent_context_tokens=agent_context_tokens,
-        model_name="claude-sonnet-4-5",
+        model_name="claude-sonnet-4-6",
         max_usable_tokens=max_usable_tokens,
         free_space_tokens=free_space_tokens,
     )

--- a/test/unit/cli/test_compact.py
+++ b/test/unit/cli/test_compact.py
@@ -49,7 +49,7 @@ async def test_compact_conversation_success(tmp_path, mock_conversation_history)
 
     # Create a proper ModelConfig for the test
     model_config = ModelConfig(
-        name=ModelName.CLAUDE_SONNET_4_5,
+        name=ModelName.CLAUDE_SONNET_4_6,
         provider=ProviderType.ANTHROPIC,
         key_provider=KeyProvider.BYOK,
         max_input_tokens=200000,
@@ -128,7 +128,7 @@ async def test_compact_conversation_no_reduction(tmp_path, mock_conversation_his
 
     # Create a proper ModelConfig for the test
     model_config = ModelConfig(
-        name=ModelName.CLAUDE_SONNET_4_5,
+        name=ModelName.CLAUDE_SONNET_4_6,
         provider=ProviderType.ANTHROPIC,
         key_provider=KeyProvider.BYOK,
         max_input_tokens=200000,

--- a/test/unit/test_config_manager.py
+++ b/test/unit/test_config_manager.py
@@ -103,7 +103,7 @@ async def test_load_config_valid_file(mock_logger):
         ConfigSection.ANTHROPIC.value: {API_KEY_FIELD: "test-anthropic-key"},
         ConfigSection.GOOGLE.value: {API_KEY_FIELD: "test-google-key"},
         ConfigSection.SHOTGUN.value: {},
-        "selected_model": "claude-sonnet-4-5",
+        "selected_model": "claude-sonnet-4-6",
         SHOTGUN_INSTANCE_ID_FIELD: str(uuid.uuid4()),
         CONFIG_VERSION_FIELD: 3,
     }
@@ -119,7 +119,7 @@ async def test_load_config_valid_file(mock_logger):
             config = await manager.load()
 
             assert isinstance(config, ShotgunConfig)
-            assert config.selected_model == ModelName.CLAUDE_SONNET_4_5
+            assert config.selected_model == ModelName.CLAUDE_SONNET_4_6
             assert isinstance(config.openai.api_key, SecretStr)
             assert config.openai.api_key.get_secret_value() == "test-openai-key"
             assert isinstance(config.anthropic.api_key, SecretStr)
@@ -170,7 +170,7 @@ async def test_save_config_with_argument(mock_logger):
         manager = ConfigManager(config_path=config_path)
 
         config = ShotgunConfig(
-            selected_model=ModelName.CLAUDE_SONNET_4_5,
+            selected_model=ModelName.CLAUDE_SONNET_4_6,
             openai=OpenAIConfig(api_key=SecretStr("test-key")),
             shotgun_instance_id=str(uuid.uuid4()),
         )
@@ -181,7 +181,7 @@ async def test_save_config_with_argument(mock_logger):
         with open(config_path, encoding="utf-8") as f:
             saved_data = json.load(f)
 
-        assert saved_data["selected_model"] == "claude-sonnet-4-5"
+        assert saved_data["selected_model"] == "claude-sonnet-4-6"
         assert saved_data["openai"]["api_key"] == "test-key"
         assert manager._config is config
         mock_logger.debug.assert_called_once_with(
@@ -315,7 +315,7 @@ async def test_get_provider_model_anthropic_with_config_key(mock_get_config_mana
         model = await get_provider_model(ProviderType.ANTHROPIC)
 
         assert isinstance(model, ModelConfig)
-        assert model.name == "claude-opus-4-5"
+        assert model.name == "claude-opus-4-6"
         assert model.api_key == "test-anthropic-key"
 
 
@@ -418,7 +418,7 @@ async def test_get_provider_model_none_finds_first_available(mock_get_config_man
         model = await get_provider_model(None)
 
         assert isinstance(model, ModelConfig)
-        assert model.name == "claude-opus-4-5"
+        assert model.name == "claude-opus-4-6"
 
 
 @patch("shotgun.agents.config.provider.get_config_manager")
@@ -435,7 +435,7 @@ async def test_get_provider_model_respects_selected_model(mock_get_config_manage
         config = ShotgunConfig(
             openai=OpenAIConfig(api_key=SecretStr("openai-key")),
             anthropic=AnthropicConfig(api_key=SecretStr("anthropic-key")),
-            selected_model=ModelName.CLAUDE_OPUS_4_5,
+            selected_model=ModelName.CLAUDE_OPUS_4_6,
             shotgun_instance_id=str(uuid.uuid4()),
         )
         manager._config = config
@@ -445,7 +445,7 @@ async def test_get_provider_model_respects_selected_model(mock_get_config_manage
 
         # Should respect selected_model (Opus) not fall back to first provider (OpenAI)
         assert isinstance(model, ModelConfig)
-        assert model.name == ModelName.CLAUDE_OPUS_4_5
+        assert model.name == ModelName.CLAUDE_OPUS_4_6
 
 
 @patch("shotgun.agents.config.provider.get_config_manager")
@@ -463,7 +463,7 @@ async def test_get_provider_model_falls_back_when_selected_model_provider_has_no
         # User has selected Opus but only has OpenAI key (Anthropic has no key)
         config = ShotgunConfig(
             openai=OpenAIConfig(api_key=SecretStr("openai-key")),
-            selected_model=ModelName.CLAUDE_OPUS_4_5,
+            selected_model=ModelName.CLAUDE_OPUS_4_6,
             shotgun_instance_id=str(uuid.uuid4()),
         )
         manager._config = config
@@ -885,7 +885,7 @@ async def test_update_provider_sets_selected_model_when_first_key():
 
         # Verify selected_model is now set to Anthropic's default
         config = await manager.load()
-        assert config.selected_model == ModelName.CLAUDE_OPUS_4_5
+        assert config.selected_model == ModelName.CLAUDE_OPUS_4_6
         assert config.anthropic.api_key.get_secret_value() == "test-anthropic-key"
 
 
@@ -977,7 +977,7 @@ async def test_load_updates_selected_model_when_provider_has_no_key(mock_logger)
             config = await manager.load()
 
             # selected_model should now be Anthropic's default since OpenAI has no key
-            assert config.selected_model == ModelName.CLAUDE_OPUS_4_5
+            assert config.selected_model == ModelName.CLAUDE_OPUS_4_6
             assert isinstance(config.anthropic.api_key, SecretStr)
             assert config.anthropic.api_key.get_secret_value() == "test-anthropic-key"
 
@@ -1046,9 +1046,9 @@ async def test_clear_provider_key_updates_selected_model():
         )
 
         # Manually set selected_model to Anthropic model
-        await manager.update_selected_model(ModelName.CLAUDE_SONNET_4_5)
+        await manager.update_selected_model(ModelName.CLAUDE_SONNET_4_6)
         config = await manager.load(force_reload=True)
-        assert config.selected_model == ModelName.CLAUDE_SONNET_4_5
+        assert config.selected_model == ModelName.CLAUDE_SONNET_4_6
 
         # Clear Anthropic provider key
         await manager.clear_provider_key(ProviderType.ANTHROPIC)
@@ -1059,7 +1059,7 @@ async def test_clear_provider_key_updates_selected_model():
         # selected_model should be updated to an OpenAI model or set to None then to OpenAI on load
         # The load() method should detect that the selected model's provider has no key
         # and switch to an available provider
-        assert config.selected_model != ModelName.CLAUDE_SONNET_4_5
+        assert config.selected_model != ModelName.CLAUDE_SONNET_4_6
         assert config.selected_model == ModelName.GPT_5_2  # Should switch to OpenAI
 
 

--- a/test/unit/test_config_migrations.py
+++ b/test/unit/test_config_migrations.py
@@ -19,6 +19,7 @@ from shotgun.agents.config.manager import (
     _migrate_v4_to_v5,
     _migrate_v6_to_v7,
     _migrate_v7_to_v8,
+    _migrate_v9_to_v10,
     get_backup_dir,
 )
 from shotgun.agents.config.models import ProviderType, ShotgunConfig
@@ -119,6 +120,21 @@ V9_CONFIG = {
     "selected_model": "gpt-5",
     "shotgun_instance_id": "test-user-id-12345",
     "config_version": 9,
+    "shown_welcome_screen": False,
+    "marketing": {"messages": {}},
+    "router_mode": "planning",
+}
+
+V10_CONFIG = {
+    "openai": {"api_key": "sk-test123", "supports_streaming": None},
+    "anthropic": {"api_key": None, "tier": None},
+    "google": {"api_key": None},
+    "shotgun": {"api_key": None, "supabase_jwt": None},
+    "ollama": {"enabled": False, "base_url": "http://localhost:11434"},
+    "context7": {},
+    "selected_model": "gpt-5",
+    "shotgun_instance_id": "test-user-id-12345",
+    "config_version": 10,
     "shown_welcome_screen": False,
     "marketing": {"messages": {}},
     "router_mode": "planning",
@@ -301,12 +317,12 @@ def test_apply_migrations_from_v4_to_current():
 
 def test_apply_migrations_already_current():
     """Test applying migrations when already at current version."""
-    config = V9_CONFIG.copy()
+    config = V10_CONFIG.copy()
 
     result = _apply_migrations(config)
 
     assert result["config_version"] == CURRENT_CONFIG_VERSION
-    assert result == V9_CONFIG  # Should be unchanged
+    assert result == V10_CONFIG  # Should be unchanged
 
 
 def test_apply_migrations_sequential():
@@ -793,7 +809,7 @@ async def test_load_creates_backup_only_when_migration_needed():
         config_path = Path(tmpdir) / "config.json"
 
         # Create a current version config (no migration needed)
-        current_config = V9_CONFIG.copy()
+        current_config = V10_CONFIG.copy()
         config_path.write_text(json.dumps(current_config))
 
         manager = ConfigManager(config_path=config_path)
@@ -945,3 +961,36 @@ async def test_ollama_config_preserved_in_migrations():
         # Verify Ollama config is preserved
         assert config.ollama.enabled is True
         assert config.ollama.base_url == "http://192.168.1.100:11434"
+
+
+def test_migrate_v9_to_v10_renames_opus():
+    """Test v9->v10 migration renames claude-opus-4-5 to claude-opus-4-6."""
+    config = V9_CONFIG.copy()
+    config["selected_model"] = "claude-opus-4-5"
+
+    result = _migrate_v9_to_v10(config)
+
+    assert result["config_version"] == 10
+    assert result["selected_model"] == "claude-opus-4-6"
+
+
+def test_migrate_v9_to_v10_renames_sonnet():
+    """Test v9->v10 migration renames claude-sonnet-4-5 to claude-sonnet-4-6."""
+    config = V9_CONFIG.copy()
+    config["selected_model"] = "claude-sonnet-4-5"
+
+    result = _migrate_v9_to_v10(config)
+
+    assert result["config_version"] == 10
+    assert result["selected_model"] == "claude-sonnet-4-6"
+
+
+def test_migrate_v9_to_v10_preserves_other_models():
+    """Test v9->v10 migration preserves non-Claude models."""
+    config = V9_CONFIG.copy()
+    config["selected_model"] = "gpt-5"
+
+    result = _migrate_v9_to_v10(config)
+
+    assert result["config_version"] == 10
+    assert result["selected_model"] == "gpt-5"

--- a/test/unit/test_context7.py
+++ b/test/unit/test_context7.py
@@ -84,9 +84,9 @@ def test_apply_migrations_from_v8_to_current():
     assert result["context7"] == {}
 
 
-def test_current_config_version_is_9():
-    """Verify current config version is 9."""
-    assert CURRENT_CONFIG_VERSION == 9
+def test_current_config_version_is_10():
+    """Verify current config version is 10."""
+    assert CURRENT_CONFIG_VERSION == 10
 
 
 # --- ConfigManager Context7 methods tests ---

--- a/test/unit/test_provider.py
+++ b/test/unit/test_provider.py
@@ -84,7 +84,7 @@ async def test_get_provider_model_anthropic_with_config_key(mock_get_config_mana
         model = await get_provider_model(ProviderType.ANTHROPIC)
 
         assert isinstance(model, ModelConfig)
-        assert model.name == "claude-opus-4-5"
+        assert model.name == "claude-opus-4-6"
         assert model.api_key == "test-anthropic-key"
 
 
@@ -187,7 +187,7 @@ async def test_get_provider_model_none_finds_first_available(mock_get_config_man
         model = await get_provider_model(None)
 
         assert isinstance(model, ModelConfig)
-        assert model.name == "claude-opus-4-5"
+        assert model.name == "claude-opus-4-6"
 
 
 @patch("shotgun.agents.config.provider.get_config_manager")
@@ -269,7 +269,7 @@ async def test_get_provider_model_provider_enum_conversion(mock_get_config_manag
         model = await get_provider_model("anthropic")
 
         assert isinstance(model, ModelConfig)
-        assert model.name == "claude-opus-4-5"
+        assert model.name == "claude-opus-4-6"
 
 
 @patch.dict(os.environ, {}, clear=True)
@@ -297,7 +297,7 @@ async def test_get_provider_model_with_env_key_precedence(mock_get_config_manage
         model = await get_provider_model(ProviderType.ANTHROPIC)
 
         assert isinstance(model, ModelConfig)
-        assert model.name == "claude-opus-4-5"
+        assert model.name == "claude-opus-4-6"
         assert model.provider == ProviderType.ANTHROPIC
         # Config key takes precedence over environment variable
         assert model.api_key == "config-anthropic-key"

--- a/test/unit/test_tier1_telemetry.py
+++ b/test/unit/test_tier1_telemetry.py
@@ -224,7 +224,7 @@ def test_message_send_event_properties_include_tier1_flag():
     # Verify the event properties structure that agent_manager would build
     event_properties = {
         "has_prompt": True,
-        "model_name": "claude-sonnet-4-5",
+        "model_name": "claude-sonnet-4-6",
         "has_attachment": False,
         "is_tier1_anthropic": True,
         "anthropic_tier": 1,
@@ -238,7 +238,7 @@ def test_message_send_event_properties_tier2_not_flagged():
     """Test that non-tier1 accounts have is_tier1_anthropic=False."""
     event_properties = {
         "has_prompt": True,
-        "model_name": "claude-sonnet-4-5",
+        "model_name": "claude-sonnet-4-6",
         "has_attachment": False,
         "is_tier1_anthropic": False,
         "anthropic_tier": 2,

--- a/test/unit/tui/components/test_context_indicator.py
+++ b/test/unit/tui/components/test_context_indicator.py
@@ -46,10 +46,10 @@ def test_context_indicator_update_context():
         agent_context_tokens=72_000, max_usable_tokens=160_000
     )
 
-    indicator.update_context(analysis, ModelName.CLAUDE_SONNET_4_5)
+    indicator.update_context(analysis, ModelName.CLAUDE_SONNET_4_6)
 
     assert indicator.context_analysis == analysis
-    assert indicator.model_name == ModelName.CLAUDE_SONNET_4_5
+    assert indicator.model_name == ModelName.CLAUDE_SONNET_4_6
 
 
 def test_context_indicator_format_token_count():
@@ -107,11 +107,11 @@ def test_context_indicator_display_with_zero_tokens():
     # Create analysis with 0 tokens (empty conversation)
     analysis = create_test_analysis(agent_context_tokens=0, max_usable_tokens=160_000)
 
-    indicator.update_context(analysis, ModelName.CLAUDE_SONNET_4_5)
+    indicator.update_context(analysis, ModelName.CLAUDE_SONNET_4_6)
 
     # Should show full context display even with 0 tokens (0% (0/160K))
     assert indicator.context_analysis == analysis
-    assert indicator.model_name == ModelName.CLAUDE_SONNET_4_5
+    assert indicator.model_name == ModelName.CLAUDE_SONNET_4_6
     # Percentage should be 0.0
     percentage = (0 / 160_000) * 100
     assert percentage == 0.0
@@ -129,11 +129,11 @@ def test_context_indicator_display_calculation():
         agent_context_tokens=80_000, max_usable_tokens=160_000
     )
 
-    indicator.update_context(analysis, ModelName.CLAUDE_SONNET_4_5)
+    indicator.update_context(analysis, ModelName.CLAUDE_SONNET_4_6)
 
     # Verify internal state
     assert indicator.context_analysis == analysis
-    assert indicator.model_name == ModelName.CLAUDE_SONNET_4_5
+    assert indicator.model_name == ModelName.CLAUDE_SONNET_4_6
 
     # Verify percentage calculation
     percentage = (80_000 / 160_000) * 100
@@ -169,8 +169,8 @@ def test_context_indicator_display_with_different_models():
 
     # Test with different models
     for model_name in [
-        ModelName.CLAUDE_SONNET_4_5,
-        ModelName.CLAUDE_OPUS_4_5,
+        ModelName.CLAUDE_SONNET_4_6,
+        ModelName.CLAUDE_OPUS_4_6,
         ModelName.GPT_5_1,
         ModelName.GEMINI_3_PRO_PREVIEW,
     ]:

--- a/test/unit/tui/conftest.py
+++ b/test/unit/tui/conftest.py
@@ -27,7 +27,7 @@ from shotgun.tui.widgets.widget_coordinator import WidgetCoordinator
 def mock_model_config():
     """Create a proper ModelConfig instance for testing."""
     return ModelConfig(
-        name=ModelName.CLAUDE_SONNET_4_5,
+        name=ModelName.CLAUDE_SONNET_4_6,
         provider=ProviderType.ANTHROPIC,
         key_provider=KeyProvider.BYOK,
         max_input_tokens=200_000,

--- a/test/unit/tui/screens/chat_screen/test_welcome_message.py
+++ b/test/unit/tui/screens/chat_screen/test_welcome_message.py
@@ -36,8 +36,8 @@ def test_welcome_message_all_flags():
         is_indexed=True,
         has_context7_key=True,
         is_frontier_model=True,
-        frontier_model_label="Select Opus 4.5",
-        frontier_model_name="claude-opus-4-5",
+        frontier_model_label="Select Opus 4.6",
+        frontier_model_name="claude-opus-4-6",
         is_ollama=False,
         is_byok=True,
         is_shotgun_account=False,
@@ -47,8 +47,8 @@ def test_welcome_message_all_flags():
     assert msg.is_indexed is True
     assert msg.has_context7_key is True
     assert msg.is_frontier_model is True
-    assert msg.frontier_model_label == "Select Opus 4.5"
-    assert msg.frontier_model_name == "claude-opus-4-5"
+    assert msg.frontier_model_label == "Select Opus 4.6"
+    assert msg.frontier_model_name == "claude-opus-4-6"
 
 
 def test_welcome_message_serialization():
@@ -129,8 +129,8 @@ async def test_build_welcome_state_byok_anthropic_frontier():
 
     assert state.is_byok is True
     assert state.is_shotgun_account is False
-    assert state.frontier_model_label == "Select Opus 4.5"
-    assert state.frontier_model_name == "claude-opus-4-5"
+    assert state.frontier_model_label == "Select Opus 4.6"
+    assert state.frontier_model_name == "claude-opus-4-6"
     assert state.is_frontier_model is False
 
 
@@ -203,7 +203,7 @@ async def test_build_welcome_state_byok_google_frontier():
 
 @pytest.mark.anyio
 async def test_build_welcome_state_shotgun_account():
-    """Test shotgun account always suggests Opus 4.5."""
+    """Test shotgun account always suggests Opus 4.6."""
     config = _make_config(shotgun_key="shotgun-test")
     mock_cm = AsyncMock()
     mock_cm.load = AsyncMock(return_value=config)
@@ -231,8 +231,8 @@ async def test_build_welcome_state_shotgun_account():
         state = await build_welcome_state()
 
     assert state.is_shotgun_account is True
-    assert state.frontier_model_label == "Select Opus 4.5"
-    assert state.frontier_model_name == "claude-opus-4-5"
+    assert state.frontier_model_label == "Select Opus 4.6"
+    assert state.frontier_model_name == "claude-opus-4-6"
 
 
 @pytest.mark.anyio
@@ -360,7 +360,7 @@ async def test_build_welcome_state_context7_key():
 @pytest.mark.anyio
 async def test_build_welcome_state_already_frontier():
     """Test already-selected frontier model is detected."""
-    config = _make_config(anthropic_key="sk-ant-test", selected_model="claude-opus-4-5")
+    config = _make_config(anthropic_key="sk-ant-test", selected_model="claude-opus-4-6")
     mock_cm = AsyncMock()
     mock_cm.load = AsyncMock(return_value=config)
     mock_cm.provider_has_api_key = MagicMock(return_value=False)
@@ -452,5 +452,5 @@ async def test_build_welcome_state_frontier_priority():
     ):
         state = await build_welcome_state()
 
-    assert state.frontier_model_label == "Select Opus 4.5"
-    assert state.frontier_model_name == "claude-opus-4-5"
+    assert state.frontier_model_label == "Select Opus 4.6"
+    assert state.frontier_model_name == "claude-opus-4-6"


### PR DESCRIPTION
## Summary
- Upgrade Claude Opus and Sonnet model references from 4.5 to 4.6 (non-dated for BYOK, `anthropic/claude-*-4-6` for LiteLLM proxy)
- Add config migration v9→v10 to automatically rename `selected_model` for existing users
- Haiku remains at 4.5 (unchanged)

## Test plan
- [x] mypy passes (`Success: no issues found in 281 source files`)
- [x] ruff passes (only pre-existing unrelated warning)
- [x] All 688 unit tests pass
- [x] All 7 smoke tests pass
- [x] Config migration tested: renames opus/sonnet 4.5→4.6, preserves other models

🤖 Generated with [Claude Code](https://claude.com/claude-code)