### PR TITLE
fix(tui): constrain indexing progress bar to single line

### DIFF
--- a/src/shotgun/tui/screens/chat/chat.tcss
+++ b/src/shotgun/tui/screens/chat/chat.tcss
@@ -65,6 +65,8 @@ ModeIndicator.mode-drafting {
 
 #indexing-job-display {
   text-align: end;
+  height: 1;
+  width: auto;
 }
 
 AttachmentBar {


### PR DESCRIPTION
## Summary
- Added `height: 1` and `width: auto` CSS constraints to `#indexing-job-display` in the chat footer
- The progress bar was rendering on multiple lines and squished in the corner because it lacked the same constraints as sibling indicators (`#model-indicator`, `#update-indicator`)

## Test plan
- [ ] Launch TUI and trigger a codebase index to verify the progress bar renders on a single line
- [ ] Verify the progress bar is right-aligned and properly sized in the footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)