### PR TITLE
fix: scope CodebaseGraphManager to current repo for concurrent sessions (alternative approach)

### DIFF
--- a/src/shotgun/cli/codebase/commands.py
+++ b/src/shotgun/cli/codebase/commands.py
@@ -48,6 +48,12 @@ def list_codebases(
     ] = OutputFormat.TEXT,
 ) -> None:
     """List all indexed codebases."""
+    # Disable the per-session database scope so all indexed codebases are shown,
+    # not just the one matching the current directory.
+    from shotgun.codebase.core.manager import CodebaseGraphManager
+
+    CodebaseGraphManager._scope_graph_ids = None
+
     sdk = CodebaseSDK()
 
     try:

--- a/src/shotgun/codebase/core/manager.py
+++ b/src/shotgun/codebase/core/manager.py
@@ -187,6 +187,14 @@ class CodebaseGraphManager:
     # Operation tracking for async operations
     _operations: ClassVar[dict[str, asyncio.Task[Any]]] = {}
 
+    # Process-wide database scope. When set, every method that enumerates
+    # .kuzu databases will only see these specific graph_ids. Set once at
+    # process startup from the CWD so concurrent sessions on different repos
+    # never open each other's databases (which would acquire exclusive locks
+    # and trigger false-positive "database locked" dialogs).
+    # None means no restriction (full scan) — used by shotgun codebase list.
+    _scope_graph_ids: ClassVar[list[str] | None] = None
+
     def __init__(self, storage_dir: Path):
         """Initialize graph manager.
 
@@ -195,6 +203,21 @@ class CodebaseGraphManager:
         """
         self.storage_dir = storage_dir
         self.storage_dir.mkdir(parents=True, exist_ok=True)
+
+    def _iter_databases(self) -> list[tuple[str, Path]]:
+        """Return (graph_id, path) pairs for databases visible to this process.
+
+        When _scope_graph_ids is set, only those databases are returned,
+        preventing this process from opening databases locked by concurrent
+        Shotgun sessions on other repositories.
+        """
+        if self._scope_graph_ids is not None:
+            return [
+                (gid, self.storage_dir / f"{gid}.kuzu")
+                for gid in self._scope_graph_ids
+                if (self.storage_dir / f"{gid}.kuzu").exists()
+            ]
+        return [(p.stem, p) for p in self.storage_dir.glob("*.kuzu")]
 
     @classmethod
     async def _get_lock(cls) -> anyio.Lock:
@@ -1362,10 +1385,7 @@ class CodebaseGraphManager:
 
         removed_graphs = []
 
-        # Find all .kuzu databases (files in v0.11.2, directories in newer versions)
-        for path in self.storage_dir.glob("*.kuzu"):
-            graph_id = path.stem
-
+        for graph_id, path in self._iter_databases():
             # Try to open and validate the database
             try:
                 # Try to open the database with a timeout to prevent hanging
@@ -1570,8 +1590,7 @@ class CodebaseGraphManager:
         """
         issues: list[DatabaseIssue] = []
 
-        for path in self.storage_dir.glob("*.kuzu"):
-            graph_id = path.stem
+        for graph_id, path in self._iter_databases():
             issue = await self._check_single_database(graph_id, path, timeout_seconds)
             if issue:
                 issues.append(issue)
@@ -1641,10 +1660,8 @@ class CodebaseGraphManager:
         """
         graphs = []
 
-        # Find all .kuzu database files (Kuzu v0.11.2 creates files, not directories)
-        for path in self.storage_dir.glob("*.kuzu"):
+        for graph_id, path in self._iter_databases():
             if path.is_file():
-                graph_id = path.stem
                 graph = await self.get_graph(graph_id)
                 if graph:
                     graphs.append(graph)

