### PR TITLE
fix: scope database health check to current repo to enable concurrent sessions

### DIFF
--- a/src/shotgun/agents/tools/codebase/codebase_shell.py
+++ b/src/shotgun/agents/tools/codebase/codebase_shell.py
@@ -128,20 +128,9 @@ async def codebase_shell(
 
         # Get repository path from specified graph or first available graph
         try:
-            graphs = await ctx.deps.codebase_service.list_graphs()
-
-            if not graphs:
-                return ShellCommandResult(
-                    success=False,
-                    command=command,
-                    args=args,
-                    error="No codebase indexed. Index a codebase first.",
-                )
-
-            # Select the appropriate graph
+            graph = None
             if graph_id:
-                # Find specific graph by ID
-                graph = next((g for g in graphs if g.graph_id == graph_id), None)
+                graph = await ctx.deps.codebase_service.get_graph(graph_id)
                 if not graph:
                     return ShellCommandResult(
                         success=False,
@@ -150,7 +139,14 @@ async def codebase_shell(
                         error=f"Graph '{graph_id}' not found",
                     )
             else:
-                # Use the first available graph
+                graphs = await ctx.deps.codebase_service.list_graphs()
+                if not graphs:
+                    return ShellCommandResult(
+                        success=False,
+                        command=command,
+                        args=args,
+                        error="No codebase indexed. Index a codebase first.",
+                    )
                 graph = graphs[0]
 
             repo_path = Path(graph.repo_path)

--- a/src/shotgun/agents/tools/codebase/directory_lister.py
+++ b/src/shotgun/agents/tools/codebase/directory_lister.py
@@ -38,10 +38,8 @@ async def directory_lister(
         repo_path: Path | None = None
 
         if graph_id and ctx.deps.codebase_service:
-            # Try to get the graph to find the repository path
             try:
-                graphs = await ctx.deps.codebase_service.list_graphs()
-                graph = next((g for g in graphs if g.graph_id == graph_id), None)
+                graph = await ctx.deps.codebase_service.get_graph(graph_id)
                 if graph:
                     repo_path = Path(graph.repo_path).resolve()
             except Exception as e:

--- a/src/shotgun/agents/tools/codebase/file_read.py
+++ b/src/shotgun/agents/tools/codebase/file_read.py
@@ -40,10 +40,8 @@ async def file_read(
         repo_path: Path | None = None
 
         if graph_id and ctx.deps.codebase_service:
-            # Try to get the graph to find the repository path
             try:
-                graphs = await ctx.deps.codebase_service.list_graphs()
-                graph = next((g for g in graphs if g.graph_id == graph_id), None)
+                graph = await ctx.deps.codebase_service.get_graph(graph_id)
                 if graph:
                     repo_path = Path(graph.repo_path).resolve()
             except Exception as e:

--- a/src/shotgun/codebase/core/manager.py
+++ b/src/shotgun/codebase/core/manager.py
@@ -1552,26 +1552,40 @@ class CodebaseGraphManager:
             )
 
     async def detect_database_issues(
-        self, timeout_seconds: float = 10.0
+        self,
+        timeout_seconds: float = 10.0,
+        graph_ids: list[str] | None = None,
     ) -> list[DatabaseIssue]:
         """Detect issues with Kuzu databases without deleting them.
 
-        This method iterates through all .kuzu files in the storage directory,
-        attempts to open them, and returns information about any issues found.
-        Unlike cleanup_corrupted_databases(), this method does NOT delete anything -
-        it only detects and reports issues for the caller to handle.
+        This method attempts to open databases and returns information about any
+        issues found. Unlike cleanup_corrupted_databases(), this method does NOT
+        delete anything - it only detects and reports issues for the caller to
+        handle.
 
         Args:
             timeout_seconds: How long to wait for each database to respond.
                             Default is 10s; use 90s for retry with large codebases.
+            graph_ids: If provided, only check these specific graph IDs instead
+                      of scanning all databases. This avoids acquiring exclusive
+                      file locks on databases belonging to other repositories,
+                      enabling concurrent Shotgun sessions on different repos.
 
         Returns:
             List of DatabaseIssue objects describing any problems found
         """
         issues: list[DatabaseIssue] = []
 
-        for path in self.storage_dir.glob("*.kuzu"):
-            graph_id = path.stem
+        if graph_ids is not None:
+            candidates = [
+                (gid, self.storage_dir / f"{gid}.kuzu")
+                for gid in graph_ids
+                if (self.storage_dir / f"{gid}.kuzu").exists()
+            ]
+        else:
+            candidates = [(p.stem, p) for p in self.storage_dir.glob("*.kuzu")]
+
+        for graph_id, path in candidates:
             issue = await self._check_single_database(graph_id, path, timeout_seconds)
             if issue:
                 issues.append(issue)

--- a/src/shotgun/codebase/core/manager.py
+++ b/src/shotgun/codebase/core/manager.py
@@ -224,6 +224,55 @@ class CodebaseGraphManager:
         normalized = str(Path(repo_path).resolve())
         return hashlib.sha256(normalized.encode()).hexdigest()[:12]
 
+    def _write_graph_meta(
+        self,
+        graph_id: str,
+        repo_path: str,
+        name: str,
+        indexed_from_cwds: list[str],
+    ) -> None:
+        """Write a lightweight JSON sidecar with graph metadata.
+
+        This allows list_graphs_for_directory() to filter graphs by path
+        without opening .kuzu databases (which would acquire exclusive locks
+        and block concurrent sessions on other repositories).
+        """
+        meta_path = self.storage_dir / f"{graph_id}.meta.json"
+        meta = {
+            "graph_id": graph_id,
+            "repo_path": repo_path,
+            "name": name,
+            "indexed_from_cwds": indexed_from_cwds,
+        }
+        meta_path.write_text(json.dumps(meta), encoding="utf-8")
+
+    def _read_graph_meta(self, graph_id: str) -> dict | None:
+        """Read a graph's sidecar metadata. Returns None if missing."""
+        meta_path = self.storage_dir / f"{graph_id}.meta.json"
+        if not meta_path.exists():
+            return None
+        try:
+            return json.loads(meta_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    def _delete_graph_meta(self, graph_id: str) -> None:
+        """Delete a graph's sidecar metadata file."""
+        meta_path = self.storage_dir / f"{graph_id}.meta.json"
+        if meta_path.exists():
+            meta_path.unlink(missing_ok=True)
+
+    def list_graph_metas(self) -> list[dict]:
+        """Read all .meta.json files (no Kuzu locks acquired)."""
+        metas = []
+        for path in self.storage_dir.glob("*.meta.json"):
+            try:
+                meta = json.loads(path.read_text(encoding="utf-8"))
+                metas.append(meta)
+            except (json.JSONDecodeError, OSError):
+                continue
+        return metas
+
     async def _update_graph_status(
         self, graph_id: str, status: GraphStatus, operation_id: str | None = None
     ) -> None:
@@ -351,7 +400,14 @@ class CodebaseGraphManager:
             },
         )
 
-        # Ensure the Project node is committed
+        # Write sidecar metadata for lock-free directory filtering
+        self._write_graph_meta(
+            graph_id=graph_id,
+            repo_path=repo_path,
+            name=name,
+            indexed_from_cwds=[indexed_from_cwd] if indexed_from_cwd else [],
+        )
+
         logger.info(f"Created initial Project node for graph {graph_id}")
 
     async def build_graph(
@@ -1349,11 +1405,18 @@ class CodebaseGraphManager:
             )
             return None
 
-    async def cleanup_corrupted_databases(self) -> list[str]:
+    async def cleanup_corrupted_databases(
+        self, graph_ids: list[str] | None = None
+    ) -> list[str]:
         """Detect and remove corrupted Kuzu databases.
 
-        This method iterates through all .kuzu files in the storage directory,
+        This method iterates through .kuzu files in the storage directory,
         attempts to open them, and removes any that are corrupted or unreadable.
+
+        Args:
+            graph_ids: If provided, only check these specific graph IDs instead
+                      of scanning all .kuzu files. This avoids opening databases
+                      belonging to other concurrent sessions.
 
         Returns:
             List of graph_ids that were removed due to corruption
@@ -1362,10 +1425,16 @@ class CodebaseGraphManager:
 
         removed_graphs = []
 
-        # Find all .kuzu databases (files in v0.11.2, directories in newer versions)
-        for path in self.storage_dir.glob("*.kuzu"):
-            graph_id = path.stem
+        if graph_ids is not None:
+            candidates = [
+                (gid, self.storage_dir / f"{gid}.kuzu")
+                for gid in graph_ids
+                if (self.storage_dir / f"{gid}.kuzu").exists()
+            ]
+        else:
+            candidates = [(p.stem, p) for p in self.storage_dir.glob("*.kuzu")]
 
+        for graph_id, path in candidates:
             # Try to open and validate the database
             try:
                 # Try to open the database with a timeout to prevent hanging
@@ -1637,6 +1706,7 @@ class CodebaseGraphManager:
                     await anyio.to_thread.run_sync(wal_path.unlink)
                     logger.debug(f"Deleted WAL file: {wal_path}")
 
+                self._delete_graph_meta(graph_id)
                 logger.info(f"Deleted database: {graph_id}")
                 return True
             else:
@@ -1647,21 +1717,38 @@ class CodebaseGraphManager:
             logger.error(f"Failed to delete database {graph_id}: {e}")
             return False
 
-    async def list_graphs(self) -> list[CodebaseGraph]:
-        """List all available graphs.
+    async def list_graphs(
+        self, graph_ids: list[str] | None = None
+    ) -> list[CodebaseGraph]:
+        """List available graphs.
+
+        Args:
+            graph_ids: If provided, only load these specific graph IDs instead
+                      of scanning all .kuzu files. This avoids opening (and
+                      locking) databases belonging to other concurrent sessions.
 
         Returns:
             List of graph metadata
         """
         graphs = []
 
-        # Find all .kuzu database files (Kuzu v0.11.2 creates files, not directories)
-        for path in self.storage_dir.glob("*.kuzu"):
-            if path.is_file():
-                graph_id = path.stem
-                graph = await self.get_graph(graph_id)
-                if graph:
-                    graphs.append(graph)
+        if graph_ids is not None:
+            candidates = [
+                (gid, self.storage_dir / f"{gid}.kuzu")
+                for gid in graph_ids
+                if (self.storage_dir / f"{gid}.kuzu").is_file()
+            ]
+        else:
+            candidates = [
+                (p.stem, p)
+                for p in self.storage_dir.glob("*.kuzu")
+                if p.is_file()
+            ]
+
+        for graph_id, _path in candidates:
+            graph = await self.get_graph(graph_id)
+            if graph:
+                graphs.append(graph)
 
         return sorted(graphs, key=lambda g: g.updated_at, reverse=True)
 
@@ -1703,6 +1790,13 @@ class CodebaseGraphManager:
                     "indexed_from_cwds": json.dumps(current_cwds),
                 },
             )
