### PR TITLE
feat(config): update Gemini model to 3.1 Pro and fix sub-agent preload ordering

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -15,7 +15,7 @@ uv run python -m evals.runner --suite router_smoke --model claude-opus-4-6 --no-
 uv run python -m evals.runner --case vague_prompt_clarifying_questions --model claude-opus-4-6
 
 # Compare multiple models
-uv run python -m evals.runner --suite router_smoke --model claude-opus-4-6 --model gpt-5.1 --model gemini-3-pro-preview
+uv run python -m evals.runner --suite router_smoke --model claude-opus-4-6 --model gpt-5.1 --model gemini-3.1-pro-preview
 ```
 
 ## Output Formats

--- a/src/shotgun/agents/config/manager.py
+++ b/src/shotgun/agents/config/manager.py
@@ -61,7 +61,7 @@ ProviderConfig = (
 )
 
 # Current config version
-CURRENT_CONFIG_VERSION = 11
+CURRENT_CONFIG_VERSION = 12
 
 # Backup directory name
 BACKUP_DIR_NAME = "backup"
@@ -320,6 +320,28 @@ def _migrate_v10_to_v11(data: dict[str, Any]) -> dict[str, Any]:
     return data
 
 
+def _migrate_v11_to_v12(data: dict[str, Any]) -> dict[str, Any]:
+    """Migrate config from version 11 to version 12.
+
+    Changes:
+    - Rename Gemini model from gemini-3-pro-preview to gemini-3.1-pro-preview
+    """
+    model_renames = {
+        "gemini-3-pro-preview": "gemini-3.1-pro-preview",
+    }
+    selected = data.get("selected_model")
+    if selected in model_renames:
+        data["selected_model"] = model_renames[selected]
+        logger.info(
+            "Migrated config v11->v12: renamed selected_model %s -> %s",
+            selected,
+            model_renames[selected],
+        )
+
+    data["config_version"] = 12
+    return data
+
+
 def _apply_migrations(data: dict[str, Any]) -> dict[str, Any]:
     """Apply all necessary migrations to bring config to current version.
 
@@ -346,6 +368,7 @@ def _apply_migrations(data: dict[str, Any]) -> dict[str, Any]:
         8: _migrate_v8_to_v9,
         9: _migrate_v9_to_v10,
         10: _migrate_v10_to_v11,
+        11: _migrate_v11_to_v12,
     }
 
     # Apply migrations sequentially

--- a/src/shotgun/agents/config/models.py
+++ b/src/shotgun/agents/config/models.py
@@ -48,7 +48,7 @@ class ModelName(StrEnum):
     CLAUDE_SONNET_4_6 = "claude-sonnet-4-6"
     CLAUDE_HAIKU_4_5 = "claude-haiku-4-5"
     GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite"
-    GEMINI_3_PRO_PREVIEW = "gemini-3-pro-preview"
+    GEMINI_3_1_PRO_PREVIEW = "gemini-3.1-pro-preview"
     GEMINI_3_FLASH_PREVIEW = "gemini-3-flash-preview"
 
 
@@ -62,7 +62,7 @@ class ModelSpec(BaseModel):
     litellm_proxy_model_name: (
         str  # LiteLLM format (e.g., "openai/gpt-5", "gemini/gemini-2-pro")
     )
-    openrouter_model_name: str  # OpenRouter format (e.g., "anthropic/claude-opus-4-6", "google/gemini-3-flash-preview")
+    openrouter_model_name: str  # OpenRouter format (e.g., "anthropic/claude-opus-4-6", "google/gemini-3.1-pro-preview")
     short_name: str  # Display name for UI (e.g., "Sonnet 4.6", "GPT-5")
 
 
@@ -217,14 +217,14 @@ MODEL_SPECS: dict[ModelName, ModelSpec] = {
         openrouter_model_name="google/gemini-2.5-flash-lite",
         short_name="Gemini 2.5 Flash Lite",
     ),
-    ModelName.GEMINI_3_PRO_PREVIEW: ModelSpec(
-        name=ModelName.GEMINI_3_PRO_PREVIEW,
+    ModelName.GEMINI_3_1_PRO_PREVIEW: ModelSpec(
+        name=ModelName.GEMINI_3_1_PRO_PREVIEW,
         provider=ProviderType.GOOGLE,
         max_input_tokens=1_048_576,
         max_output_tokens=65_536,
-        litellm_proxy_model_name="gemini/gemini-3-pro-preview",
-        openrouter_model_name="google/gemini-3-pro-preview",
-        short_name="Gemini 3 Pro",
+        litellm_proxy_model_name="gemini/gemini-3.1-pro-preview",
+        openrouter_model_name="google/gemini-3.1-pro-preview",
+        short_name="Gemini 3.1 Pro",
     ),
     ModelName.GEMINI_3_FLASH_PREVIEW: ModelSpec(
         name=ModelName.GEMINI_3_FLASH_PREVIEW,
@@ -241,7 +241,7 @@ MODEL_SPECS: dict[ModelName, ModelSpec] = {
 DEFAULT_PROVIDER_MODELS: dict[ProviderType, ModelName] = {
     ProviderType.OPENAI: ModelName.GPT_5_2,
     ProviderType.ANTHROPIC: ModelName.CLAUDE_OPUS_4_6,
-    ProviderType.GOOGLE: ModelName.GEMINI_3_PRO_PREVIEW,
+    ProviderType.GOOGLE: ModelName.GEMINI_3_1_PRO_PREVIEW,
 }
 
 # Sub-agent model mappings for cost optimization
@@ -251,7 +251,7 @@ SUB_AGENT_MODEL_MAPPINGS: dict[ModelName, ModelName] = {
     ModelName.CLAUDE_OPUS_4_6: ModelName.CLAUDE_HAIKU_4_5,
     ModelName.CLAUDE_SONNET_4_6: ModelName.CLAUDE_HAIKU_4_5,
     # Gemini: Pro uses Flash for sub-agents
-    ModelName.GEMINI_3_PRO_PREVIEW: ModelName.GEMINI_3_FLASH_PREVIEW,
+    ModelName.GEMINI_3_1_PRO_PREVIEW: ModelName.GEMINI_3_FLASH_PREVIEW,
     # OpenAI: 5.2 uses 5.1 for sub-agents
     ModelName.GPT_5_2: ModelName.GPT_5_1,
 }
@@ -425,7 +425,7 @@ class ShotgunConfig(BaseModel):
     shotgun_instance_id: str = Field(
         description="Unique shotgun instance identifier (also used for anonymous telemetry)",
     )
-    config_version: int = Field(default=11, description="Configuration schema version")
+    config_version: int = Field(default=12, description="Configuration schema version")
     shown_welcome_screen: bool = Field(
         default=False,
         description="Whether the welcome screen has been shown to the user",

--- a/src/shotgun/agents/config/provider.py
+++ b/src/shotgun/agents/config/provider.py
@@ -319,7 +319,7 @@ def get_default_model_for_provider(config: ShotgunConfig) -> ModelName:
     if _get_api_key(config.openai.api_key):
         return ModelName.GPT_5_2
     if _get_api_key(config.google.api_key):
-        return ModelName.GEMINI_3_PRO_PREVIEW
+        return ModelName.GEMINI_3_1_PRO_PREVIEW
 
     # Fallback: system-wide default
     return ModelName.CLAUDE_OPUS_4_6
@@ -736,13 +736,13 @@ async def get_provider_model(
                 "Gemini API key not configured. Set via config or GEMINI_API_KEY env var."
             )
 
-        # Use requested model or default to gemini-3-pro-preview
+        # Use requested model or default to gemini-3.1-pro-preview
         model_name = (
-            requested_model if requested_model else ModelName.GEMINI_3_PRO_PREVIEW
+            requested_model if requested_model else ModelName.GEMINI_3_1_PRO_PREVIEW
         )
         # Gracefully fall back if model doesn't exist
         if model_name not in MODEL_SPECS:
-            model_name = ModelName.GEMINI_3_PRO_PREVIEW
+            model_name = ModelName.GEMINI_3_1_PRO_PREVIEW
 
         # Apply sub-agent model mapping for cost optimization
         if for_sub_agent:

--- a/src/shotgun/agents/router/tools/delegation_tools.py
+++ b/src/shotgun/agents/router/tools/delegation_tools.py
@@ -18,6 +18,7 @@ from pydantic_ai.messages import (
     ModelResponse,
     ToolCallPart,
     ToolReturnPart,
+    UserPromptPart,
 )
 from pydantic_ai.tools import ToolDefinition
 
@@ -293,6 +294,18 @@ async def build_preloaded_history(
         loaded_paths.append(file_path)
 
     if loaded_paths:
+        # Prepend a synthetic user message so that the first tool call (ModelResponse)
+        # follows a user turn. Gemini requires: user turn → assistant tool call → tool return.
+        # Without this, the preloaded tool calls would immediately follow the system prompt,
+        # which Gemini rejects with "function call turn must come after a user turn".
+        user_msg = ModelRequest(
+            parts=[
+                UserPromptPart(
+                    content=f"Reading {len(loaded_paths)} preloaded file(s): {', '.join(loaded_paths)}"
+                )
+            ]
+        )
+        messages.insert(0, user_msg)
         logger.info("Preloaded %d files: %s", len(loaded_paths), loaded_paths)
 
     return messages, loaded_paths

--- a/src/shotgun/tui/screens/chat_screen/welcome_message.py
+++ b/src/shotgun/tui/screens/chat_screen/welcome_message.py
@@ -104,7 +104,7 @@ async def build_welcome_state() -> WelcomeMessage:
     frontier_models = {
         ModelName.CLAUDE_OPUS_4_6,
         ModelName.GPT_5_2,
-        ModelName.GEMINI_3_PRO_PREVIEW,
+        ModelName.GEMINI_3_1_PRO_PREVIEW,
     }
 
     if config.selected_model and config.selected_model in frontier_models:
@@ -121,8 +121,8 @@ async def build_welcome_state() -> WelcomeMessage:
             frontier_model_label = "Select GPT-5.2"
             frontier_model_name = ModelName.GPT_5_2
         elif has_google:
-            frontier_model_label = "Select Gemini 3 Pro"
-            frontier_model_name = ModelName.GEMINI_3_PRO_PREVIEW
+            frontier_model_label = "Select Gemini 3.1 Pro"
+            frontier_model_name = ModelName.GEMINI_3_1_PRO_PREVIEW
 
     return WelcomeMessage(
         is_home_directory=is_home,

--- a/src/shotgun/tui/screens/model_picker.py
+++ b/src/shotgun/tui/screens/model_picker.py
@@ -639,7 +639,7 @@ class ModelPickerScreen(Screen[ModelConfigUpdated | None]):
             ModelName.CLAUDE_SONNET_4_6: "Claude Sonnet 4.6 (Anthropic)",
             ModelName.CLAUDE_HAIKU_4_5: "Claude Haiku 4.5 (Anthropic)",
             ModelName.GEMINI_2_5_FLASH_LITE: "Gemini 2.5 Flash Lite (Google)",
-            ModelName.GEMINI_3_PRO_PREVIEW: "Gemini 3 Pro Preview (Google)",
+            ModelName.GEMINI_3_1_PRO_PREVIEW: "Gemini 3.1 Pro Preview (Google)",
             ModelName.GEMINI_3_FLASH_PREVIEW: "Gemini 3 Flash Preview (Google)",
         }
         return names.get(model_name, model_name.value)

--- a/test/unit/agents/config/test_models.py
+++ b/test/unit/agents/config/test_models.py
@@ -40,10 +40,10 @@ def test_model_spec_short_name_gpt_5_2():
     assert spec.short_name == "GPT-5.2"
 
 
-def test_model_spec_short_name_gemini_3_pro():
-    """Test ModelSpec short_name for Gemini 3 Pro."""
-    spec = MODEL_SPECS[ModelName.GEMINI_3_PRO_PREVIEW]
-    assert spec.short_name == "Gemini 3 Pro"
+def test_model_spec_short_name_gemini_3_1_pro():
+    """Test ModelSpec short_name for Gemini 3.1 Pro."""
+    spec = MODEL_SPECS[ModelName.GEMINI_3_1_PRO_PREVIEW]
+    assert spec.short_name == "Gemini 3.1 Pro"
 
 
 def test_model_spec_short_name_gemini_3_flash():

--- a/test/unit/agents/config/test_openrouter.py
+++ b/test/unit/agents/config/test_openrouter.py
@@ -183,14 +183,14 @@ async def test_openrouter_with_selected_model(mock_get_config_manager):
         manager = ConfigManager(config_path=Path(temp_dir) / "config.json")
         config = _make_config(
             openrouter=OpenRouterConfig(api_key=SecretStr("or-key")),
-            selected_model=ModelName.GEMINI_3_PRO_PREVIEW,
+            selected_model=ModelName.GEMINI_3_1_PRO_PREVIEW,
         )
         manager._config = config
         mock_get_config_manager.return_value = manager
 
         result = await get_provider_model()
 
-        assert result.name == ModelName.GEMINI_3_PRO_PREVIEW
+        assert result.name == ModelName.GEMINI_3_1_PRO_PREVIEW
         assert result.key_provider == KeyProvider.OPENROUTER
 
 

--- a/test/unit/agents/config/test_sub_agent_models.py
+++ b/test/unit/agents/config/test_sub_agent_models.py
@@ -26,9 +26,9 @@ def test_anthropic_haiku_returns_self():
 
 
 def test_gemini_pro_maps_to_flash():
-    """Gemini 3 Pro should map to Gemini 3 Flash for sub-agents."""
+    """Gemini 3.1 Pro should map to Gemini 3 Flash for sub-agents."""
     assert (
-        get_sub_agent_model(ModelName.GEMINI_3_PRO_PREVIEW)
+        get_sub_agent_model(ModelName.GEMINI_3_1_PRO_PREVIEW)
         == ModelName.GEMINI_3_FLASH_PREVIEW
     )
 

--- a/test/unit/agents/router/test_preload_files.py
+++ b/test/unit/agents/router/test_preload_files.py
@@ -11,6 +11,7 @@ from pydantic_ai.messages import (
     ModelResponse,
     ToolCallPart,
     ToolReturnPart,
+    UserPromptPart,
 )
 
 from shotgun.agents.config.models import KeyProvider, ModelConfig, ProviderType
@@ -60,10 +61,16 @@ async def test_build_preloaded_history_single_file(tmp_path):
         messages, loaded = await build_preloaded_history(["research.md"])
 
     assert loaded == ["research.md"]
-    assert len(messages) == 2
+    assert len(messages) == 3
 
-    # First message: ModelResponse with ToolCallPart
-    call_msg = messages[0]
+    # First message: Synthetic UserPromptPart (required for Gemini message ordering)
+    user_msg = messages[0]
+    assert isinstance(user_msg, ModelRequest)
+    assert len(user_msg.parts) == 1
+    assert isinstance(user_msg.parts[0], UserPromptPart)
+
+    # Second message: ModelResponse with ToolCallPart
+    call_msg = messages[1]
     assert isinstance(call_msg, ModelResponse)
     assert len(call_msg.parts) == 1
     call_part = call_msg.parts[0]
@@ -76,8 +83,8 @@ async def test_build_preloaded_history_single_file(tmp_path):
     assert call_part.tool_call_id is not None
     assert call_part.tool_call_id.startswith("preload-")
 
-    # Second message: ModelRequest with ToolReturnPart
-    return_msg = messages[1]
+    # Third message: ModelRequest with ToolReturnPart
+    return_msg = messages[2]
     assert isinstance(return_msg, ModelRequest)
     assert len(return_msg.parts) == 1
     return_part = return_msg.parts[0]
@@ -104,10 +111,14 @@ async def test_build_preloaded_history_multiple_files(tmp_path):
         )
 
     assert loaded == ["research.md", "specification.md"]
-    assert len(messages) == 4  # 2 pairs
+    assert len(messages) == 5  # 1 synthetic user msg + 2 pairs
+
+    # First message: synthetic user prompt
+    assert isinstance(messages[0], ModelRequest)
+    assert isinstance(messages[0].parts[0], UserPromptPart)
 
     # Check second pair has spec content
-    return_part = messages[3].parts[0]
+    return_part = messages[4].parts[0]
     assert isinstance(return_part, ToolReturnPart)
     assert return_part.content == "Spec content"
 
@@ -128,7 +139,7 @@ async def test_build_preloaded_history_nonexistent_file_skipped(tmp_path):
         )
 
     assert loaded == ["research.md"]
-    assert len(messages) == 2  # Only 1 pair for existing file
+    assert len(messages) == 3  # 1 synthetic user msg + 1 pair for existing file
 
 
 @pytest.mark.asyncio
@@ -152,8 +163,8 @@ async def test_build_preloaded_history_utf8_content(tmp_path):
         messages, loaded = await build_preloaded_history(["research.md"])
 
     assert loaded == ["research.md"]
-    assert len(messages) == 2
-    return_part = messages[1].parts[0]
+    assert len(messages) == 3
+    return_part = messages[2].parts[0]
     assert isinstance(return_part, ToolReturnPart)
     assert "Analiza" in return_part.content
     assert "\u017c" in return_part.content  # Polish character preserved
@@ -212,8 +223,8 @@ async def test_build_preloaded_history_tool_call_id_matches():
         ):
             messages, loaded = await build_preloaded_history(["plan.md"])
 
-    call_part = messages[0].parts[0]
-    return_part = messages[1].parts[0]
+    call_part = messages[1].parts[0]
+    return_part = messages[2].parts[0]
     assert isinstance(call_part, ToolCallPart)
     assert isinstance(return_part, ToolReturnPart)
     assert call_part.tool_call_id == return_part.tool_call_id
@@ -235,7 +246,7 @@ async def test_build_preloaded_history_subdirectory_files(tmp_path):
         messages, loaded = await build_preloaded_history(["contracts/auth.py"])
 
     assert loaded == ["contracts/auth.py"]
-    return_part = messages[1].parts[0]
+    return_part = messages[2].parts[0]
     assert isinstance(return_part, ToolReturnPart)
     assert return_part.content == "class AuthContract: pass"
 
@@ -378,9 +389,10 @@ async def test_run_sub_agent_passes_preloaded_history(tmp_path):
     # Verify the message_history was passed with preloaded content
     assert "message_history" in captured_kwargs
     history = captured_kwargs["message_history"]
-    assert len(history) == 2
-    assert isinstance(history[0], ModelResponse)
-    assert isinstance(history[1], ModelRequest)
+    assert len(history) == 3  # 1 synthetic user msg + 1 tool call/return pair
+    assert isinstance(history[0], ModelRequest)  # Synthetic user prompt
+    assert isinstance(history[1], ModelResponse)
+    assert isinstance(history[2], ModelRequest)
 
 
 @pytest.mark.asyncio

--- a/test/unit/test_config_manager.py
+++ b/test/unit/test_config_manager.py
@@ -355,7 +355,7 @@ async def test_get_provider_model_google_with_config_key(mock_get_config_manager
         model = await get_provider_model(ProviderType.GOOGLE)
 
         assert isinstance(model, ModelConfig)
-        assert model.name == "gemini-3-pro-preview"
+        assert model.name == "gemini-3.1-pro-preview"
         assert model.api_key == "test-google-key"
 
 
@@ -926,7 +926,7 @@ async def test_update_provider_sets_selected_model_for_google():
 
         # Verify selected_model is now set to Google's default
         config = await manager.load()
-        assert config.selected_model == ModelName.GEMINI_3_PRO_PREVIEW
+        assert config.selected_model == ModelName.GEMINI_3_1_PRO_PREVIEW
         assert config.google.api_key.get_secret_value() == "test-google-key"
 
 

--- a/test/unit/test_config_migrations.py
+++ b/test/unit/test_config_migrations.py
@@ -20,6 +20,7 @@ from shotgun.agents.config.manager import (
     _migrate_v6_to_v7,
     _migrate_v7_to_v8,
     _migrate_v9_to_v10,
+    _migrate_v11_to_v12,
     get_backup_dir,
 )
 from shotgun.agents.config.models import ProviderType, ShotgunConfig
@@ -151,6 +152,22 @@ V11_CONFIG = {
     "selected_model": "gpt-5",
     "shotgun_instance_id": "test-user-id-12345",
     "config_version": 11,
+    "shown_welcome_screen": False,
+    "marketing": {"messages": {}},
+    "router_mode": "planning",
+}
+
+V12_CONFIG = {
+    "openai": {"api_key": "sk-test123", "supports_streaming": None},
+    "anthropic": {"api_key": None, "tier": None},
+    "google": {"api_key": None},
+    "shotgun": {"api_key": None, "supabase_jwt": None},
+    "openrouter": {},
+    "ollama": {"enabled": False, "base_url": "http://localhost:11434"},
+    "context7": {},
+    "selected_model": "gpt-5",
+    "shotgun_instance_id": "test-user-id-12345",
+    "config_version": 12,
     "shown_welcome_screen": False,
     "marketing": {"messages": {}},
     "router_mode": "planning",
@@ -333,12 +350,12 @@ def test_apply_migrations_from_v4_to_current():
 
 def test_apply_migrations_already_current():
     """Test applying migrations when already at current version."""
-    config = V11_CONFIG.copy()
+    config = V12_CONFIG.copy()
 
     result = _apply_migrations(config)
 
     assert result["config_version"] == CURRENT_CONFIG_VERSION
-    assert result == V11_CONFIG  # Should be unchanged
+    assert result == V12_CONFIG  # Should be unchanged
 
 
 def test_apply_migrations_sequential():
@@ -687,7 +704,7 @@ def test_apply_migrations_v2_to_current_with_full_config():
     assert result["anthropic"]["api_key"] == "sk-ant-full-test"
     assert result["google"]["api_key"] == "AIza-full-test"
     assert result["shotgun"]["api_key"] == "sg_full_test"
-    assert result["selected_model"] == "gemini-3-pro-preview"
+    assert result["selected_model"] == "gemini-3.1-pro-preview"  # v11->v12
 
 
 def test_apply_migrations_v3_to_current_with_partial_config():
@@ -825,7 +842,7 @@ async def test_load_creates_backup_only_when_migration_needed():
         config_path = Path(tmpdir) / "config.json"
 
         # Create a current version config (no migration needed)
-        current_config = V11_CONFIG.copy()
+        current_config = V12_CONFIG.copy()
         config_path.write_text(json.dumps(current_config))
 
         manager = ConfigManager(config_path=config_path)
@@ -1031,3 +1048,25 @@ def test_migrate_v9_to_v10_preserves_other_models():
 
     assert result["config_version"] == 10
     assert result["selected_model"] == "gpt-5"
+
+
+def test_migrate_v11_to_v12_renames_gemini_3_pro():
+    """Test v11->v12 migration renames gemini-3-pro-preview to gemini-3.1-pro-preview."""
+    config = V11_CONFIG.copy()
+    config["selected_model"] = "gemini-3-pro-preview"
+
+    result = _migrate_v11_to_v12(config)
+
+    assert result["config_version"] == 12
+    assert result["selected_model"] == "gemini-3.1-pro-preview"
+
+
+def test_migrate_v11_to_v12_preserves_other_models():
+    """Test v11->v12 migration preserves non-Gemini models."""
+    config = V11_CONFIG.copy()
+    config["selected_model"] = "claude-opus-4-6"
+
+    result = _migrate_v11_to_v12(config)
+
+    assert result["config_version"] == 12
+    assert result["selected_model"] == "claude-opus-4-6"

--- a/test/unit/test_posthog_telemetry.py
+++ b/test/unit/test_posthog_telemetry.py
@@ -426,7 +426,7 @@ def test_submit_feedback_survey_other_feedback(
     """Test submitting other type of feedback."""
     mock_config_manager = MagicMock()
     mock_config = MagicMock()
-    mock_config.selected_model.value = "gemini-3-pro-preview"
+    mock_config.selected_model.value = "gemini-3.1-pro-preview"
     mock_config.config_version = "1.5.0"
     mock_config_manager.load = AsyncMock(return_value=mock_config)
     mock_get_config_manager.return_value = mock_config_manager

--- a/test/unit/test_provider.py
+++ b/test/unit/test_provider.py
@@ -124,7 +124,7 @@ async def test_get_provider_model_google_with_config_key(mock_get_config_manager
         model = await get_provider_model(ProviderType.GOOGLE)
 
         assert isinstance(model, ModelConfig)
-        assert model.name == "gemini-3-pro-preview"
+        assert model.name == "gemini-3.1-pro-preview"
         assert model.api_key == "test-google-key"
 
 

--- a/test/unit/tui/components/test_context_indicator.py
+++ b/test/unit/tui/components/test_context_indicator.py
@@ -172,7 +172,7 @@ def test_context_indicator_display_with_different_models():
         ModelName.CLAUDE_SONNET_4_6,
         ModelName.CLAUDE_OPUS_4_6,
         ModelName.GPT_5_1,
-        ModelName.GEMINI_3_PRO_PREVIEW,
+        ModelName.GEMINI_3_1_PRO_PREVIEW,
     ]:
         indicator.update_context(analysis, model_name)
         assert indicator.model_name == model_name

--- a/test/unit/tui/screens/chat_screen/test_welcome_message.py
+++ b/test/unit/tui/screens/chat_screen/test_welcome_message.py
@@ -196,8 +196,8 @@ async def test_build_welcome_state_byok_google_frontier():
     ):
         state = await build_welcome_state()
 
-    assert state.frontier_model_label == "Select Gemini 3 Pro"
-    assert state.frontier_model_name == "gemini-3-pro-preview"
+    assert state.frontier_model_label == "Select Gemini 3.1 Pro"
+    assert state.frontier_model_name == "gemini-3.1-pro-preview"
     assert state.has_gemini_key is True
 
 


### PR DESCRIPTION
## Summary
- Update default Gemini model from `gemini-3-pro-preview` to `gemini-3.1-pro-preview` for both shotgun accounts and BYOK
- Add config migration v11→v12 to auto-rename existing users' selected model
- Fix Gemini sub-agent crash when files are preloaded: prepend a synthetic user message so tool calls follow a user turn (Gemini's strict ordering requirement)

## Test plan
- [x] All smoke tests pass (`pytest -m smoke`)
- [x] All affected unit tests pass (config migrations, provider, models, preload files, welcome message, etc.)
- [x] mypy passes on all changed source files
- [x] ruff passes on all changed files
- [x] Verified migration correctly renames `gemini-3-pro-preview` → `gemini-3.1-pro-preview`
- [x] Verified preloaded history now starts with UserPromptPart before tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)