### PR TITLE
feat(config): add OpenRouter as BYOK provider

### DIFF
--- a/src/shotgun/agents/config/constants.py
+++ b/src/shotgun/agents/config/constants.py
@@ -16,6 +16,7 @@ class ConfigSection(StrEnum):
     ANTHROPIC = auto()
     GOOGLE = auto()
     SHOTGUN = auto()
+    OPENROUTER = auto()
     CONTEXT7 = auto()
 
 

--- a/src/shotgun/agents/config/manager.py
+++ b/src/shotgun/agents/config/manager.py
@@ -27,6 +27,7 @@ from .models import (
     GoogleConfig,
     ModelName,
     OpenAIConfig,
+    OpenRouterConfig,
     ProviderType,
     ShotgunAccountConfig,
     ShotgunConfig,
@@ -51,10 +52,16 @@ class ConfigMigrationError(Exception):
 
 
 # Type alias for provider configuration objects
-ProviderConfig = OpenAIConfig | AnthropicConfig | GoogleConfig | ShotgunAccountConfig
+ProviderConfig = (
+    OpenAIConfig
+    | AnthropicConfig
+    | GoogleConfig
+    | ShotgunAccountConfig
+    | OpenRouterConfig
+)
 
 # Current config version
-CURRENT_CONFIG_VERSION = 10
+CURRENT_CONFIG_VERSION = 11
 
 # Backup directory name
 BACKUP_DIR_NAME = "backup"
@@ -299,6 +306,20 @@ def _migrate_v9_to_v10(data: dict[str, Any]) -> dict[str, Any]:
     return data
 
 
+def _migrate_v10_to_v11(data: dict[str, Any]) -> dict[str, Any]:
+    """Migrate config from version 10 to version 11.
+
+    Changes:
+    - Add 'openrouter' section for OpenRouter provider
+    """
+    if "openrouter" not in data:
+        data["openrouter"] = {}
+        logger.info("Migrated config v10->v11: added openrouter configuration")
+
+    data["config_version"] = 11
+    return data
+
+
 def _apply_migrations(data: dict[str, Any]) -> dict[str, Any]:
     """Apply all necessary migrations to bring config to current version.
 
@@ -324,6 +345,7 @@ def _apply_migrations(data: dict[str, Any]) -> dict[str, Any]:
         7: _migrate_v7_to_v8,
         8: _migrate_v8_to_v9,
         9: _migrate_v9_to_v10,
+        10: _migrate_v10_to_v11,
     }
 
     # Apply migrations sequentially
@@ -461,7 +483,11 @@ class ConfigManager:
                 should_save = True
 
             # Validate selected_model for BYOK mode - verify provider has a key
-            if not self.provider_has_api_key(self._config.shotgun):
+            # Skip validation for multi-model providers (Shotgun Account, OpenRouter)
+            # since they provide access to all models regardless of individual BYOK keys
+            if not self.provider_has_api_key(
+                self._config.shotgun
+            ) and not self.provider_has_api_key(self._config.openrouter):
                 # If selected_model is set, verify its provider has a key
                 # (Skip validation for Ollama models which don't need API keys)
                 if self._config.selected_model and not is_ollama_model(
@@ -593,12 +619,13 @@ class ConfigManager:
         """
         config = await self.load()
 
-        # Get provider config and check if it's shotgun
-        provider_config, is_shotgun = self._get_provider_config_and_type(
+        # Get provider config and its section type
+        provider_config, section = self._get_provider_config_and_section(
             config, provider
         )
-        # For non-shotgun providers, we need the enum for default provider logic
-        provider_enum = None if is_shotgun else self._ensure_provider_enum(provider)
+        is_multi_model = section in (ConfigSection.SHOTGUN, ConfigSection.OPENROUTER)
+        # For standard LLM providers, resolve the enum for default-model logic
+        provider_enum = None if is_multi_model else self._ensure_provider_enum(provider)
 
         # Only support api_key updates
         if API_KEY_FIELD in kwargs:
@@ -608,16 +635,12 @@ class ConfigManager:
             )
 
             # Reset streaming capabilities when OpenAI API key is changed
-            if not is_shotgun and provider_enum == ProviderType.OPENAI:
+            if provider_enum == ProviderType.OPENAI:
                 if isinstance(provider_config, OpenAIConfig):
                     provider_config.supports_streaming = None
 
         # Support tier updates for Anthropic
-        if (
-            "tier" in kwargs
-            and not is_shotgun
-            and provider_enum == ProviderType.ANTHROPIC
-        ):
+        if "tier" in kwargs and provider_enum == ProviderType.ANTHROPIC:
             if isinstance(provider_config, AnthropicConfig):
                 provider_config.tier = kwargs["tier"]
 
@@ -626,10 +649,22 @@ class ConfigManager:
         if unsupported_fields:
             raise ValueError(f"Unsupported configuration fields: {unsupported_fields}")
 
-        # If no other providers have keys configured and we just added one,
-        # set selected_model to that provider's default model (only for LLM providers, not shotgun)
-        if not is_shotgun and API_KEY_FIELD in kwargs and api_key_value is not None:
-            # provider_enum is guaranteed to be non-None here since is_shotgun is False
+        # Auto-select model and mark welcome screen based on provider type
+        if (
+            section == ConfigSection.OPENROUTER
+            and API_KEY_FIELD in kwargs
+            and api_key_value is not None
+        ):
+            # OpenRouter provides access to all models - auto-select Opus 4.6
+            if not config.selected_model:
+                config.selected_model = ModelName.CLAUDE_OPUS_4_6
+            config.shown_welcome_screen = True
+        elif (
+            not is_multi_model and API_KEY_FIELD in kwargs and api_key_value is not None
+        ):
+            # If no other providers have keys configured and we just added one,
+            # set selected_model to that provider's default model (only for LLM providers)
+            # provider_enum is guaranteed non-None here since is_multi_model is False
             if provider_enum is None:
                 raise RuntimeError("Provider enum should not be None for LLM providers")
             other_providers = [p for p in ProviderType if p != provider_enum]
@@ -654,22 +689,24 @@ class ConfigManager:
         await self.save(config)
 
     async def clear_provider_key(self, provider: ProviderType | str) -> None:
-        """Remove the API key for the given provider (LLM provider or shotgun)."""
+        """Remove the API key for the given provider (LLM provider, shotgun, or openrouter)."""
         config = await self.load()
 
-        # Get provider config (shotgun or LLM provider)
-        provider_config, is_shotgun = self._get_provider_config_and_type(
+        # Get provider config and section type
+        provider_config, section = self._get_provider_config_and_section(
             config, provider
         )
 
         provider_config.api_key = None
 
         # For Shotgun Account, also clear the JWT
-        if is_shotgun and isinstance(provider_config, ShotgunAccountConfig):
+        if section == ConfigSection.SHOTGUN and isinstance(
+            provider_config, ShotgunAccountConfig
+        ):
             provider_config.supabase_jwt = None
 
         # Reset streaming capabilities when OpenAI API key is cleared
-        if not is_shotgun:
+        if section is None:
             provider_enum = self._ensure_provider_enum(provider)
             if provider_enum == ProviderType.OPENAI:
                 if isinstance(provider_config, OpenAIConfig):
@@ -714,7 +751,9 @@ class ConfigManager:
         )
         # Also check Shotgun Account key
         has_shotgun_key = self.provider_has_api_key(config.shotgun)
-        return has_llm_key or has_shotgun_key
+        # Also check OpenRouter key
+        has_openrouter_key = self.provider_has_api_key(config.openrouter)
+        return has_llm_key or has_shotgun_key or has_openrouter_key
 
     async def initialize(self) -> ShotgunConfig:
         """Initialize configuration with defaults and save to file.
@@ -840,37 +879,56 @@ class ConfigManager:
 
         return bool(value.strip())
 
-    def _is_shotgun_provider(self, provider: ProviderType | str) -> bool:
-        """Check if provider string represents Shotgun Account.
+    def _is_section_provider(
+        self, provider: ProviderType | str, section: ConfigSection
+    ) -> bool:
+        """Check if provider string matches a ConfigSection (e.g. shotgun, openrouter).
+
+        Args:
+            provider: Provider type or string
+            section: The ConfigSection to compare against
+
+        Returns:
+            True if provider matches the given section
+        """
+        return isinstance(provider, str) and provider.lower() == section.value
+
+    def _is_multi_model_provider(self, provider: ProviderType | str) -> bool:
+        """Check if provider is a multi-model provider (Shotgun Account or OpenRouter).
+
+        Multi-model providers give access to all models regardless of individual BYOK keys.
 
         Args:
             provider: Provider type or string
 
         Returns:
-            True if provider is shotgun account
+            True if provider is shotgun or openrouter
         """
-        return (
-            isinstance(provider, str)
-            and provider.lower() == ConfigSection.SHOTGUN.value
-        )
+        return self._is_section_provider(
+            provider, ConfigSection.SHOTGUN
+        ) or self._is_section_provider(provider, ConfigSection.OPENROUTER)
 
-    def _get_provider_config_and_type(
+    def _get_provider_config_and_section(
         self, config: ShotgunConfig, provider: ProviderType | str
-    ) -> tuple[ProviderConfig, bool]:
-        """Get provider config, handling shotgun as special case.
+    ) -> tuple[ProviderConfig, ConfigSection | None]:
+        """Get provider config and its ConfigSection if it's a non-LLM provider.
 
         Args:
             config: Shotgun configuration
             provider: Provider type or string
 
         Returns:
-            Tuple of (provider_config, is_shotgun)
+            Tuple of (provider_config, section_or_none). section is None for
+            standard LLM providers (openai, anthropic, google).
         """
-        if self._is_shotgun_provider(provider):
-            return (config.shotgun, True)
+        if self._is_section_provider(provider, ConfigSection.SHOTGUN):
+            return (config.shotgun, ConfigSection.SHOTGUN)
+
+        if self._is_section_provider(provider, ConfigSection.OPENROUTER):
+            return (config.openrouter, ConfigSection.OPENROUTER)
 
         provider_enum = self._ensure_provider_enum(provider)
-        return (self._get_provider_config(config, provider_enum), False)
+        return (self._get_provider_config(config, provider_enum), None)
 
     async def get_shotgun_instance_id(self) -> str:
         """Get the shotgun instance ID from configuration.

--- a/src/shotgun/agents/config/models.py
+++ b/src/shotgun/agents/config/models.py
@@ -23,6 +23,7 @@ class KeyProvider(StrEnum):
 
     BYOK = "byok"  # Bring Your Own Key (individual provider keys)
     SHOTGUN = "shotgun"  # Shotgun Account (unified LiteLLM proxy)
+    OPENROUTER = "openrouter"  # OpenRouter (multi-model API aggregator)
 
 
 ANTHROPIC_ROUTER_CACHE_SETTINGS = AnthropicModelSettings(
@@ -61,6 +62,7 @@ class ModelSpec(BaseModel):
     litellm_proxy_model_name: (
         str  # LiteLLM format (e.g., "openai/gpt-5", "gemini/gemini-2-pro")
     )
+    openrouter_model_name: str  # OpenRouter format (e.g., "anthropic/claude-opus-4-6", "google/gemini-3-flash-preview")
     short_name: str  # Display name for UI (e.g., "Sonnet 4.6", "GPT-5")
 
 
@@ -137,6 +139,15 @@ class ModelConfig(BaseModel):
         """
         return self.key_provider == KeyProvider.SHOTGUN
 
+    @property
+    def is_openrouter(self) -> bool:
+        """Check if this model is using OpenRouter authentication.
+
+        Returns:
+            True if using OpenRouter, False otherwise
+        """
+        return self.key_provider == KeyProvider.OPENROUTER
+
 
 def get_model_display_name(name: "ModelName | str") -> str:
     """Get the UI display name for a model.
@@ -158,6 +169,7 @@ MODEL_SPECS: dict[ModelName, ModelSpec] = {
         max_input_tokens=272_000,
         max_output_tokens=128_000,
         litellm_proxy_model_name="openai/gpt-5.1",
+        openrouter_model_name="openai/gpt-5.1",
         short_name="GPT-5.1",
     ),
     ModelName.GPT_5_2: ModelSpec(
@@ -166,6 +178,7 @@ MODEL_SPECS: dict[ModelName, ModelSpec] = {
         max_input_tokens=272_000,
         max_output_tokens=128_000,
         litellm_proxy_model_name="openai/gpt-5.2",
+        openrouter_model_name="openai/gpt-5.2",
         short_name="GPT-5.2",
     ),
     ModelName.CLAUDE_SONNET_4_6: ModelSpec(
@@ -174,6 +187,7 @@ MODEL_SPECS: dict[ModelName, ModelSpec] = {
         max_input_tokens=200_000,
         max_output_tokens=16_000,
         litellm_proxy_model_name="anthropic/claude-sonnet-4-6",
+        openrouter_model_name="anthropic/claude-sonnet-4-6",
         short_name="Sonnet 4.6",
     ),
     ModelName.CLAUDE_HAIKU_4_5: ModelSpec(
@@ -182,6 +196,7 @@ MODEL_SPECS: dict[ModelName, ModelSpec] = {
         max_input_tokens=200_000,
         max_output_tokens=64_000,
         litellm_proxy_model_name="anthropic/claude-haiku-4-5",
+        openrouter_model_name="anthropic/claude-haiku-4-5",
         short_name="Haiku 4.5",
     ),
     ModelName.CLAUDE_OPUS_4_6: ModelSpec(
@@ -190,6 +205,7 @@ MODEL_SPECS: dict[ModelName, ModelSpec] = {
         max_input_tokens=200_000,
         max_output_tokens=64_000,
         litellm_proxy_model_name="anthropic/claude-opus-4-6",
+        openrouter_model_name="anthropic/claude-opus-4-6",
         short_name="Opus 4.6",
     ),
     ModelName.GEMINI_2_5_FLASH_LITE: ModelSpec(
@@ -198,6 +214,7 @@ MODEL_SPECS: dict[ModelName, ModelSpec] = {
         max_input_tokens=1_048_576,
         max_output_tokens=65_536,
         litellm_proxy_model_name="gemini/gemini-2.5-flash-lite",
+        openrouter_model_name="google/gemini-2.5-flash-lite",
         short_name="Gemini 2.5 Flash Lite",
     ),
     ModelName.GEMINI_3_PRO_PREVIEW: ModelSpec(
@@ -206,6 +223,7 @@ MODEL_SPECS: dict[ModelName, ModelSpec] = {
         max_input_tokens=1_048_576,
         max_output_tokens=65_536,
         litellm_proxy_model_name="gemini/gemini-3-pro-preview",
+        openrouter_model_name="google/gemini-3-pro-preview",
         short_name="Gemini 3 Pro",
     ),
     ModelName.GEMINI_3_FLASH_PREVIEW: ModelSpec(
@@ -214,6 +232,7 @@ MODEL_SPECS: dict[ModelName, ModelSpec] = {
         max_input_tokens=1_048_576,
         max_output_tokens=65_536,
         litellm_proxy_model_name="gemini/gemini-3-flash-preview",
+        openrouter_model_name="google/gemini-3-flash-preview",
         short_name="Gemini 3 Flash",
     ),
 }
@@ -267,6 +286,16 @@ class GoogleConfig(BaseModel):
     """Configuration for Google provider."""
 
     api_key: SecretStr | None = None
+
+
+class OpenRouterConfig(BaseModel):
+    """Configuration for OpenRouter (multi-model API aggregator)."""
+
+    api_key: SecretStr | None = None
+
+
+# OpenRouter API base URL
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
 
 class ShotgunAccountConfig(BaseModel):
@@ -386,6 +415,7 @@ class ShotgunConfig(BaseModel):
     anthropic: AnthropicConfig = Field(default_factory=AnthropicConfig)
     google: GoogleConfig = Field(default_factory=GoogleConfig)
     shotgun: ShotgunAccountConfig = Field(default_factory=ShotgunAccountConfig)
+    openrouter: OpenRouterConfig = Field(default_factory=OpenRouterConfig)
     ollama: OllamaConfig = Field(default_factory=OllamaConfig)
     context7: Context7Config = Field(default_factory=Context7Config)
     selected_model: ModelName | str | None = Field(
@@ -395,7 +425,7 @@ class ShotgunConfig(BaseModel):
     shotgun_instance_id: str = Field(
         description="Unique shotgun instance identifier (also used for anonymous telemetry)",
     )
-    config_version: int = Field(default=10, description="Configuration schema version")
+    config_version: int = Field(default=11, description="Configuration schema version")
     shown_welcome_screen: bool = Field(
         default=False,
         description="Whether the welcome screen has been shown to the user",

--- a/src/shotgun/agents/config/provider.py
+++ b/src/shotgun/agents/config/provider.py
@@ -25,6 +25,7 @@ from .manager import get_config_manager
 from .models import (
     MODEL_SPECS,
     OLLAMA_PLACEHOLDER_API_KEY,
+    OPENROUTER_BASE_URL,
     KeyProvider,
     ModelConfig,
     ModelName,
@@ -198,6 +199,100 @@ def _create_openai_compat_model(
     )
 
 
+def _resolve_multi_provider_model(
+    config: ShotgunConfig,
+    provider_or_model: ProviderType | ModelName | None,
+    for_sub_agent: bool,
+) -> ModelName:
+    """Resolve which ModelName to use for multi-provider backends (Shotgun Account, OpenRouter).
+
+    Encapsulates the logic for determining the model when the backend supports all providers.
+
+    Args:
+        config: Shotgun configuration
+        provider_or_model: Explicit model, provider hint, or None for auto-selection
+        for_sub_agent: If True, substitute a cheaper model for cost optimization
+
+    Returns:
+        Resolved ModelName
+    """
+    if isinstance(provider_or_model, ModelName):
+        # Specific model requested - honor it (e.g., web search tools)
+        model_name = provider_or_model
+    elif isinstance(provider_or_model, ProviderType):
+        # Specific provider requested - use default model for that provider
+        provider_defaults = {
+            ProviderType.OPENAI: ModelName.GPT_5_2,
+            ProviderType.ANTHROPIC: ModelName.CLAUDE_OPUS_4_6,
+            ProviderType.GOOGLE: ModelName.GEMINI_3_FLASH_PREVIEW,
+        }
+        selected = (
+            config.selected_model
+            if isinstance(config.selected_model, ModelName)
+            else get_default_model_for_provider(config)
+        )
+        model_name = provider_defaults.get(provider_or_model, selected)
+    else:
+        # No specific model requested - use selected or default
+        if isinstance(config.selected_model, ModelName):
+            model_name = config.selected_model
+        else:
+            model_name = get_default_model_for_provider(config)
+
+    # Gracefully fall back if the selected model doesn't exist (backwards compatibility)
+    if model_name not in MODEL_SPECS:
+        model_name = get_default_model_for_provider(config)
+
+    # Apply sub-agent model mapping for cost optimization
+    if for_sub_agent:
+        original_model = model_name
+        model_name = get_sub_agent_model(model_name)
+        if model_name != original_model:
+            logger.debug(
+                "Sub-agent model substitution: %s -> %s",
+                original_model.value,
+                model_name.value,
+            )
+
+    return model_name
+
+
+def _build_multi_provider_model_config(
+    config: ShotgunConfig,
+    provider_or_model: ProviderType | ModelName | None,
+    for_sub_agent: bool,
+    *,
+    key_provider: KeyProvider,
+    api_key: str,
+) -> ModelConfig:
+    """Build a ModelConfig for multi-model providers (Shotgun Account, OpenRouter).
+
+    These providers give access to all models through a single API key,
+    so the logic for resolving which model to use is shared.
+
+    Args:
+        config: Shotgun configuration
+        provider_or_model: Explicit model, provider hint, or None for auto-selection
+        for_sub_agent: If True, substitute a cheaper model for cost optimization
+        key_provider: Authentication method (SHOTGUN or OPENROUTER)
+        api_key: The resolved API key string
+
+    Returns:
+        Fully configured ModelConfig
+    """
+    model_name = _resolve_multi_provider_model(config, provider_or_model, for_sub_agent)
+    spec = MODEL_SPECS[model_name]
+    return ModelConfig(
+        name=spec.name,
+        provider=spec.provider,
+        key_provider=key_provider,
+        max_input_tokens=spec.max_input_tokens,
+        max_output_tokens=spec.max_output_tokens,
+        api_key=api_key,
+        supports_streaming=True,
+    )
+
+
 def get_default_model_for_provider(config: ShotgunConfig) -> ModelName:
     """Get the default model based on which provider/account is configured.
 
@@ -212,6 +307,10 @@ def get_default_model_for_provider(config: ShotgunConfig) -> ModelName:
     """
     # Priority 1: Shotgun Account
     if _get_api_key(config.shotgun.api_key):
+        return ModelName.CLAUDE_OPUS_4_6
+
+    # Priority 1.5: OpenRouter
+    if _get_api_key(config.openrouter.api_key):
         return ModelName.CLAUDE_OPUS_4_6
 
     # Priority 2: Individual provider keys
@@ -333,6 +432,18 @@ def get_or_create_model(
             )
         else:
             raise ValueError(f"Unsupported provider: {provider}")
+    elif key_provider == KeyProvider.OPENROUTER:
+        # OpenRouter: all models go through OpenAI-compatible API
+        if isinstance(model_name, ModelName) and model_name in MODEL_SPECS:
+            openrouter_name = MODEL_SPECS[model_name].openrouter_model_name
+        else:
+            openrouter_name = str(model_name)
+        openai_provider = OpenAIProvider(api_key=api_key, base_url=OPENROUTER_BASE_URL)
+        return OpenAIChatModel(
+            openrouter_name,
+            provider=openai_provider,
+            settings=ModelSettings(max_tokens=max_tokens),
+        )
     else:
         raise ValueError(f"Unsupported key provider: {key_provider}")
 
@@ -401,66 +512,29 @@ async def get_provider_model(
     # Use cached config for read-only access (performance)
     config = await config_manager.load(force_reload=False)
 
-    # Priority 1: Check if Shotgun key exists - if so, use it for ANY model
+    # Priority 1: Shotgun Account — use it for ANY model
     shotgun_api_key = _get_api_key(config.shotgun.api_key)
     if shotgun_api_key:
-        # Determine which model to use
-        if isinstance(provider_or_model, ModelName):
-            # Specific model requested - honor it (e.g., web search tools)
-            model_name = provider_or_model
-        elif isinstance(provider_or_model, ProviderType):
-            # Specific provider requested - use default model for that provider
-            # This is important for web search tools that need specific provider APIs
-            provider_defaults = {
-                ProviderType.OPENAI: ModelName.GPT_5_2,
-                ProviderType.ANTHROPIC: ModelName.CLAUDE_OPUS_4_6,
-                ProviderType.GOOGLE: ModelName.GEMINI_3_FLASH_PREVIEW,
-            }
-            # For provider-based requests, use selected ModelName or default
-            selected = (
-                config.selected_model
-                if isinstance(config.selected_model, ModelName)
-                else get_default_model_for_provider(config)
-            )
-            model_name = provider_defaults.get(provider_or_model, selected)
-        else:
-            # No specific model requested - use selected or default
-            # Only use selected_model if it's a ModelName enum (not Ollama string)
-            if isinstance(config.selected_model, ModelName):
-                model_name = config.selected_model
-            else:
-                model_name = get_default_model_for_provider(config)
-
-        # Gracefully fall back if the selected model doesn't exist (backwards compatibility)
-        if model_name not in MODEL_SPECS:
-            model_name = get_default_model_for_provider(config)
-
-        # Apply sub-agent model mapping for cost optimization
-        if for_sub_agent:
-            original_model = model_name
-            model_name = get_sub_agent_model(model_name)
-            if model_name != original_model:
-                logger.debug(
-                    "Sub-agent model substitution: %s -> %s",
-                    original_model.value,
-                    model_name.value,
-                )
-
-        spec = MODEL_SPECS[model_name]
-
-        # Use Shotgun Account with determined model (provider = actual LLM provider)
-        # Shotgun accounts always support streaming (via LiteLLM proxy)
-        return ModelConfig(
-            name=spec.name,
-            provider=spec.provider,  # Actual LLM provider (OPENAI/ANTHROPIC/GOOGLE)
-            key_provider=KeyProvider.SHOTGUN,  # Authenticated via Shotgun Account
-            max_input_tokens=spec.max_input_tokens,
-            max_output_tokens=spec.max_output_tokens,
+        return _build_multi_provider_model_config(
+            config,
+            provider_or_model,
+            for_sub_agent,
+            key_provider=KeyProvider.SHOTGUN,
             api_key=shotgun_api_key,
-            supports_streaming=True,  # Shotgun accounts always support streaming
         )
 
-    # Priority 1.5: Check for Ollama model (selected via TUI)
+    # Priority 1.5: OpenRouter — multi-model aggregator
+    openrouter_api_key = _get_api_key(config.openrouter.api_key, "OPENROUTER_API_KEY")
+    if openrouter_api_key:
+        return _build_multi_provider_model_config(
+            config,
+            provider_or_model,
+            for_sub_agent,
+            key_provider=KeyProvider.OPENROUTER,
+            api_key=openrouter_api_key,
+        )
+
+    # Priority 2: Check for Ollama model (selected via TUI)
     # Handle when user has selected an Ollama model without any cloud API keys
     if is_ollama_model(config.selected_model) and config.ollama.enabled:
         # is_ollama_model TypeGuard narrows type to str

--- a/src/shotgun/agents/conversation/history/token_counting/utils.py
+++ b/src/shotgun/agents/conversation/history/token_counting/utils.py
@@ -2,7 +2,7 @@
 
 from pydantic_ai.messages import ModelMessage
 
-from shotgun.agents.config.models import ModelConfig, ProviderType
+from shotgun.agents.config.models import KeyProvider, ModelConfig, ProviderType
 from shotgun.logging_config import get_logger
 
 from .anthropic import AnthropicTokenCounter
@@ -52,6 +52,17 @@ def get_token_counter(model_config: ModelConfig) -> TokenCounter:
     )
 
     counter: TokenCounter
+
+    # OpenRouter can't use provider-specific token counting APIs (e.g., Anthropic's
+    # count_tokens endpoint), so use a local tokenizer for all OpenRouter models.
+    if model_config.key_provider == KeyProvider.OPENROUTER:
+        counter = OpenAITokenCounter(str(model_config.name))
+        _token_counter_cache[cache_key] = counter
+        logger.debug(
+            f"Cached token counter for {model_config.provider.value}:{model_config.name}"
+        )
+        return counter
+
     if model_config.provider == ProviderType.OPENAI:
         counter = OpenAITokenCounter(model_config.name)
     elif model_config.provider == ProviderType.OPENAI_COMPATIBLE:

--- a/src/shotgun/agents/tools/web_search/__init__.py
+++ b/src/shotgun/agents/tools/web_search/__init__.py
@@ -4,6 +4,7 @@ Provides web search capabilities for multiple LLM providers:
 - OpenAI: Uses Responses API with web_search tool
 - Anthropic: Uses Messages API with web_search_20250305 tool
 - Gemini: Uses grounding with Google Search via Pydantic AI
+- OpenRouter: Uses :online model variant for web search grounding
 - OpenAI-compatible: Uses Responses API via custom endpoint (e.g., LiteLLM proxy)
 
 For BYOK users, Gemini Flash web search is preferred when a Google API key is available,
@@ -22,6 +23,7 @@ from .anthropic import anthropic_web_search_tool
 from .gemini import gemini_web_search_tool
 from .openai import openai_web_search_tool
 from .openai_compatible import openai_compatible_web_search_tool
+from .openrouter import openrouter_web_search_tool
 from .utils import is_provider_available
 
 logger = get_logger(__name__)
@@ -63,6 +65,11 @@ async def get_available_web_search_tools() -> list[WebSearchTool]:
         logger.info("Using Gemini web search (Shotgun Account)")
         return [gemini_web_search_tool]
 
+    # Priority 1.5: OpenRouter uses :online model variant
+    if config.openrouter.api_key:
+        logger.info("Using OpenRouter web search (:online variant)")
+        return [openrouter_web_search_tool]
+
     # Priority 2: For BYOK users, prefer Gemini web search when available
     # Gemini Flash grounded search is the most reliable web search option
     if await is_provider_available(ProviderType.GOOGLE):
@@ -88,6 +95,7 @@ __all__ = [
     "anthropic_web_search_tool",
     "gemini_web_search_tool",
     "openai_compatible_web_search_tool",
+    "openrouter_web_search_tool",
     "get_available_web_search_tools",
     "is_provider_available",
     "WebSearchTool",

--- a/src/shotgun/agents/tools/web_search/openrouter.py
+++ b/src/shotgun/agents/tools/web_search/openrouter.py
@@ -1,0 +1,124 @@
+"""OpenRouter web search tool implementation."""
+
+from opentelemetry import trace
+from pydantic_ai.messages import ModelMessage, ModelRequest, TextPart
+from pydantic_ai.settings import ModelSettings
+
+from shotgun.agents.config.constants import MEDIUM_TEXT_8K_TOKENS
+from shotgun.agents.config.manager import get_config_manager
+from shotgun.agents.config.models import (
+    OPENROUTER_BASE_URL,
+    KeyProvider,
+    ModelConfig,
+    ProviderType,
+)
+from shotgun.agents.llm import shotgun_model_request
+from shotgun.agents.tools.registry import ToolCategory, register_tool
+from shotgun.agents.tools.web_search.utils import track_usage
+from shotgun.logging_config import get_logger
+from shotgun.prompts import PromptLoader
+from shotgun.utils.datetime_utils import get_datetime_context
+
+logger = get_logger(__name__)
+
+# Global prompt loader instance
+prompt_loader = PromptLoader()
+
+
+@register_tool(
+    category=ToolCategory.WEB_RESEARCH,
+    display_text="Searching web",
+    key_arg="query",
+)
+async def openrouter_web_search_tool(query: str) -> str:
+    """Perform a web search using OpenRouter's :online model variant.
+
+    Uses Google Gemini Flash via OpenRouter with the :online suffix
+    which enables web search grounding for the query.
+
+    Args:
+        query: The search query
+
+    Returns:
+        Search results as a formatted string
+    """
+    logger.debug("Invoking OpenRouter web_search_tool with query: %s", query)
+
+    span = trace.get_current_span()
+    span.set_attribute("input.value", f"**Query:** {query}\n")
+
+    # Get OpenRouter API key from config
+    config_manager = get_config_manager()
+    config = await config_manager.load(force_reload=False)
+
+    if not config.openrouter.api_key:
+        error_msg = "OpenRouter API key not configured"
+        logger.error(error_msg)
+        span.set_attribute("output.value", f"**Error:**\n {error_msg}\n")
+        return error_msg
+
+    openrouter_api_key = config.openrouter.api_key.get_secret_value()
+
+    # Create ModelConfig for OpenRouter with :online variant
+    model_config = ModelConfig(
+        name="google/gemini-3-flash-preview:online",
+        provider=ProviderType.GOOGLE,
+        key_provider=KeyProvider.OPENROUTER,
+        max_input_tokens=1_048_576,
+        max_output_tokens=65_536,
+        api_key=openrouter_api_key,
+        base_url=OPENROUTER_BASE_URL,
+        supports_streaming=True,
+    )
+
+    # Get datetime context for the search prompt
+    dt_context = get_datetime_context()
+
+    # Render search prompt from template
+    search_prompt = prompt_loader.render(
+        "tools/web_search.j2",
+        query=query,
+        current_datetime=dt_context.datetime_formatted,
+        timezone_name=dt_context.timezone_name,
+        utc_offset=dt_context.utc_offset,
+    )
+
+    # Build the request messages
+    messages: list[ModelMessage] = [ModelRequest.user_text_prompt(search_prompt)]
+
+    # Generate response using OpenRouter with :online model
+    try:
+        response = await shotgun_model_request(
+            model_config=model_config,
+            messages=messages,
+            model_settings=ModelSettings(
+                temperature=0.3,
+                max_tokens=MEDIUM_TEXT_8K_TOKENS,
+            ),
+        )
+
+        # Track usage from the web search LLM call
+        await track_usage(
+            response.usage,
+            model_name=str(model_config.name),
+            provider=model_config.provider,
+        )
+
+        # Extract text from response
+        result_text = "No content returned from search"
+        if response.parts:
+            for part in response.parts:
+                if isinstance(part, TextPart):
+                    result_text = part.content
+                    break
+
+        logger.debug("OpenRouter web search result: %d characters", len(result_text))
+
+        span.set_attribute("output.value", f"**Results:**\n {result_text}\n")
+
+        return result_text
+    except Exception as e:
+        error_msg = f"Error performing OpenRouter web search: {str(e)}"
+        logger.error("OpenRouter web search failed: %s", str(e))
+        span.set_attribute("output.value", f"**Error:**\n {error_msg}\n")
+        return error_msg

--- a/src/shotgun/tui/screens/model_picker.py
+++ b/src/shotgun/tui/screens/model_picker.py
@@ -236,15 +236,17 @@ class ModelPickerScreen(Screen[ModelConfigUpdated | None]):
             or config_manager.provider_has_api_key(config.anthropic)
             or config_manager.provider_has_api_key(config.google)
             or config_manager.provider_has_api_key(config.shotgun)
+            or config_manager.provider_has_api_key(config.openrouter)
         )
 
         # Log provider key status
         logger.debug(
-            "Provider keys: openai=%s, anthropic=%s, google=%s, shotgun=%s, has_any=%s",
+            "Provider keys: openai=%s, anthropic=%s, google=%s, shotgun=%s, openrouter=%s, has_any=%s",
             config_manager.provider_has_api_key(config.openai),
             config_manager.provider_has_api_key(config.anthropic),
             config_manager.provider_has_api_key(config.google),
             config_manager.provider_has_api_key(config.shotgun),
+            config_manager.provider_has_api_key(config.openrouter),
             has_cloud_keys,
         )
 
@@ -572,6 +574,11 @@ class ModelPickerScreen(Screen[ModelConfigUpdated | None]):
         # If Shotgun Account is configured, all models are available
         if self.config_manager.provider_has_api_key(config.shotgun):
             logger.debug("Model %s available (Shotgun Account configured)", model_name)
+            return True
+
+        # If OpenRouter is configured, all models are available
+        if self.config_manager.provider_has_api_key(config.openrouter):
+            logger.debug("Model %s available (OpenRouter configured)", model_name)
             return True
 
         # In BYOK mode, check if the model's provider has a key

--- a/src/shotgun/tui/screens/provider_config.py
+++ b/src/shotgun/tui/screens/provider_config.py
@@ -48,9 +48,9 @@ def get_configurable_providers() -> list[str]:
 
     Returns:
         List of provider identifiers that can be configured.
-        Includes all providers: openai, anthropic, google, and shotgun.
+        Includes: openrouter, openai, anthropic, google, and shotgun.
     """
-    return ["openai", "anthropic", "google", "shotgun"]
+    return ["openrouter", "openai", "anthropic", "google", "shotgun"]
 
 
 class ProviderConfigScreen(Screen[None]):
@@ -236,7 +236,7 @@ class ProviderConfigScreen(Screen[None]):
         ("ctrl+c", "app.quit", "Quit"),
     ]
 
-    selected_provider: reactive[str] = reactive("openai")
+    selected_provider: reactive[str] = reactive("openrouter")
     ollama_status: reactive[OllamaStatus | None] = reactive(None)
 
     def __init__(
@@ -586,6 +586,7 @@ class ProviderConfigScreen(Screen[None]):
             "openai": "OpenAI",
             "anthropic": "Anthropic",
             "google": "Google Gemini",
+            "openrouter": "OpenRouter",
             "shotgun": "Shotgun Account",
         }
         return names.get(provider_id, provider_id.title())
@@ -595,17 +596,18 @@ class ProviderConfigScreen(Screen[None]):
 
     async def _has_provider_key(self, provider_id: str) -> bool:
         """Check if provider has a configured API key."""
-        if provider_id == "shotgun":
-            # Check shotgun key directly
+        # Non-LLM providers (shotgun, openrouter) are config attributes, not ProviderType enums
+        if provider_id in ("openrouter", "shotgun"):
             config = await self.config_manager.load()
-            return self.config_manager.provider_has_api_key(config.shotgun)
-        else:
-            # Check LLM provider key
-            try:
-                provider = ProviderType(provider_id)
-                return await self.config_manager.has_provider_key(provider)
-            except ValueError:
-                return False
+            provider_config = getattr(config, provider_id)
+            return self.config_manager.provider_has_api_key(provider_config)
+
+        # Standard LLM providers (openai, anthropic, google)
+        try:
+            provider = ProviderType(provider_id)
+            return await self.config_manager.has_provider_key(provider)
+        except ValueError:
+            return False
 
     def _save_api_key(self) -> None:
         self.run_worker(self._do_save_api_key(), exclusive=True)

--- a/src/shotgun/tui/screens/welcome.py
+++ b/src/shotgun/tui/screens/welcome.py
@@ -227,9 +227,10 @@ class WelcomeScreen(Screen[None]):
                 with Vertical(classes="option-box", id="byok-box"):
                     yield Static("Bring Your Own Key (BYOK)", classes="option-title")
                     yield Markdown(
-                        "**Benefits:**\n"
-                        "• 100% Supported\n"
-                        "• Use your existing API keys from OpenAI, Anthropic, or Google",
+                        "**Recommended: [OpenRouter](https://openrouter.ai)**\n"
+                        "• One API key for all models (Anthropic, OpenAI, Google)\n"
+                        "• Pay-as-you-go pricing\n\n"
+                        "Or use individual API keys from OpenAI, Anthropic, or Google",
                         classes="option-benefits",
                     )
                     yield Button(

--- a/test/unit/agents/config/test_openrouter.py
+++ b/test/unit/agents/config/test_openrouter.py
@@ -1,0 +1,432 @@
+"""Tests for OpenRouter provider integration."""
+
+import json
+import os
+import tempfile
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pydantic import SecretStr
+from pydantic_ai.models.openai import OpenAIChatModel
+
+from shotgun.agents.config.manager import ConfigManager, _migrate_v10_to_v11
+from shotgun.agents.config.models import (
+    MODEL_SPECS,
+    OPENROUTER_BASE_URL,
+    AnthropicConfig,
+    KeyProvider,
+    ModelConfig,
+    ModelName,
+    OpenRouterConfig,
+    ProviderType,
+    ShotgunAccountConfig,
+    ShotgunConfig,
+)
+from shotgun.agents.config.provider import (
+    _resolve_multi_provider_model,
+    get_default_model_for_provider,
+    get_or_create_model,
+    get_provider_model,
+)
+
+# --- Helper to build config ---
+
+
+def _make_config(**kwargs) -> ShotgunConfig:
+    defaults = {"shotgun_instance_id": str(uuid.uuid4())}
+    defaults.update(kwargs)
+    return ShotgunConfig(**defaults)
+
+
+# ================================================================
+# get_provider_model(): OpenRouter block
+# ================================================================
+
+
+@pytest.fixture(autouse=True)
+def clear_model_cache():
+    """Clear the LRU cache before and after each test."""
+    get_or_create_model.cache_clear()
+    yield
+    get_or_create_model.cache_clear()
+
+
+@patch.dict(os.environ, {}, clear=True)
+@patch("shotgun.agents.config.provider.get_config_manager")
+@pytest.mark.asyncio
+async def test_get_provider_model_openrouter_returns_config(mock_get_config_manager):
+    """get_provider_model returns OpenRouter ModelConfig when OpenRouter key is set."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        manager = ConfigManager(config_path=Path(temp_dir) / "config.json")
+        config = _make_config(
+            openrouter=OpenRouterConfig(api_key=SecretStr("or-test-key")),
+        )
+        manager._config = config
+        mock_get_config_manager.return_value = manager
+
+        result = await get_provider_model()
+
+        assert isinstance(result, ModelConfig)
+        assert result.key_provider == KeyProvider.OPENROUTER
+        assert result.api_key == "or-test-key"
+        assert result.supports_streaming is True
+        # Default model should be Opus 4.6
+        assert result.name == ModelName.CLAUDE_OPUS_4_6
+
+
+@patch.dict(os.environ, {}, clear=True)
+@patch("shotgun.agents.config.provider.get_config_manager")
+@pytest.mark.asyncio
+async def test_openrouter_priority_below_shotgun(mock_get_config_manager):
+    """Shotgun Account takes priority over OpenRouter when both are configured."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        manager = ConfigManager(config_path=Path(temp_dir) / "config.json")
+        config = _make_config(
+            shotgun=ShotgunAccountConfig(api_key=SecretStr("sg-key")),
+            openrouter=OpenRouterConfig(api_key=SecretStr("or-key")),
+        )
+        manager._config = config
+        mock_get_config_manager.return_value = manager
+
+        result = await get_provider_model()
+
+        assert result.key_provider == KeyProvider.SHOTGUN
+        assert result.api_key == "sg-key"
+
+
+@patch.dict(os.environ, {}, clear=True)
+@patch("shotgun.agents.config.provider.get_config_manager")
+@pytest.mark.asyncio
+async def test_openrouter_priority_above_byok(mock_get_config_manager):
+    """OpenRouter takes priority over individual BYOK keys."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        manager = ConfigManager(config_path=Path(temp_dir) / "config.json")
+        config = _make_config(
+            openrouter=OpenRouterConfig(api_key=SecretStr("or-key")),
+            anthropic=AnthropicConfig(api_key=SecretStr("ant-key")),
+        )
+        manager._config = config
+        mock_get_config_manager.return_value = manager
+
+        result = await get_provider_model()
+
+        assert result.key_provider == KeyProvider.OPENROUTER
+        assert result.api_key == "or-key"
+
+
+@patch.dict(os.environ, {}, clear=True)
+@patch("shotgun.agents.config.provider.get_config_manager")
+@pytest.mark.asyncio
+async def test_openrouter_sub_agent_model_mapping(mock_get_config_manager):
+    """OpenRouter applies sub-agent model mapping for cost optimization."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        manager = ConfigManager(config_path=Path(temp_dir) / "config.json")
+        config = _make_config(
+            openrouter=OpenRouterConfig(api_key=SecretStr("or-key")),
+        )
+        manager._config = config
+        mock_get_config_manager.return_value = manager
+
+        result = await get_provider_model(for_sub_agent=True)
+
+        # Opus 4.6 -> Haiku 4.5 for sub-agents
+        assert result.name == ModelName.CLAUDE_HAIKU_4_5
+        assert result.key_provider == KeyProvider.OPENROUTER
+
+
+@patch.dict(os.environ, {}, clear=True)
+@patch("shotgun.agents.config.provider.get_config_manager")
+@pytest.mark.asyncio
+async def test_openrouter_specific_model_request(mock_get_config_manager):
+    """OpenRouter honors specific ModelName requests."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        manager = ConfigManager(config_path=Path(temp_dir) / "config.json")
+        config = _make_config(
+            openrouter=OpenRouterConfig(api_key=SecretStr("or-key")),
+        )
+        manager._config = config
+        mock_get_config_manager.return_value = manager
+
+        result = await get_provider_model(ModelName.GPT_5_2)
+
+        assert result.name == ModelName.GPT_5_2
+        assert result.key_provider == KeyProvider.OPENROUTER
+        assert result.provider == ProviderType.OPENAI
+
+
+@patch.dict(os.environ, {"OPENROUTER_API_KEY": "or-env-key"}, clear=True)
+@patch("shotgun.agents.config.provider.get_config_manager")
+@pytest.mark.asyncio
+async def test_openrouter_env_var_fallback(mock_get_config_manager):
+    """OpenRouter falls back to OPENROUTER_API_KEY environment variable."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        manager = ConfigManager(config_path=Path(temp_dir) / "config.json")
+        # No openrouter key in config, but env var is set
+        config = _make_config()
+        manager._config = config
+        mock_get_config_manager.return_value = manager
+
+        result = await get_provider_model()
+
+        assert result.key_provider == KeyProvider.OPENROUTER
+        assert result.api_key == "or-env-key"
+
+
+@patch.dict(os.environ, {}, clear=True)
+@patch("shotgun.agents.config.provider.get_config_manager")
+@pytest.mark.asyncio
+async def test_openrouter_with_selected_model(mock_get_config_manager):
+    """OpenRouter respects the user's selected_model from config."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        manager = ConfigManager(config_path=Path(temp_dir) / "config.json")
+        config = _make_config(
+            openrouter=OpenRouterConfig(api_key=SecretStr("or-key")),
+            selected_model=ModelName.GEMINI_3_PRO_PREVIEW,
+        )
+        manager._config = config
+        mock_get_config_manager.return_value = manager
+
+        result = await get_provider_model()
+
+        assert result.name == ModelName.GEMINI_3_PRO_PREVIEW
+        assert result.key_provider == KeyProvider.OPENROUTER
+
+
+# ================================================================
+# get_default_model_for_provider()
+# ================================================================
+
+
+def test_get_default_model_openrouter():
+    """get_default_model_for_provider returns Opus 4.6 for OpenRouter."""
+    config = _make_config(
+        openrouter=OpenRouterConfig(api_key=SecretStr("or-key")),
+    )
+    result = get_default_model_for_provider(config)
+    assert result == ModelName.CLAUDE_OPUS_4_6
+
+
+def test_get_default_model_shotgun_over_openrouter():
+    """get_default_model_for_provider prefers Shotgun over OpenRouter."""
+    config = _make_config(
+        shotgun=ShotgunAccountConfig(api_key=SecretStr("sg-key")),
+        openrouter=OpenRouterConfig(api_key=SecretStr("or-key")),
+    )
+    result = get_default_model_for_provider(config)
+    # Both would return CLAUDE_OPUS_4_6, but shotgun path is tested
+    assert result == ModelName.CLAUDE_OPUS_4_6
+
+
+# ================================================================
+# _resolve_multi_provider_model()
+# ================================================================
+
+
+def test_resolve_with_explicit_model_name():
+    """_resolve_multi_provider_model passes through explicit ModelName."""
+    config = _make_config()
+    result = _resolve_multi_provider_model(
+        config, ModelName.GPT_5_2, for_sub_agent=False
+    )
+    assert result == ModelName.GPT_5_2
+
+
+def test_resolve_with_provider_type():
+    """_resolve_multi_provider_model returns provider default for ProviderType."""
+    config = _make_config()
+    result = _resolve_multi_provider_model(
+        config, ProviderType.OPENAI, for_sub_agent=False
+    )
+    assert result == ModelName.GPT_5_2
+
+
+def test_resolve_with_none_uses_selected_model():
+    """_resolve_multi_provider_model uses selected_model when provider_or_model is None."""
+    config = _make_config(selected_model=ModelName.GEMINI_3_FLASH_PREVIEW)
+    result = _resolve_multi_provider_model(config, None, for_sub_agent=False)
+    assert result == ModelName.GEMINI_3_FLASH_PREVIEW
+
+
+def test_resolve_applies_sub_agent_mapping():
+    """_resolve_multi_provider_model maps to cheaper model for sub-agents."""
+    config = _make_config(selected_model=ModelName.CLAUDE_OPUS_4_6)
+    result = _resolve_multi_provider_model(config, None, for_sub_agent=True)
+    assert result == ModelName.CLAUDE_HAIKU_4_5
+
+
+def test_resolve_falls_back_for_invalid_model():
+    """_resolve_multi_provider_model falls back when model not in MODEL_SPECS."""
+    config = _make_config(
+        selected_model="some-invalid-model",
+        openrouter=OpenRouterConfig(api_key=SecretStr("or-key")),
+    )
+    result = _resolve_multi_provider_model(config, None, for_sub_agent=False)
+    # Falls back to get_default_model_for_provider
+    assert result == ModelName.CLAUDE_OPUS_4_6
+
+
+# ================================================================
+# get_or_create_model(): OpenRouter key_provider
+# ================================================================
+
+
+def test_get_or_create_model_openrouter():
+    """get_or_create_model creates OpenAI-compatible model for OpenRouter."""
+    model = get_or_create_model(
+        provider=ProviderType.ANTHROPIC,
+        key_provider=KeyProvider.OPENROUTER,
+        model_name=ModelName.CLAUDE_OPUS_4_6,
+        api_key="or-test-key",
+    )
+    # Should be an OpenAIChatModel pointed at OpenRouter
+    assert isinstance(model, OpenAIChatModel)
+
+
+def test_get_or_create_model_openrouter_uses_openrouter_model_name():
+    """get_or_create_model maps ModelName to openrouter_model_name from specs."""
+    spec = MODEL_SPECS[ModelName.CLAUDE_OPUS_4_6]
+    assert spec.openrouter_model_name == "anthropic/claude-opus-4-6"
+
+
+# ================================================================
+# Migration: v10 -> v11
+# ================================================================
+
+
+def test_migrate_v10_to_v11_adds_openrouter():
+    """v10->v11 migration adds openrouter section."""
+    config = {
+        "openai": {"api_key": "sk-test"},
+        "config_version": 10,
+    }
+    result = _migrate_v10_to_v11(config)
+
+    assert "openrouter" in result
+    assert result["openrouter"] == {}
+    assert result["config_version"] == 11
+
+
+def test_migrate_v10_to_v11_preserves_existing_openrouter():
+    """v10->v11 migration preserves existing openrouter section."""
+    config = {
+        "openrouter": {"api_key": "or-existing-key"},
+        "config_version": 10,
+    }
+    result = _migrate_v10_to_v11(config)
+
+    assert result["openrouter"] == {"api_key": "or-existing-key"}
+    assert result["config_version"] == 11
+
+
+# ================================================================
+# has_any_provider_key() includes OpenRouter
+# ================================================================
+
+
+@pytest.mark.asyncio
+async def test_has_any_provider_key_includes_openrouter():
+    """has_any_provider_key returns True when only OpenRouter key is configured."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        manager = ConfigManager(config_path=Path(temp_dir) / "config.json")
+        config = _make_config(
+            openrouter=OpenRouterConfig(api_key=SecretStr("or-key")),
+        )
+        manager._config = config
+
+        result = await manager.has_any_provider_key()
+
+        assert result is True
+
+
+@pytest.mark.asyncio
+async def test_has_any_provider_key_false_without_any_keys():
+    """has_any_provider_key returns False when no keys are configured."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        manager = ConfigManager(config_path=Path(temp_dir) / "config.json")
+        config = _make_config()
+        manager._config = config
+
+        result = await manager.has_any_provider_key()
+
+        assert result is False
+
+
+# ================================================================
+# OpenRouter constants
+# ================================================================
+
+
+def test_openrouter_base_url():
+    """OPENROUTER_BASE_URL is the correct OpenRouter API endpoint."""
+    assert OPENROUTER_BASE_URL == "https://openrouter.ai/api/v1"
+
+
+def test_openrouter_config_default():
+    """OpenRouterConfig defaults to no API key."""
+    config = OpenRouterConfig()
+    assert config.api_key is None
+
+
+def test_all_model_specs_have_openrouter_model_name():
+    """Every model in MODEL_SPECS has an openrouter_model_name."""
+    for model_name, spec in MODEL_SPECS.items():
+        assert spec.openrouter_model_name, (
+            f"Model {model_name.value} is missing openrouter_model_name"
+        )
+
+
+def test_model_config_is_openrouter_property():
+    """ModelConfig.is_openrouter returns True for OpenRouter key provider."""
+    config = ModelConfig(
+        name=ModelName.CLAUDE_OPUS_4_6,
+        provider=ProviderType.ANTHROPIC,
+        key_provider=KeyProvider.OPENROUTER,
+        max_input_tokens=200_000,
+        max_output_tokens=64_000,
+        api_key="or-key",
+    )
+    assert config.is_openrouter is True
+    assert config.is_shotgun_account is False
+
+
+def test_model_config_is_openrouter_false_for_byok():
+    """ModelConfig.is_openrouter returns False for BYOK key provider."""
+    config = ModelConfig(
+        name=ModelName.CLAUDE_OPUS_4_6,
+        provider=ProviderType.ANTHROPIC,
+        key_provider=KeyProvider.BYOK,
+        max_input_tokens=200_000,
+        max_output_tokens=64_000,
+        api_key="ant-key",
+    )
+    assert config.is_openrouter is False
+
+
+# ================================================================
+# Manager load(): selected_model validation with OpenRouter
+# ================================================================
+
+
+@pytest.mark.asyncio
+async def test_load_preserves_selected_model_with_openrouter():
+    """Manager load() should NOT reset selected_model when OpenRouter key is present.
+
+    Regression test: previously, load() only checked for Shotgun Account keys
+    before validating BYOK keys. Without an Anthropic BYOK key, it would reset
+    selected_model=CLAUDE_OPUS_4_6 to None, even though OpenRouter provides
+    access to all models.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        config_path = Path(temp_dir) / "config.json"
+        config = _make_config(
+            openrouter=OpenRouterConfig(api_key=SecretStr("or-key")),
+            selected_model=ModelName.CLAUDE_OPUS_4_6,
+        )
+        config_path.write_text(json.dumps(config.model_dump(mode="json")))
+
+        manager = ConfigManager(config_path=config_path)
+        await manager.load()
+
+        assert manager._config.selected_model == ModelName.CLAUDE_OPUS_4_6

--- a/test/unit/agents/tools/web_search/test_openrouter_web_search.py
+++ b/test/unit/agents/tools/web_search/test_openrouter_web_search.py
@@ -1,0 +1,139 @@
+"""Tests for OpenRouter web search tool and routing."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from shotgun.agents.config.models import (
+    OPENROUTER_BASE_URL,
+    KeyProvider,
+)
+from shotgun.agents.tools.web_search.openrouter import openrouter_web_search_tool
+
+
+@pytest.mark.asyncio
+async def test_openrouter_web_search_uses_online_variant():
+    """OpenRouter web search uses :online model variant."""
+    mock_response = Mock()
+    mock_response.parts = [Mock(content="Search results")]
+    mock_response.parts[0].__class__.__name__ = "TextPart"
+    mock_response.usage = Mock()
+
+    with (
+        patch(
+            "shotgun.agents.tools.web_search.openrouter.get_config_manager"
+        ) as mock_get_cm,
+        patch(
+            "shotgun.agents.tools.web_search.openrouter.shotgun_model_request",
+            new_callable=AsyncMock,
+        ) as mock_request,
+        patch("shotgun.agents.tools.web_search.openrouter.trace") as mock_trace,
+        patch(
+            "shotgun.agents.tools.web_search.openrouter.track_usage",
+            new_callable=AsyncMock,
+        ),
+    ):
+        # Set up config mock
+        mock_config = Mock()
+        mock_config.openrouter.api_key = SecretStr("or-test-key")
+        mock_manager = AsyncMock()
+        mock_manager.load.return_value = mock_config
+        mock_get_cm.return_value = mock_manager
+
+        mock_request.return_value = mock_response
+        mock_trace.get_current_span.return_value = Mock()
+
+        # Import TextPart for isinstance check in the tool
+        from pydantic_ai.messages import TextPart
+
+        mock_response.parts = [TextPart(content="Search results")]
+
+        await openrouter_web_search_tool("test query")
+
+        # Verify model_config passed to shotgun_model_request uses :online variant
+        call_args = mock_request.call_args
+        model_config = call_args.kwargs.get("model_config") or call_args[0][0]
+        assert ":online" in str(model_config.name)
+        assert model_config.key_provider == KeyProvider.OPENROUTER
+        assert model_config.base_url == OPENROUTER_BASE_URL
+
+
+@pytest.mark.asyncio
+async def test_openrouter_web_search_no_api_key():
+    """OpenRouter web search returns error when API key is not configured."""
+    with (
+        patch(
+            "shotgun.agents.tools.web_search.openrouter.get_config_manager"
+        ) as mock_get_cm,
+        patch("shotgun.agents.tools.web_search.openrouter.trace") as mock_trace,
+    ):
+        mock_config = Mock()
+        mock_config.openrouter.api_key = None
+        mock_manager = AsyncMock()
+        mock_manager.load.return_value = mock_config
+        mock_get_cm.return_value = mock_manager
+        mock_trace.get_current_span.return_value = Mock()
+
+        result = await openrouter_web_search_tool("test query")
+
+        assert "not configured" in result
+
+
+@pytest.mark.asyncio
+async def test_web_search_routing_prefers_openrouter():
+    """get_available_web_search_tools returns OpenRouter tool when OpenRouter key is set."""
+    from shotgun.agents.tools.web_search import (
+        get_available_web_search_tools,
+    )
+    from shotgun.agents.tools.web_search import (
+        openrouter_web_search_tool as or_tool,
+    )
+
+    mock_config = Mock()
+    mock_config.shotgun.api_key = None  # No shotgun key
+    mock_config.openrouter.api_key = SecretStr("or-key")
+
+    with (
+        patch("shotgun.agents.tools.web_search.settings") as mock_settings,
+        patch("shotgun.agents.tools.web_search.get_config_manager") as mock_get_cm,
+    ):
+        mock_settings.openai_compat.base_url = None
+        mock_settings.openai_compat.api_key = None
+        mock_manager = AsyncMock()
+        mock_manager.load.return_value = mock_config
+        mock_get_cm.return_value = mock_manager
+
+        tools = await get_available_web_search_tools()
+
+        assert len(tools) == 1
+        assert tools[0] is or_tool
+
+
+@pytest.mark.asyncio
+async def test_web_search_routing_shotgun_over_openrouter():
+    """Shotgun Account web search takes priority over OpenRouter."""
+    from shotgun.agents.tools.web_search import (
+        gemini_web_search_tool,
+        get_available_web_search_tools,
+    )
+
+    mock_config = Mock()
+    mock_config.shotgun.api_key = SecretStr("sg-key")  # Shotgun key present
+    mock_config.openrouter.api_key = SecretStr("or-key")
+
+    with (
+        patch("shotgun.agents.tools.web_search.settings") as mock_settings,
+        patch("shotgun.agents.tools.web_search.get_config_manager") as mock_get_cm,
+    ):
+        mock_settings.openai_compat.base_url = None
+        mock_settings.openai_compat.api_key = None
+        mock_manager = AsyncMock()
+        mock_manager.load.return_value = mock_config
+        mock_get_cm.return_value = mock_manager
+
+        tools = await get_available_web_search_tools()
+
+        assert len(tools) == 1
+        # Shotgun uses gemini web search, not openrouter
+        assert tools[0] is gemini_web_search_tool

--- a/test/unit/test_config_migrations.py
+++ b/test/unit/test_config_migrations.py
@@ -140,6 +140,22 @@ V10_CONFIG = {
     "router_mode": "planning",
 }
 
+V11_CONFIG = {
+    "openai": {"api_key": "sk-test123", "supports_streaming": None},
+    "anthropic": {"api_key": None, "tier": None},
+    "google": {"api_key": None},
+    "shotgun": {"api_key": None, "supabase_jwt": None},
+    "openrouter": {},
+    "ollama": {"enabled": False, "base_url": "http://localhost:11434"},
+    "context7": {},
+    "selected_model": "gpt-5",
+    "shotgun_instance_id": "test-user-id-12345",
+    "config_version": 11,
+    "shown_welcome_screen": False,
+    "marketing": {"messages": {}},
+    "router_mode": "planning",
+}
+
 
 def test_migrate_v2_to_v3():
     """Test migration from version 2 to version 3."""
@@ -317,12 +333,12 @@ def test_apply_migrations_from_v4_to_current():
 
 def test_apply_migrations_already_current():
     """Test applying migrations when already at current version."""
-    config = V10_CONFIG.copy()
+    config = V11_CONFIG.copy()
 
     result = _apply_migrations(config)
 
     assert result["config_version"] == CURRENT_CONFIG_VERSION
-    assert result == V10_CONFIG  # Should be unchanged
+    assert result == V11_CONFIG  # Should be unchanged
 
 
 def test_apply_migrations_sequential():
@@ -809,7 +825,7 @@ async def test_load_creates_backup_only_when_migration_needed():
         config_path = Path(tmpdir) / "config.json"
 
         # Create a current version config (no migration needed)
-        current_config = V10_CONFIG.copy()
+        current_config = V11_CONFIG.copy()
         config_path.write_text(json.dumps(current_config))
 
         manager = ConfigManager(config_path=config_path)

--- a/test/unit/tui/test_provider_config.py
+++ b/test/unit/tui/test_provider_config.py
@@ -6,19 +6,27 @@ from shotgun.tui.screens.provider_config import get_configurable_providers
 
 
 @pytest.mark.smoke
-def test_get_configurable_providers_includes_shotgun():
-    """Test that get_configurable_providers always includes shotgun."""
+def test_get_configurable_providers_includes_all():
+    """Test that get_configurable_providers includes all expected providers."""
     providers = get_configurable_providers()
 
     assert "shotgun" in providers
     assert "openai" in providers
     assert "anthropic" in providers
     assert "google" in providers
+    assert "openrouter" in providers
 
 
 def test_get_configurable_providers_returns_all_providers():
-    """Test that get_configurable_providers returns all four providers."""
+    """Test that get_configurable_providers returns all five providers in order."""
     providers = get_configurable_providers()
 
-    assert len(providers) == 4
-    assert providers == ["openai", "anthropic", "google", "shotgun"]
+    assert len(providers) == 5
+    assert providers == ["openrouter", "openai", "anthropic", "google", "shotgun"]
+
+
+def test_get_configurable_providers_openrouter_is_first():
+    """Test that openrouter is the first provider in the list."""
+    providers = get_configurable_providers()
+
+    assert providers[0] == "openrouter"


### PR DESCRIPTION
## Summary

- Adds OpenRouter as a multi-model API aggregator provider, giving users access to all models (Anthropic, OpenAI, Google) with a single API key
- Priority order: Shotgun Account > OpenRouter > individual BYOK providers
- Extracts `_resolve_multi_provider_model()` shared helper to deduplicate multi-model provider logic between Shotgun Account and OpenRouter

## Changes

**Config & Provider** (`src/shotgun/agents/config/`)
- `KeyProvider.OPENROUTER` enum, `OpenRouterConfig` model, `OPENROUTER_BASE_URL` constant
- `openrouter_model_name` field on `ModelSpec` for all models
- `is_openrouter` property on `ModelConfig`
- OpenRouter block in `get_provider_model()` and `get_or_create_model()`
- `_resolve_multi_provider_model()` shared helper extracted from Shotgun Account inline logic
- Config migration v10→v11 adding `openrouter` section
- `has_any_provider_key()` and `load()` validation updated for OpenRouter

**Web Search** (`src/shotgun/agents/tools/web_search/`)
- New `openrouter_web_search_tool` using OpenRouter's `:online` model variant
- Routing priority: Shotgun > OpenRouter > BYOK

**TUI** (`src/shotgun/tui/screens/`)
- OpenRouter in provider config list and model picker
- All models available when OpenRouter key is configured

**Bug Fixes**
- Token counting uses local tokenizer for OpenRouter (not Anthropic's count_tokens API)
- `selected_model` validation in `load()` accounts for OpenRouter

## Test plan

- [x] 30 new tests across `test_openrouter.py` and `test_openrouter_web_search.py`
- [x] Updated `test_config_migrations.py` and `test_provider_config.py`
- [x] mypy clean (excluding pre-existing MCP issues)
- [x] ruff clean
- [x] Smoke tests pass (7/7)
- [ ] Manual TUI test: settings → add OpenRouter key → verify all models available

🤖 Generated with [Claude Code](https://claude.com/claude-code)