--- a/src/shotgun/main.py
+++ b/src/shotgun/main.py
@@ -210,6 +210,17 @@ def main(
     if not ctx.resilient_parsing:
         perform_auto_update_async(no_update_check=no_update_check)
 
+    if not ctx.resilient_parsing:
+        # Set process-wide database scope so this session only sees its own
+        # repository's database. This prevents opening databases locked by
+        # other concurrent Shotgun sessions on different repositories, which
+        # would otherwise trigger false-positive "database locked" dialogs.
+        from shotgun.codebase.core.manager import CodebaseGraphManager
+
+        CodebaseGraphManager._scope_graph_ids = [
+            CodebaseGraphManager.generate_graph_id(os.getcwd())
+        ]
+
     if ctx.invoked_subcommand is None and not ctx.resilient_parsing:
         # If --model is specified, resolve and apply the override
         if model:


### PR DESCRIPTION
## Problem

When two Shotgun sessions run simultaneously on different repositories in the same parent directory, a startup health check scans **every** `.kuzu` file in `~/.shotgun-sh/codebases/`. Kuzu uses exclusive file locks, so any database held open by a peer session is reported as \"locked\" — even though the current repo's database is perfectly fine. This shows a blocking dialog and prevents the second session from starting.

Reported in #534.

## Root cause

Three methods in `CodebaseGraphManager` glob the entire storage directory:
- `detect_database_issues()` — the startup health check
- `list_graphs()` — used by `shotgun codebase list` and graph service
- `cleanup_corrupted_databases()` — called during startup and recovery

## This fix (alternative to #535)

Add a single **process-wide class variable** `_scope_graph_ids` to `CodebaseGraphManager`, set once at process startup from the current working directory. A new `_iter_databases()` method replaces all three `.glob("*.kuzu")` calls. Any future method that enumerates databases uses `_iter_databases()` and automatically inherits the scope — no parameter threading required.

```
main.py (2 lines)
  └─ CodebaseGraphManager._scope_graph_ids = [generate_graph_id(cwd)]

manager.py (~15 lines)
  └─ _scope_graph_ids: ClassVar[list[str] | None] = None
  └─ _iter_databases() → replaces 3 glob sites

cli/codebase/commands.py (1 line)
  └─ list_codebases(): _scope_graph_ids = None  # needs all DBs
```

**Total: 3 files changed, 43 insertions(+), 9 deletions(-)**

## Comparison with PR #535

| | PR #535 | This PR |
|---|---|---|
| Approach | `graph_ids` parameter on each method + `.meta.json` sidecars | Process-wide `ClassVar`, set once in `main.py` |
| Files changed | 8 | 3 |
| New future-proofing | Must thread parameter / update sidecar for every new method | `_iter_databases()` handles it automatically |
| `shotgun codebase list` | Shows all codebases (uses full glob) | Explicitly unscopes for this one command |

## How it works

Every Shotgun process starts from a CWD. `main.py` calls `generate_graph_id(os.getcwd())` and stores the result in the class variable. Because `_scope_graph_ids` is a `ClassVar`, **every instance** of `CodebaseGraphManager` created anywhere in the process automatically respects the scope — TUI, `shotgun run`, `shotgun codebase index`, benchmarks, all covered by the two lines in `main.py`.

The only exception is `shotgun codebase list`, which legitimately needs to show all indexed repositories. It clears the scope before querying.

## Tests

Standalone test script using `real_ladybug==0.15.1` and `multiprocessing` to hold real Kuzu file locks. 3 simulated repos (`project-alpha`, `project-beta`, `project-gamma`). All 8 tests pass:

| # | Scenario | Result |
|---|---|---|
| T1 | Bug reproduced: OLD globs all, 2 peers locked, blocks 3rd | PASS |
| T2 | NEW scope set → alpha/beta never opened, gamma starts clean | PASS |
| T3 | `list_graphs` scoped: opens 1/3 not 3/3 | PASS |
| T4 | Each CWD's scope targets only its own graph | PASS |
| T5 | Unrelated CWD returns empty | PASS |
| T6 | Scoped cleanup avoids locked peers | PASS |
| T7 | Backward compat: `scope=None` still full-scans | PASS |
| T8 | `graph_id` uniqueness across 3 repos | PASS |

Closes #534

Made with [Cursor](https://cursor.com)