### PR TITLE
feat(tui): add copy URL to clipboard button on auth screen

### DIFF
--- a/src/shotgun/tui/screens/shotgun_auth.py
+++ b/src/shotgun/tui/screens/shotgun_auth.py
@@ -77,6 +77,12 @@ class ShotgunAuthScreen(Screen[bool]):
             text-align: center;
         }
 
+        #copy-url {
+            margin: 1 0;
+            width: auto;
+            align: center middle;
+        }
+
         #actions {
             padding: 1;
             align: center middle;
@@ -131,6 +137,9 @@ class ShotgunAuthScreen(Screen[bool]):
         with Vertical(id="content"):
             yield Label("Initializing...", id="status")
             yield Markdown("", id="auth-url")
+            yield Button(
+                "Copy URL to ClipBoard", variant="primary", id="copy-url", disabled=True
+            )
             yield Markdown(
                 "**Instructions:**\n"
                 "1. A browser window will open automatically\n"
@@ -172,6 +181,13 @@ class ShotgunAuthScreen(Screen[bool]):
         """Handle cancel button press."""
         self.action_cancel()
 
+    @on(Button.Pressed, "#copy-url")
+    def _on_copy_url_pressed(self) -> None:
+        """Copy the authentication URL to the clipboard."""
+        if self.auth_url:
+            self.app.copy_to_clipboard(self.auth_url)
+            self.notify("URL copied to clipboard")
+
     @property
     def config_manager(self) -> ConfigManager:
         app = cast("ShotgunApp", self.app)
@@ -206,6 +222,7 @@ class ShotgunAuthScreen(Screen[bool]):
             self.query_one("#auth-url", Markdown).update(
                 f"**Authentication URL:**\n\n[{self.auth_url}]({self.auth_url})"
             )
+            self.query_one("#copy-url", Button).disabled = False
 
             # Try to open browser
             try:

--- a/test/unit/tui/screens/test_shotgun_auth.py
+++ b/test/unit/tui/screens/test_shotgun_auth.py
@@ -1,0 +1,41 @@
+"""Tests for ShotgunAuthScreen copy URL button."""
+
+from unittest.mock import Mock, patch
+
+from shotgun.tui.screens.shotgun_auth import ShotgunAuthScreen
+
+
+def test_copy_url_button_starts_disabled() -> None:
+    """Test that the copy URL button is initially disabled (auth_url is None)."""
+    screen = ShotgunAuthScreen()
+    assert screen.auth_url is None
+
+
+def test_on_copy_url_pressed_copies_url() -> None:
+    """Test that pressing copy button copies the auth URL to clipboard."""
+    screen = ShotgunAuthScreen()
+    screen.auth_url = "https://example.com/auth/token123"
+
+    mock_app = Mock()
+
+    with patch.object(type(screen), "app", new=mock_app):
+        with patch.object(screen, "notify") as mock_notify:
+            screen._on_copy_url_pressed()
+
+    mock_app.copy_to_clipboard.assert_called_once_with(
+        "https://example.com/auth/token123"
+    )
+    mock_notify.assert_called_once_with("URL copied to clipboard")
+
+
+def test_on_copy_url_pressed_no_url() -> None:
+    """Test that pressing copy button does nothing when no URL is set."""
+    screen = ShotgunAuthScreen()
+    screen.auth_url = None
+
+    mock_app = Mock()
+
+    with patch.object(type(screen), "app", new=mock_app):
+        screen._on_copy_url_pressed()
+
+    mock_app.copy_to_clipboard.assert_not_called()


### PR DESCRIPTION
## Summary
- Adds a "Copy URL to ClipBoard" button to the Shotgun Account authentication screen (`ShotgunAuthScreen`)
- Button starts disabled and enables once the auth URL is ready
- Uses Textual's built-in `copy_to_clipboard` and shows a notification on success

## Test plan
- [x] Unit tests for copy button handler (3 tests in `test/unit/tui/screens/test_shotgun_auth.py`)
- [ ] Manual: Run TUI, trigger auth flow, verify button appears below the URL
- [ ] Manual: Click "Copy URL to ClipBoard" and verify URL is in clipboard
- [ ] Manual: Verify button is disabled before URL loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)