+            # Keep sidecar in sync
+            self._write_graph_meta(
+                graph_id=graph_id,
+                repo_path=graph.repo_path,
+                name=graph.name,
+                indexed_from_cwds=current_cwds,
+            )
             logger.info(f"Added CWD access for {cwd} to graph {graph_id}")
 
     async def remove_cwd_access(self, graph_id: str, cwd: str) -> None:
@@ -1739,6 +1833,13 @@ class CodebaseGraphManager:
                     "graph_id": graph_id,
                     "indexed_from_cwds": json.dumps(current_cwds),
                 },
+            )
+            # Keep sidecar in sync
+            self._write_graph_meta(
+                graph_id=graph_id,
+                repo_path=graph.repo_path,
+                name=graph.name,
+                indexed_from_cwds=current_cwds,
             )
             logger.info(f"Removed CWD access for {cwd} from graph {graph_id}")
 
@@ -1784,6 +1885,7 @@ class CodebaseGraphManager:
         if wal_path.exists():
             await anyio.to_thread.run_sync(wal_path.unlink)
 
+        self._delete_graph_meta(graph_id)
         logger.info(f"Deleted graph - graph_id: {graph_id}")
 
     async def _get_graph_statistics(

--- a/src/shotgun/codebase/service.py
+++ b/src/shotgun/codebase/service.py
@@ -55,6 +55,14 @@ class CodebaseService:
     ) -> list[CodebaseGraph]:
         """List graphs that match a specific directory.
 
+        Uses lightweight .meta.json sidecar files to filter candidates without
+        opening any Kuzu databases, then loads only the matching graphs. This
+        prevents exclusive file locks from blocking concurrent Shotgun sessions
+        on other repositories.
+
+        Falls back to the full scan when no sidecar files exist (backward
+        compatibility with databases created before this change).
+
         Args:
             directory: Directory to filter by. If None, uses current working directory.
 
@@ -68,22 +76,35 @@ class CodebaseService:
         elif isinstance(directory, str):
             directory = Path(directory)
 
-        # Resolve to absolute path for comparison
         target_path = str(directory.resolve())
 
-        # Get all graphs and filter by those accessible from this directory
+        # Try sidecar-based filtering first (no Kuzu locks)
+        metas = self.manager.list_graph_metas()
+
+        if metas:
+            matching_ids = []
+            for meta in metas:
+                cwds = meta.get("indexed_from_cwds", [])
+                repo = meta.get("repo_path", "")
+                if not cwds:
+                    matching_ids.append(meta["graph_id"])
+                elif target_path in cwds:
+                    matching_ids.append(meta["graph_id"])
+                elif repo and Path(target_path).resolve() == Path(repo).resolve():
+                    matching_ids.append(meta["graph_id"])
+
+            return await self.manager.list_graphs(graph_ids=matching_ids)
+
+        # Fallback: no sidecar files exist (pre-existing databases).
+        # Open all databases to filter (original behavior).
         all_graphs = await self.manager.list_graphs()
         filtered_graphs = []
 
         for graph in all_graphs:
-            # If indexed_from_cwds is empty, it's globally accessible (backward compatibility)
             if not graph.indexed_from_cwds:
                 filtered_graphs.append(graph)
-            # Otherwise, check if current directory is in the allowed list
             elif target_path in graph.indexed_from_cwds:
                 filtered_graphs.append(graph)
-            # Also allow access if current directory IS the repository itself
-            # Use Path.resolve() for robust comparison (handles symlinks, etc.)
             elif Path(target_path).resolve() == Path(graph.repo_path).resolve():
                 filtered_graphs.append(graph)
 

--- a/src/shotgun/tui/app.py
+++ b/src/shotgun/tui/app.py
@@ -406,10 +406,20 @@ def run(
     storage_dir = get_shotgun_home() / "codebases"
     manager = CodebaseGraphManager(storage_dir)
 
+    # Scope the health check to the current repo's database only.
+    # This avoids locking databases belonging to other repositories,
+    # which would prevent concurrent Shotgun sessions on different repos.
+    cwd_graph_id = CodebaseGraphManager.generate_graph_id(os.getcwd())
+    check_graph_ids = [cwd_graph_id]
+
     pending_db_issues: list[DatabaseIssue] = []
     try:
-        # First pass: 10-second timeout
-        issues = asyncio.run(manager.detect_database_issues(timeout_seconds=10.0))
+        # First pass: 10-second timeout, scoped to current repo
+        issues = asyncio.run(
+            manager.detect_database_issues(
+                timeout_seconds=10.0, graph_ids=check_graph_ids
+            )
+        )
         if issues:
             # Categorize issues for logging
             for issue in issues:
@@ -494,8 +504,16 @@ def serve(
     storage_dir = get_shotgun_home() / "codebases"
     manager = CodebaseGraphManager(storage_dir)
 
+    # Scope the health check to the current repo's database only.
+    cwd_graph_id = CodebaseGraphManager.generate_graph_id(os.getcwd())
+    check_graph_ids = [cwd_graph_id]
+
     try:
-        issues = asyncio.run(manager.detect_database_issues(timeout_seconds=10.0))
+        issues = asyncio.run(
+            manager.detect_database_issues(
+                timeout_seconds=10.0, graph_ids=check_graph_ids
+            )
+        )
         if issues:
             for issue in issues:
                 logger.info(

--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -2040,7 +2040,9 @@ class ChatScreen(Screen[None]):
                         manager = CodebaseGraphManager(
                             self.codebase_sdk.service.storage_dir
                         )
-                        cleaned = await manager.cleanup_corrupted_databases()
+                        cleaned = await manager.cleanup_corrupted_databases(
+                            graph_ids=[graph_id]
+                        )
                         logger.info(f"Cleaned up {len(cleaned)} corrupted database(s)")
                         self.agent_manager.add_hint_message(
                             HintMessage(

--- a/src/shotgun/tui/screens/chat/chat_screen.py
+++ b/src/shotgun/tui/screens/chat/chat_screen.py
@@ -522,7 +522,10 @@ class ChatScreen(Screen[None]):
                 return True
 
             # locked_action == LockedDialogAction.RETRY - re-detect to see if locks are cleared
-            new_issues = await manager.detect_database_issues(timeout_seconds=10.0)
+            locked_graph_ids = [i.graph_id for i in locked_issues]
+            new_issues = await manager.detect_database_issues(
+                timeout_seconds=10.0, graph_ids=locked_graph_ids
+            )
             still_locked = [
                 i for i in new_issues if i.error_type == KuzuErrorType.LOCKED
             ]
@@ -551,9 +554,9 @@ class ChatScreen(Screen[None]):
                     )
                 )
                 if action == "retry":
-                    # Retry with longer timeout (90s)
+                    # Retry with longer timeout (90s), scoped to the specific graph
                     new_issues = await manager.detect_database_issues(
-                        timeout_seconds=90.0
+                        timeout_seconds=90.0, graph_ids=[issue.graph_id]
                     )
                     still_timeout = any(
                         i.graph_id == issue.graph_id


### PR DESCRIPTION
## Summary

Eliminates all cross-repo database locking that prevents concurrent Shotgun sessions on different repositories. The fix touches every code path that previously opened all `.kuzu` databases in `~/.shotgun-sh/codebases/`.

### Changes

**`manager.py` — core engine:**
- Adds `.meta.json` sidecar files written alongside each `.kuzu` database, containing `repo_path`, `name`, and `indexed_from_cwds`. These enable directory-based filtering without acquiring any Kuzu file locks.
- Sidecar lifecycle: created on graph init, updated on CWD access changes, removed on graph/database deletion.
- `list_graphs(graph_ids=None)` — new optional parameter to open only specified databases instead of globbing all.
- `cleanup_corrupted_databases(graph_ids=None)` — same scoping pattern.
- `detect_database_issues(graph_ids=None)` — same scoping pattern (from first commit).
- Consolidated duplicated loop bodies into single candidate-list + iteration pattern.

**`service.py` — service layer:**
- `list_graphs_for_directory()` now reads `.meta.json` sidecars first to identify candidates, then opens only matching databases. Falls back to full scan when no sidecars exist (backward compat with pre-existing databases).

**Agent tools (`file_read.py`, `directory_lister.py`, `codebase_shell.py`):**
- Replaced `list_graphs()` + linear search with direct `get_graph(graph_id)` when the caller already knows the graph_id.

**`chat_screen.py`:**
- Scoped `cleanup_corrupted_databases()` call to the graph being indexed.
- Scoped `detect_database_issues()` retry flows to relevant graph_ids.

**`app.py`:**
- Scoped startup `detect_database_issues()` to current repo's graph_id only.

## Root Cause

On startup, `detect_database_issues()` globbed every `.kuzu` file in `~/.shotgun-sh/codebases/` and attempted to open each one. When another Shotgun instance was already running on a different repository, its database file was exclusively locked by Kuzu. The health check reported this as a "locked database" issue, and the TUI showed a blocking dialog — even though the **current repo's** database was perfectly accessible.

The same pattern existed in `list_graphs()`, `cleanup_corrupted_databases()`, and `list_graphs_for_directory()` — all opening every database for every operation.

## Test Results

Tested with `real_ladybug==0.15.1` against **3 simulated repos** (atoma, auto-research, voice-feedback-analytics — mirroring the actual layout) using `multiprocessing` to hold database locks:

```
T1 OLD blocks with peer locks:      PASS (bug reproduced — 2 locked, TUI would block)
T2 NEW scoped detect:               PASS (only checks own database)
T3 list_graphs scoped:              PASS (opens 1/3, not 3/3)
T4 sidecar filtering 3 repos:       PASS (each CWD sees only its own graph)
T5 unrelated CWD empty:             PASS (no false positives)
T6 scoped cleanup:                  PASS (corrupted DB found, locked peers untouched)
T7 backward compat:                 PASS (full scan works when no sidecars/locks)
T8 uniqueness:                      PASS (3 distinct graph_ids)
```

## Known Limitation

The `list_graphs()` method (used by `codebase_shell` when no `graph_id` is specified) still falls back to a full scan. This is the "show all indexed codebases" use case — rare during normal operation but could be improved with a registry approach in the future.

## Test Plan

- [x] Automated 8-test suite with `real_ladybug` confirming bug reproduction and fix across 3 repos
- [ ] Manual test: start Shotgun in 3 different repos simultaneously — all should run concurrently
- [ ] Verify single-instance startup is unaffected (backward compat)
- [ ] Verify `.meta.json` files are created during indexing and cleaned up on deletion

Closes #534